### PR TITLE
PUT /au/option/ APIモックの追加とZodバリデーションの実装

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
-import { AuOptionCategoryDtoArraySchema, ExRTabDtoArraySchema, OptionTab, OptionValueType } from '../src/type';
-import type { AuOptionCategoryDto, ExRTabDto } from '../src/type';
+import { AuOptionCategoryDtoArraySchema, ExRTabDtoArraySchema, OptionTab, OptionValueType, UpdatedOptionsSchema, VanillaOptionPutRequestSchema } from '../src/type';
+import type { AuOptionCategoryDto, ExRTabDto, UpdatedOptions } from '../src/type';
 
 /**
  * モックデータの作成
@@ -157,5 +157,46 @@ export const handlers = [
    */
   http.get('/au/option/', () => {
     return HttpResponse.json(validatedAuMockData);
+  }),
+
+  /**
+   * PUT /au/option/ のハンドラー
+   */
+  http.put('/au/option/', async ({ request }) => {
+    const body = await request.json();
+
+    // リクエストボディのバリデーション
+    const validatedRequest = VanillaOptionPutRequestSchema.safeParse(body);
+    if (!validatedRequest.success) {
+      return HttpResponse.json(validatedRequest.error, { status: 400 });
+    }
+
+    // 固定のレスポンスデータを定義
+    const mockUpdatedOptions: UpdatedOptions = {
+      UpdatedCategory: {
+        Id: 1,
+        Name: 'ゲーム設定',
+        Options: [
+          {
+            Id: 101,
+            IsActive: true,
+            TransedName: '移動速度',
+            Selection: 1,
+            Format: '{0}x',
+            RangeMeta: {
+              Type: 'Single',
+              Values: [0.5, 1.0, 1.5, 2.0, 2.5, 3.0],
+            },
+            Childs: [],
+          },
+        ],
+      },
+      ChainUpdatedOption: [],
+    };
+
+    // レスポンスデータのバリデーション
+    const validatedResponse = UpdatedOptionsSchema.parse(mockUpdatedOptions);
+
+    return HttpResponse.json(validatedResponse);
   }),
 ];

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -139,10 +139,36 @@ const mockAuOptionCategoryDtoList: AuOptionCategoryDto[] = [
 ];
 
 /**
+ * 更新されたオプションのモックデータ作成
+ */
+const mockUpdatedOptions: UpdatedOptions = {
+  UpdatedCategory: {
+    Id: 1,
+    Name: 'ゲーム設定',
+    Options: [
+      {
+        Id: 101,
+        IsActive: true,
+        TransedName: '移動速度',
+        Selection: 1,
+        Format: '{0}x',
+        RangeMeta: {
+          Type: 'Single',
+          Values: [0.5, 1.0, 1.5, 2.0, 2.5, 3.0],
+        },
+        Childs: [],
+      },
+    ],
+  },
+  ChainUpdatedOption: [],
+};
+
+/**
  * Zodを使用してモックデータのバリデーションを実施
  */
 const validatedExRMockData = ExRTabDtoArraySchema.parse(mockExRTabDtoList);
 const validatedAuMockData = AuOptionCategoryDtoArraySchema.parse(mockAuOptionCategoryDtoList);
