### PR TITLE
モックサーバーのGETデータをJSONファイルからロードするように変更

### DIFF
--- a/mocks/get/au/option.json
+++ b/mocks/get/au/option.json
@@ -1,0 +1,65 @@
+[
+  {
+    "TranslatedTitle": "ゲーム設定",
+    "Options": [
+      {
+        "TranslatedTitle": "マップ",
+        "TranslatedFormat": "{0}",
+        "Value": 0,
+        "Info": {
+          "ValueType": 1,
+          "OptionName": 1
+        },
+        "Range": ["The Skeld", "Mira HQ", "Polus", "The Fungle"]
+      },
+      {
+        "TranslatedTitle": "インポスターの数",
+        "TranslatedFormat": "{0}",
+        "Value": 2,
+        "Info": {
+          "ValueType": 2,
+          "OptionName": 2
+        },
+        "Range": [1, 2, 3]
+      },
+      {
+        "TranslatedTitle": "匿名投票",
+        "TranslatedFormat": "{0}",
+        "Value": true,
+        "Info": {
+          "ValueType": 0,
+          "OptionName": 3
+        },
+        "Range": ["OFF", "ON"]
+      }
+    ]
+  },
+  {
+    "TranslatedTitle": "役職設定",
+    "Options": [
+      {
+        "TranslatedTitle": "シェリフ",
+        "TranslatedFormat": "{0}",
+        "Value": {
+          "MaxCount": 1,
+          "Chance": 100
+        },
+        "Info": {
+          "ValueType": 5,
+          "OptionName": 101
+        },
+        "Range": null
+      },
+      {
+        "TranslatedTitle": "キルクールダウン",
+        "TranslatedFormat": "{0}s",
+        "Value": 20.5,
+        "Info": {
+          "ValueType": 4,
+          "OptionName": 102
+        },
+        "Range": [10.0, 15.0, 20.0, 25.0, 30.0]
+      }
+    ]
+  }
+]

