### PR TITLE
AuOptionCategoryDtoのGET APIモックの追加

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
-import { ExRTabDtoArraySchema, OptionTab } from '../src/type';
-import type { ExRTabDto } from '../src/type';
+import { AuOptionCategoryDtoArraySchema, ExRTabDtoArraySchema, OptionTab, OptionValueType } from '../src/type';
+import type { AuOptionCategoryDto, ExRTabDto } from '../src/type';
 
 /**
  * モックデータの作成
@@ -70,15 +70,82 @@ const mockExRTabDtoList: ExRTabDto[] = [
 ];
 
 /**
+ * Au系オプションのモックデータ作成
+ */
+const mockAuOptionCategoryDtoList: AuOptionCategoryDto[] = [
+  {
+    TranslatedTitle: 'ゲーム設定',
+    Options: [
+      {
+        TranslatedTitle: 'マップ',
+        TranslatedFormat: '{0}',
+        Value: 0,
+        Info: {
+          ValueType: OptionValueType.Byte,
+          OptionName: 1,
+        },
+        Range: ['The Skeld', 'Mira HQ', 'Polus', 'The Fungle'],
+      },
+      {
+        TranslatedTitle: 'インポスターの数',
+        TranslatedFormat: '{0}',
+        Value: 2,
+        Info: {
+          ValueType: OptionValueType.Int,
+          OptionName: 2,
+        },
+        Range: [1, 2, 3],
+      },
+    ],
+  },
+  {
+    TranslatedTitle: '役職設定',
+    Options: [
+      {
+        TranslatedTitle: 'シェリフ',
+        TranslatedFormat: '{0}',
+        Value: {
+          MaxCount: 1,
+          Chance: 100,
+        },
+        Info: {
+          ValueType: OptionValueType.RoleBase,
+          OptionName: 101,
+        },
+        Range: null,
+      },
+      {
+        TranslatedTitle: 'キルクールダウン',
+        TranslatedFormat: '{0}s',
+        Value: 20.5,
+        Info: {
+          ValueType: OptionValueType.Float,
+          OptionName: 102,
+        },
+        Range: [10.0, 15.0, 20.0, 25.0, 30.0],
+      },
+    ],
+  },
+];
+
+/**
  * Zodを使用してモックデータのバリデーションを実施
  */
-const validatedMockData = ExRTabDtoArraySchema.parse(mockExRTabDtoList);
+const validatedExRMockData = ExRTabDtoArraySchema.parse(mockExRTabDtoList);
+const validatedAuMockData = AuOptionCategoryDtoArraySchema.parse(mockAuOptionCategoryDtoList);
 
 export const handlers = [
   /**
    * GET /exr/option/ のハンドラー
    */
   http.get('/exr/option/', () => {
-    return HttpResponse.json(validatedMockData);
+    return HttpResponse.json(validatedExRMockData);
+  }),
+
+  /**
+   * GET /au/option/ のハンドラー
+   */
+  http.get('/au/option/', () => {
+    return HttpResponse.json(validatedAuMockData);
   }),
 ];

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -96,6 +96,16 @@ const mockAuOptionCategoryDtoList: AuOptionCategoryDto[] = [
         },
         Range: [1, 2, 3],
       },