+const validatedUpdatedOptions = UpdatedOptionsSchema.parse(mockUpdatedOptions);
 
 export const handlers = [
   /**
@@ -171,32 +197,6 @@ export const handlers = [
       return HttpResponse.json(validatedRequest.error, { status: 400 });
     }
 
-    // 固定のレスポンスデータを定義
-    const mockUpdatedOptions: UpdatedOptions = {
-      UpdatedCategory: {
-        Id: 1,
-        Name: 'ゲーム設定',
-        Options: [
-          {
-            Id: 101,
-            IsActive: true,
-            TransedName: '移動速度',
-            Selection: 1,
-            Format: '{0}x',
-            RangeMeta: {
-              Type: 'Single',
-              Values: [0.5, 1.0, 1.5, 2.0, 2.5, 3.0],
-            },
-            Childs: [],
-          },
-        ],
-      },
-      ChainUpdatedOption: [],
-    };
-
-    // レスポンスデータのバリデーション
-    const validatedResponse = UpdatedOptionsSchema.parse(mockUpdatedOptions);
-
-    return HttpResponse.json(validatedResponse);
+    return HttpResponse.json(validatedUpdatedOptions);
   }),
 ];

--- a/src/type.ts
+++ b/src/type.ts
@@ -153,3 +153,31 @@ export const AuOptionCategoryDtoSchema = z.object({
 });
 
 export const AuOptionCategoryDtoArraySchema = z.array(AuOptionCategoryDtoSchema);
+
+/**
+ * オプション更新リクエスト
+ */
+export interface VanillaOptionPutRequest {
+  ValueType: OptionValueType;
+  OptionName: number;
+  NewValue: number | boolean | AuRoleOption;
+}
+
+export const VanillaOptionPutRequestSchema = z.object({
+  ValueType: OptionValueTypeSchema,
+  OptionName: z.number().int(),
+  NewValue: z.union([z.number(), z.boolean(), AuRoleOptionSchema]),
+});
+
+/**
+ * 更新されたオプション情報
+ */
+export interface UpdatedOptions {
+  UpdatedCategory: ExRCategoryDto | null;
+  ChainUpdatedOption: ExROptionDto[];
+}
+
+export const UpdatedOptionsSchema = z.object({
+  UpdatedCategory: ExRCategoryDtoSchema.nullable(),
+  ChainUpdatedOption: z.array(ExROptionDtoSchema),
+});

--- a/tests/api-validation.test.ts
+++ b/tests/api-validation.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { OptionValueType, VanillaOptionPutRequestSchema, UpdatedOptionsSchema } from '../src/type';
+
+describe('VanillaOptionPutRequest Validation', () => {
+  it('should validate a correct number value request', () => {
+    const data = {
+      ValueType: OptionValueType.Int,
+      OptionName: 1,
+      NewValue: 10,
+    };
+    const result = VanillaOptionPutRequestSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a correct boolean value request', () => {
+    const data = {
+      ValueType: OptionValueType.Bool,
+      OptionName: 3,
+      NewValue: true,
+    };
+    const result = VanillaOptionPutRequestSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a correct AuRoleOption value request', () => {
+    const data = {
+      ValueType: OptionValueType.RoleBase,
+      OptionName: 101,
+      NewValue: {
+        MaxCount: 2,
+        Chance: 50,
+      },
+    };
+    const result = VanillaOptionPutRequestSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail if NewValue is a string', () => {
+    const data = {
+      ValueType: OptionValueType.Byte,
+      OptionName: 1,
+      NewValue: 'invalid',
+    };
+    const result = VanillaOptionPutRequestSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('UpdatedOptions Validation', () => {
+  it('should validate a correct UpdatedOptions with category', () => {
+    const data = {
+      UpdatedCategory: {
+        Id: 1,
+        Name: 'Category',
+        Options: [],
+      },
+      ChainUpdatedOption: [],
+    };
+    const result = UpdatedOptionsSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a correct UpdatedOptions with null category', () => {
+    const data = {
+      UpdatedCategory: null,
+      ChainUpdatedOption: [
+        {
+          Id: 201,
+          IsActive: true,
+          TransedName: 'Option',
+          Selection: 1,
+          Format: '{0}',
+          RangeMeta: {
+            Type: 'Int32',
+            Values: [1, 2, 3],
+          },
+          Childs: [],
+        },
+      ],
+    };
+    const result = UpdatedOptionsSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
「/au/option/」のPUT APIモックをMSWに追加しました。
VanillaOptionPutRequestを受け取り、UpdatedOptionsを返す仕様に基づき、Zodによるバリデーション処理を実装しています。
また、追加した型とスキーマの正しさを検証するためのユニットテストを追加しました。

---
*PR created automatically by Jules for task [13294506093877317072](https://jules.google.com/task/13294506093877317072) started by @yukieiji*