--- a/mocks/get/exr/option.json
+++ b/mocks/get/exr/option.json
@@ -1,0 +1,63 @@
+[
+  {
+    "Id": 0,
+    "Name": "基本設定",
+    "Categories": [
+      {
+        "Id": 1,
+        "Name": "ゲーム設定",
+        "Options": [
+          {
+            "Id": 101,
+            "IsActive": true,
+            "TransedName": "移動速度",
+            "Selection": 1,
+            "Format": "{0}x",
+            "RangeMeta": {
+              "Type": "Single",
+              "Values": [0.5, 1.0, 1.5, 2.0, 2.5, 3.0]
+            },
+            "Childs": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Id": 1,
+    "Name": "クルーメイト",
+    "Categories": [
+      {
+        "Id": 2,
+        "Name": "役職設定",
+        "Options": [
+          {
+            "Id": 201,
+            "IsActive": true,
+            "TransedName": "シェリフ",
+            "Selection": 0,
+            "Format": "{0}",
+            "RangeMeta": {
+              "Type": "String",
+              "Values": ["無効", "有効"]
+            },
+            "Childs": [
+              {
+                "Id": 202,
+                "IsActive": false,
+                "TransedName": "キルクールダウン",
+                "Selection": 2,
+                "Format": "{0}s",
+                "RangeMeta": {
+                  "Type": "Single",
+                  "Values": [10, 20, 30, 40]
+                },
+                "Childs": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -4,147 +4,19 @@ import {
   ExRTabDtoArraySchema,
   ExROptionPutRequestSchema,
   UpdatedOptionsSchema,
-  OptionTab,
-  OptionValueType,
   VanillaOptionPutRequestSchema
 } from '../src/type';
-import type { AuOptionCategoryDto, ExRTabDto, UpdatedOptions } from '../src/type';
+import type { UpdatedOptions } from '../src/type';
+
+// JSONファイルのロード
+import exrOptionData from './get/exr/option.json';
+import auOptionData from './get/au/option.json';
 
 /**
- * モックデータの作成
+ * Zodを使用してロードしたデータのバリデーションを実施
  */
-const mockExRTabDtoList: ExRTabDto[] = [
-  {
-    Id: OptionTab.GeneralTab,
-    Name: '基本設定',
-    Categories: [
-      {
-        Id: 1,
-        Name: 'ゲーム設定',
-        Options: [
-          {
-            Id: 101,
-            IsActive: true,
-            TransedName: '移動速度',
-            Selection: 1,
-            Format: '{0}x',
-            RangeMeta: {
-              Type: 'Single',
-              Values: [0.5, 1.0, 1.5, 2.0, 2.5, 3.0],
-            },
-            Childs: [],
-          },
-        ],
-      },
-    ],
-  },
-  {
-    Id: OptionTab.CrewmateTab,
-    Name: 'クルーメイト',
-    Categories: [
-      {
-        Id: 2,
-        Name: '役職設定',
-        Options: [
-          {
-            Id: 201,
-            IsActive: true,
-            TransedName: 'シェリフ',
-            Selection: 0,
-            Format: '{0}',
-            RangeMeta: {
-              Type: 'String',
-              Values: ['無効', '有効'],
-            },
-            Childs: [
-              {
-                Id: 202,
-                IsActive: false,
-                TransedName: 'キルクールダウン',
-                Selection: 2,
-                Format: '{0}s',
-                RangeMeta: {
-                  Type: 'Single',
-                  Values: [10, 20, 30, 40],
-                },
-                Childs: [],
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-];
-
-/**
- * Au系オプションのモックデータ作成
- */
-const mockAuOptionCategoryDtoList: AuOptionCategoryDto[] = [
-  {
-    TranslatedTitle: 'ゲーム設定',
-    Options: [
-      {
-        TranslatedTitle: 'マップ',
-        TranslatedFormat: '{0}',
-        Value: 0,
-        Info: {
-          ValueType: OptionValueType.Byte,
-          OptionName: 1,
-        },
-        Range: ['The Skeld', 'Mira HQ', 'Polus', 'The Fungle'],
-      },
-      {
-        TranslatedTitle: 'インポスターの数',
-        TranslatedFormat: '{0}',
-        Value: 2,
-        Info: {
-          ValueType: OptionValueType.Int,
-          OptionName: 2,
-        },
-        Range: [1, 2, 3],
-      },
-      {
-        TranslatedTitle: '匿名投票',
-        TranslatedFormat: '{0}',
-        Value: true,
-        Info: {
-          ValueType: OptionValueType.Bool,
-          OptionName: 3,
-        },
-        Range: ['OFF', 'ON'],
-      },
-    ],
-  },
-  {
-    TranslatedTitle: '役職設定',
-    Options: [
-      {
-        TranslatedTitle: 'シェリフ',
-        TranslatedFormat: '{0}',
-        Value: {
-          MaxCount: 1,
-          Chance: 100,
-        },
-        Info: {
-          ValueType: OptionValueType.RoleBase,
-          OptionName: 101,
-        },
-        Range: null,
-      },
-      {
-        TranslatedTitle: 'キルクールダウン',
-        TranslatedFormat: '{0}s',
-        Value: 20.5,
-        Info: {
-          ValueType: OptionValueType.Float,
-          OptionName: 102,
-        },
-        Range: [10.0, 15.0, 20.0, 25.0, 30.0],
-      },
-    ],
-  },
-];
+const validatedExRMockData = ExRTabDtoArraySchema.parse(exrOptionData);
+const validatedAuMockData = AuOptionCategoryDtoArraySchema.parse(auOptionData);
 
 /**
  * 更新されたオプションのモックデータ作成
@@ -171,11 +43,6 @@ const mockUpdatedOptions: UpdatedOptions = {
   ChainUpdatedOption: [],
 };
 
-/**
- * Zodを使用してモックデータのバリデーションを実施
- */
-const validatedExRMockData = ExRTabDtoArraySchema.parse(mockExRTabDtoList);
-const validatedAuMockData = AuOptionCategoryDtoArraySchema.parse(mockAuOptionCategoryDtoList);
 const validatedUpdatedOptions = UpdatedOptionsSchema.parse(mockUpdatedOptions);
 
 export const handlers = [


### PR DESCRIPTION
モックサーバー（MSW）のGETリクエストで返却するデータを、外部のJSONファイルからロードするように変更しました。

### 変更内容
1. `mocks/get/exr/option.json` および `mocks/get/au/option.json` を作成し、従来のハードコードされていたモックデータを移行しました。
2. `mocks/handlers.ts` において、上記JSONファイルを `import` 文で読み込むように修正しました。
3. 読み込んだデータに対して、既存のZodスキーマ（`ExRTabDtoArraySchema`, `AuOptionCategoryDtoArraySchema`）を用いたバリデーションを導入し、型安全性を確保しました。
4. `handlers.ts` 内に直接記述されていた大きなオブジェクト定数を削除し、コードの見通しを改善しました。

### 確認事項
- `pnpm test` を実行し、すべてのユニットテストがパスすることを確認しました。
- `pnpm run lint` および `tsc` による静的解析でエラーがないことを確認しました。
- 以前のコードレビューで指摘されたインポート漏れや未定義変数の参照がないことを再確認しました。

---
*PR created automatically by Jules for task [1514689794583198632](https://jules.google.com/task/1514689794583198632) started by @yukieiji*