### PR TITLE
ExROptionEditor のタブ化実装

### DIFF
--- a/src/feature/ExROptionEditor.tsx
+++ b/src/feature/ExROptionEditor.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '../useStore';
 import type { ExRTabDto } from '../type';
 
 interface ExROptionEditorProps {
@@ -8,14 +9,46 @@ interface ExROptionEditorProps {
  * ExRオプションを表示するコンポーネント
  */
 export function ExROptionEditor({ data }: ExROptionEditorProps) {
+  const selectedExRTabId = useStore((state) => {
+    return state.selectedExRTabId;
+  });
+  const setSelectedExRTabId = useStore((state) => {
+    return state.setSelectedExRTabId;
+  });
+
+  const selectedTab = data.find((tab) => {
+    return tab.Id === selectedExRTabId;
+  }) || data[0];
+
   return (
-    <div className="bg-gray-800 text-green-400 p-6 rounded-lg shadow-lg overflow-auto max-h-[80vh]">
-      <pre
-        data-testid="exr-json-pre"
-        className="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed"
-      >
-        {JSON.stringify(data, null, 2)}
-      </pre>
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap gap-2 border-b border-gray-200 pb-2">
+        {data.map((tab) => {
+          return (
+            <button
+              key={tab.Id}
+              onClick={() => {
+                setSelectedExRTabId(tab.Id);
+              }}
+              className={`
+                px-4 py-2 rounded-t-lg transition-colors font-medium
+                ${selectedExRTabId === tab.Id ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}
+              `}
+            >
+              {tab.Name}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="bg-gray-800 text-green-400 p-6 rounded-lg shadow-lg overflow-auto max-h-[80vh]">
+        <pre
+          data-testid="exr-json-pre"
+          className="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed"
+        >
+          {JSON.stringify(selectedTab, null, 2)}
+        </pre>
+      </div>
     </div>
   );
 }

--- a/src/slices/optionGroupToggleSidebarSlice.ts
+++ b/src/slices/optionGroupToggleSidebarSlice.ts
@@ -1,5 +1,7 @@
 import type { StateCreator } from 'zustand';
 
+import type { OptionTab } from '../type';
+
 export type SelectedTab = 'Au' | 'ExR';
 
 /**
@@ -8,8 +10,10 @@ export type SelectedTab = 'Au' | 'ExR';
 export interface OptionGroupToggleSidebarSlice {
   isSidebarOpen: boolean;
   selectedTab: SelectedTab;
+  selectedExRTabId: OptionTab;
   toggleSidebar: () => void;
   setSelectedTab: (tab: SelectedTab) => void;
+  setSelectedExRTabId: (id: OptionTab) => void;
 }
 
 /**
@@ -19,6 +23,7 @@ export const createOptionGroupToggleSidebarSlice: StateCreator<OptionGroupToggle
   return {
     isSidebarOpen: true,
     selectedTab: 'Au',
+    selectedExRTabId: 0,
     toggleSidebar: () => {
       set((state) => {
         return { isSidebarOpen: !state.isSidebarOpen };
@@ -26,6 +31,9 @@ export const createOptionGroupToggleSidebarSlice: StateCreator<OptionGroupToggle
     },
     setSelectedTab: (tab: SelectedTab) => {
       set({ selectedTab: tab });
+    },
+    setSelectedExRTabId: (id: OptionTab) => {
+      set({ selectedExRTabId: id });
     },
   };
 };

--- a/tests/OptionEditor.test.tsx
+++ b/tests/OptionEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ExROptionEditor } from '../src/feature/ExROptionEditor';
 import { AuOptionEditor } from '../src/feature/AuOptionEditor';
 import type { ExRTabDto, AuOptionCategoryDto } from '../src/type';
@@ -9,18 +9,28 @@ describe('OptionEditor Components', () => {
     const mockData: ExRTabDto[] = [
       {
         Id: 0,
-        Name: 'Test Tab',
+        Name: 'Test Tab 1',
+        Categories: [],
+      },
+      {
+        Id: 1,
+        Name: 'Test Tab 2',
         Categories: [],
       },
     ];
 
     render(<ExROptionEditor data={mockData} />);
 
-    // JSON 文字列が含まれていることを確認
-    const pre = screen.getByText((content) => {
-        return content.includes('"Name": "Test Tab"');
-    });
-    expect(pre).toBeTruthy();
+    // 最初は最初のタブの内容が表示されていることを確認
+    const pre = screen.getByTestId('exr-json-pre');
+    expect(pre.textContent).toContain('"Name": "Test Tab 1"');
+
+    // タブ2をクリック
+    const tab2Button = screen.getByText('Test Tab 2');
+    fireEvent.click(tab2Button);
+
+    // タブ2の内容が表示されていることを確認
+    expect(pre.textContent).toContain('"Name": "Test Tab 2"');
   });
 
   it('AuOptionEditor がデータを正しく表示すること', () => {

--- a/tests/optionGroupToggleSidebarStore.test.ts
+++ b/tests/optionGroupToggleSidebarStore.test.ts
@@ -7,6 +7,7 @@ describe('OptionGroupToggleSidebarStore', () => {
     useStore.setState({
       isSidebarOpen: true,
       selectedTab: 'ExR',
+      selectedExRTabId: 0,
     });
   });
 
@@ -14,6 +15,7 @@ describe('OptionGroupToggleSidebarStore', () => {
     const state = useStore.getState();
     expect(state.isSidebarOpen).toBe(true);
     expect(state.selectedTab).toBe('ExR');
+    expect(state.selectedExRTabId).toBe(0);
   });
 
   it('toggleSidebar で isSidebarOpen が切り替わること', () => {
@@ -30,5 +32,13 @@ describe('OptionGroupToggleSidebarStore', () => {
 
     useStore.getState().setSelectedTab('ExR');
     expect(useStore.getState().selectedTab).toBe('ExR');
+  });
+
+  it('setSelectedExRTabId で selectedExRTabId が変更されること', () => {
+    useStore.getState().setSelectedExRTabId(1);
+    expect(useStore.getState().selectedExRTabId).toBe(1);
+
+    useStore.getState().setSelectedExRTabId(2);
+    expect(useStore.getState().selectedExRTabId).toBe(2);
   });
 });


### PR DESCRIPTION
ExROptionEditor コンポーネントにおいて、すべての ExRTabDto が一つの JSON として表示されていたものを、タブ形式で切り替えて表示できるように変更しました。

主な変更点：
- Zustand ストアのスライスを拡張し、ExR オプション内の現在選択されているタブ ID を管理できるようにしました。
- `ExROptionEditor` コンポーネントの上部に、データに基づいた動的なタブ（ボタン）を表示するようにしました。
- 選択されたタブに応じたデータのみを `pre` タグ内に表示するようにしました。
- 各種テストおよびフロントエンドの動作確認を行い、正常に動作することを確認しました。

---
*PR created automatically by Jules for task [16356652884303311832](https://jules.google.com/task/16356652884303311832) started by @yukieiji*