+      {
+        TranslatedTitle: '匿名投票',
+        TranslatedFormat: '{0}',
+        Value: true,
+        Info: {
+          ValueType: OptionValueType.Bool,
+          OptionName: 3,
+        },
+        Range: ['OFF', 'ON'],
+      },
     ],
   },
   {

--- a/src/type.ts
+++ b/src/type.ts
@@ -129,7 +129,7 @@ export const AuOptionInfoSchema = z.object({
 export interface AuOptionDto {
   TranslatedTitle: string;
   TranslatedFormat: string;
-  Value: number | string | AuRoleOption;
+  Value: number | boolean | AuRoleOption;
   Info: AuOptionInfo;
   Range: (number | string)[] | null;
 }
@@ -137,7 +137,7 @@ export interface AuOptionDto {
 export const AuOptionDtoSchema = z.object({
   TranslatedTitle: z.string(),
   TranslatedFormat: z.string(),
-  Value: z.union([z.number(), z.string(), AuRoleOptionSchema]),
+  Value: z.union([z.number(), z.boolean(), AuRoleOptionSchema]),
   Info: AuOptionInfoSchema,
   Range: z.array(z.union([z.number(), z.string()])).nullable(),
 });

--- a/src/type.ts
+++ b/src/type.ts
@@ -88,3 +88,68 @@ export const ExRTabDtoSchema = z.object({
 });
 
 export const ExRTabDtoArraySchema = z.array(ExRTabDtoSchema);
+
+/**
+ * Au系のオプション設定に関連する型定義
+ */
+
+export const OptionValueType = {
+  Bool: 0,
+  Byte: 1,
+  Int: 2,
+  UInt: 3,
+  Float: 4,
+  RoleBase: 5,
+} as const;
+
+export type OptionValueType = (typeof OptionValueType)[keyof typeof OptionValueType];
+
+export const OptionValueTypeSchema = z.nativeEnum(OptionValueType);
+
+export interface AuRoleOption {
+  MaxCount: number;
+  Chance: number;
+}
+
+export const AuRoleOptionSchema = z.object({
+  MaxCount: z.number().int(),
+  Chance: z.number().int(),
+});
+
+export interface AuOptionInfo {
+  ValueType: OptionValueType;
+  OptionName: number;
+}
+
+export const AuOptionInfoSchema = z.object({
+  ValueType: OptionValueTypeSchema,
+  OptionName: z.number().int(),
+});
+
+export interface AuOptionDto {
+  TranslatedTitle: string;
+  TranslatedFormat: string;
+  Value: number | string | AuRoleOption;
+  Info: AuOptionInfo;
+  Range: (number | string)[] | null;
+}
+
+export const AuOptionDtoSchema = z.object({
+  TranslatedTitle: z.string(),
+  TranslatedFormat: z.string(),
+  Value: z.union([z.number(), z.string(), AuRoleOptionSchema]),
+  Info: AuOptionInfoSchema,
+  Range: z.array(z.union([z.number(), z.string()])).nullable(),
+});
+
+export interface AuOptionCategoryDto {
+  TranslatedTitle: string;
+  Options: AuOptionDto[];
+}
+
+export const AuOptionCategoryDtoSchema = z.object({
+  TranslatedTitle: z.string(),
+  Options: z.array(AuOptionDtoSchema),
+});
+
+export const AuOptionCategoryDtoArraySchema = z.array(AuOptionCategoryDtoSchema);

--- a/tests/au-dto-validation.test.ts
+++ b/tests/au-dto-validation.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { AuOptionCategoryDtoArraySchema, OptionValueType } from '../src/type';
+
+describe('AuOptionCategoryDto Validation', () => {
+  it('should validate a correct AuOptionCategoryDto array', () => {
+    const data = [
+      {
+        TranslatedTitle: 'Game Settings',
+        Options: [
+          {
+            TranslatedTitle: 'Map',
+            TranslatedFormat: '{0}',
+            Value: 0,
+            Info: {
+              ValueType: OptionValueType.Byte,
+              OptionName: 1,
+            },
+            Range: ['The Skeld', 'Mira HQ'],
+          },
+          {
+            TranslatedTitle: 'Sheriff',
+            TranslatedFormat: '{0}',
+            Value: {
+              MaxCount: 1,
+              Chance: 100,
+            },
+            Info: {
+              ValueType: OptionValueType.RoleBase,
+              OptionName: 101,
+            },
+            Range: null,
+          },
+        ],
+      },
+    ];
+
+    const result = AuOptionCategoryDtoArraySchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail validation if Value is incorrect for AuRoleOption', () => {
+    const invalidData = [
+      {
+        TranslatedTitle: 'Role Settings',
+        Options: [
+          {
+            TranslatedTitle: 'Sheriff',
+            TranslatedFormat: '{0}',
+            Value: {
+              MaxCount: '1', // Should be number
+              Chance: 100,
+            },
+            Info: {
+              ValueType: OptionValueType.RoleBase,
+              OptionName: 101,
+            },
+            Range: null,
+          },
+        ],
+      },
+    ];
+
+    const result = AuOptionCategoryDtoArraySchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail validation if OptionValueType is invalid', () => {
+    const invalidData = [
+      {
+        TranslatedTitle: 'Settings',
+        Options: [
+          {
+            TranslatedTitle: 'Opt',
+            TranslatedFormat: '{0}',
+            Value: 1,
+            Info: {
+              ValueType: 99, // Invalid enum value
+              OptionName: 1,
+            },
+            Range: [],
+          },
+        ],
+      },
+    ];
+
+    const result = AuOptionCategoryDtoArraySchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/au-dto-validation.test.ts
+++ b/tests/au-dto-validation.test.ts
@@ -30,12 +30,45 @@ describe('AuOptionCategoryDto Validation', () => {
             },
             Range: null,
           },
+          {
+            TranslatedTitle: 'Anonymous Voting',
+            TranslatedFormat: '{0}',
+            Value: true,
+            Info: {
+              ValueType: OptionValueType.Bool,
+              OptionName: 3,
+            },
+            Range: ['OFF', 'ON'],
+          },
         ],
       },
     ];
 
     const result = AuOptionCategoryDtoArraySchema.safeParse(data);
     expect(result.success).toBe(true);
+  });
+
+  it('should fail validation if Value is a string', () => {
+    const invalidData = [
+      {
+        TranslatedTitle: 'Settings',
+        Options: [
+          {
+            TranslatedTitle: 'Invalid Option',
+            TranslatedFormat: '{0}',
+            Value: 'string value', // No longer allowed
+            Info: {
+              ValueType: OptionValueType.Int,
+              OptionName: 1,
+            },
+            Range: [],
+          },
+        ],
+      },
+    ];
+
+    const result = AuOptionCategoryDtoArraySchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
   });
 
   it('should fail validation if Value is incorrect for AuRoleOption', () => {


### PR DESCRIPTION
AuOptionCategoryDtoのArrayを返す「/au/option/」のGET APIモックサーバーをMSWに追加しました。
バリデーションにはZodを使用し、定義は提供されたC#の構造に基づいています。
また、追加したスキーマが正しく動作することを確認するためのユニットテストも追加しました。

---
*PR created automatically by Jules for task [12368598826936164036](https://jules.google.com/task/12368598826936164036) started by @yukieiji*