### PR TITLE
/exr/option/ の PUT API モックの追加

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,6 +1,13 @@
 import { http, HttpResponse } from 'msw';
-import { AuOptionCategoryDtoArraySchema, ExRTabDtoArraySchema, OptionTab, OptionValueType } from '../src/type';
-import type { AuOptionCategoryDto, ExRTabDto } from '../src/type';
+import {
+  AuOptionCategoryDtoArraySchema,
+  ExRTabDtoArraySchema,
+  ExROptionPutRequestSchema,
+  UpdatedOptionsSchema,
+  OptionTab,
+  OptionValueType,
+} from '../src/type';
+import type { AuOptionCategoryDto, ExRTabDto, UpdatedOptions } from '../src/type';
 
 /**
  * モックデータの作成
@@ -150,6 +157,38 @@ export const handlers = [
    */
   http.get('/exr/option/', () => {
     return HttpResponse.json(validatedExRMockData);
+  }),
+
+  /**
+   * PUT /exr/option/ のハンドラー
+   */
+  http.put('/exr/option/', async ({ request }) => {
+    const body = await request.json();
+
+    // Zodを使用してリクエストボディをバリデーション
+    const result = ExROptionPutRequestSchema.safeParse(body);
+
+    if (!result.success) {
+      return new HttpResponse(null, { status: 400 });
+    }
+
+    const { CategoryId, OptionId } = result.data;
+
+    // CategoryIdとOptionIdが0のときは202を返す（ボディなし）
+    if (CategoryId === 0 && OptionId === 0) {
+      return new HttpResponse(null, { status: 202 });
+    }
+
+    // それ以外はUpdatedOptionsを返す
+    const mockUpdatedOptions: UpdatedOptions = {
+      UpdatedCategory: validatedExRMockData[0].Categories[0],
+      ChainUpdatedOption: [validatedExRMockData[0].Categories[0].Options[0]],
+    };
+
+    // レスポンスデータのバリデーション
+    const validatedResponse = UpdatedOptionsSchema.parse(mockUpdatedOptions);
+
+    return HttpResponse.json(validatedResponse);
   }),
 
   /**

--- a/src/type.ts
+++ b/src/type.ts
@@ -153,3 +153,33 @@ export const AuOptionCategoryDtoSchema = z.object({
 });
 
 export const AuOptionCategoryDtoArraySchema = z.array(AuOptionCategoryDtoSchema);
+
+/**
+ * オプション更新リクエスト
+ */
+export interface ExROptionPutRequest {
+  TabId: number;
+  CategoryId: number;
+  OptionId: number;
+  Selection: number;
+}
+
+export const ExROptionPutRequestSchema = z.object({
+  TabId: z.number().int(),
+  CategoryId: z.number().int(),
+  OptionId: z.number().int(),
+  Selection: z.number().int(),
+});
+
+/**
+ * 更新されたオプション情報
+ */
+export interface UpdatedOptions {
+  UpdatedCategory: ExRCategoryDto | null;
+  ChainUpdatedOption: ExROptionDto[];
+}
+
+export const UpdatedOptionsSchema = z.object({
+  UpdatedCategory: ExRCategoryDtoSchema.nullable(),
+  ChainUpdatedOption: z.array(ExROptionDtoSchema),
+});

--- a/tests/api-validation.test.ts
+++ b/tests/api-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ExROptionPutRequestSchema, UpdatedOptionsSchema, OptionValueType, VanillaOptionPutRequestSchema, } from '../src/type';
+import { ExROptionPutRequestSchema, UpdatedOptionsSchema, OptionValueType, VanillaOptionPutRequestSchema } from '../src/type';
 
 describe('ExROptionPutRequest and UpdatedOptions Validation', () => {
   it('should validate a correct ExROptionPutRequest', () => {
@@ -50,6 +50,21 @@ describe('ExROptionPutRequest and UpdatedOptions Validation', () => {
           Id: 101,
           IsActive: true,
           TransedName: 'Test Option',
+          Selection: 1,
+          Format: 'Test Format',
+          RangeMeta: {
+            Type: 'Int32',
+            Values: [1, 2, 3],
+          },
+          Childs: [],
+        },
+      ],
+    };
+
+    const result = UpdatedOptionsSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+});
 
 describe('VanillaOptionPutRequest Validation', () => {
   it('should validate a correct number value request', () => {

--- a/tests/api-validation.test.ts
+++ b/tests/api-validation.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { ExROptionPutRequestSchema, UpdatedOptionsSchema } from '../src/type';
+
+describe('ExROptionPutRequest and UpdatedOptions Validation', () => {
+  it('should validate a correct ExROptionPutRequest', () => {
+    const data = {
+      TabId: 1,
+      CategoryId: 2,
+      OptionId: 101,
+      Selection: 1,
+    };
+
+    const result = ExROptionPutRequestSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail validation if ExROptionPutRequest has missing fields', () => {
+    const data = {
+      TabId: 1,
+      CategoryId: 2,
+      // OptionId missing
+      Selection: 1,
+    };
+
+    const result = ExROptionPutRequestSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail validation if ExROptionPutRequest has incorrect types', () => {
+    const data = {
+      TabId: '1', // string instead of number
+      CategoryId: 2,
+      OptionId: 101,
+      Selection: 1,
+    };
+
+    const result = ExROptionPutRequestSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('should validate a correct UpdatedOptions', () => {
+    const data = {
+      UpdatedCategory: {
+        Id: 1,
+        Name: 'Test Category',
+        Options: [],
+      },
+      ChainUpdatedOption: [
+        {
+          Id: 101,
+          IsActive: true,
+          TransedName: 'Test Option',
+          Selection: 1,
+          Format: '{0}',
+          RangeMeta: {
+            Type: 'Int32',
+            Values: [1, 2, 3],
+          },
+          Childs: [],
+        },
+      ],
+    };
+
+    const result = UpdatedOptionsSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate UpdatedOptions with null UpdatedCategory', () => {
+    const data = {
+      UpdatedCategory: null,
+      ChainUpdatedOption: [],
+    };
+
+    const result = UpdatedOptionsSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
MSW を使用して `/exr/option/` の PUT API モックを実装しました。
リクエストボディとして `ExROptionPutRequest` を受け取り、Zod による厳密なバリデーションを行います。
`CategoryId` と `OptionId` が共に 0 の場合はステータスコード 202 (ボディなし) を返し、それ以外の場合は `UpdatedOptions` オブジェクトを 200 OK で返します。
また、追加した型と Zod スキーマの正当性を確認するためのユニットテストを `tests/api-validation.test.ts` に作成しました。

---
*PR created automatically by Jules for task [1321476369927538228](https://jules.google.com/task/1321476369927538228) started by @yukieiji*