### PR TITLE
mocksの新しいJSONデータに対応しE2Eテストを修正

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -6,12 +6,12 @@ test('ExR Option Accordion behavior', async ({ page }) => {
   const sidebar = page.getByLabel('オプションサイドバー');
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();
 
-  // カテゴリ「ゲーム設定」のアコーディオンがあることを確認
-  const accordionButton = page.getByRole('button', { name: 'ゲーム設定' });
+  // カテゴリ「プリセット」のアコーディオンがあることを確認
+  const accordionButton = page.getByRole('button', { name: 'プリセット' });
   await expect(accordionButton).toBeVisible();
 
   // 初期状態では閉じている（JSONが表示されていない）
-  const jsonPre = page.getByTestId('category-json-1');
+  const jsonPre = page.getByTestId('category-json-0');
   // アコーディオンのコンテンツ部分は DOM にはあるが、高さ 0 で隠されている。
   // grid-rows-[0fr] かつ overflow-hidden の場合、Playwright では visibility をどう判断するかによる。
   // 以前のテスト結果では visible と判定されていたため、属性やスタイルを直接確認するか、
@@ -22,15 +22,15 @@ test('ExR Option Accordion behavior', async ({ page }) => {
   // アコーディオンを開く
   await accordionButton.click();
   await expect(jsonPre).toBeVisible();
-  await expect(jsonPre).toContainText('"TransedName": "移動速度"');
+  await expect(jsonPre).toContainText('"TranslatedName": "使用するプリセット"');
 
   // タブを切り替えてもアコーディオンの状態が維持されることを確認
-  // クルーメイトタブに切り替え
-  await page.getByRole('button', { name: 'クルーメイト' }).click();
-  await expect(page.getByRole('button', { name: '役職設定' })).toBeVisible();
+  // ゴーストニュートラルタブに切り替え
+  await page.getByRole('button', { name: 'ゴーストニュートラル役職設定' }).click();
+  await expect(page.getByRole('button', { name: 'フォラス' })).toBeVisible();
 
-  // 基本設定タブに戻る
-  await page.getByRole('button', { name: '基本設定' }).click();
+  // グローバル設定タブに戻る
+  await page.getByRole('button', { name: 'グローバル設定' }).click();
   // ゲーム設定アコーディオンがまだ開いていることを確認
   await expect(jsonPre).toBeVisible();
 

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test';
 
 test('has sidebar and json viewer', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/', { waitUntil: 'networkidle' });
 
   // サイドバーが表示されていることを確認
   const sidebar = page.getByLabel('オプションサイドバー');
-  await expect(sidebar).toBeVisible();
+  await expect(sidebar).toBeVisible({ timeout: 10000 });
 
   // サイドバー内のボタンを明示的に指定
   await expect(sidebar.getByRole('button', { name: 'Au Options' })).toBeVisible();
@@ -13,13 +13,14 @@ test('has sidebar and json viewer', async ({ page }) => {
 
   // Au Options が初期で表示されることを確認する
   await expect(page.getByRole('heading', { name: 'Au Options JSON' })).toBeVisible();
-  await expect(page.getByTestId('au-json-pre')).toContainText('"TranslatedTitle": "ゲーム設定"');
+  // 以前のデータには "ゲーム設定" があったが、新しいデータには "インポスター" などがある
+  await expect(page.getByTestId('au-json-pre')).toContainText('"TranslatedTitle": "インポスター"');
   
   // ExR Options に切り替え
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();
   await expect(page.getByRole('heading', { name: 'ExR Options JSON' })).toBeVisible();
   // JSON pre はなくなったので、アコーディオンが表示されていることを確認
-  await expect(page.getByText('基本設定')).toBeVisible();
+  await expect(page.getByText('グローバル設定')).toBeVisible();
 
   // サイドバーの開閉
   await page.getByRole('button', { name: 'サイドバーを閉じる' }).click();

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -6,7 +6,7 @@ import {
   UpdatedOptionsSchema,
   VanillaOptionPutRequestSchema
 } from '../src/type';
-import type { UpdatedOptions } from '../src/type';
+import type { UpdatedOptions, ExRTabDto, AuOptionCategoryDto } from '../src/type';
 
 // JSONファイルのロード
 import exrOptionData from './get/exr/setting-webui-dev_20260321.json';
@@ -15,8 +15,16 @@ import auOptionData from './get/au/setting-webui-dev_20260321.json';
 /**
  * Zodを使用してロードしたデータのバリデーションを実施
  */
-const validatedExRMockData = ExRTabDtoArraySchema.parse(exrOptionData);
-const validatedAuMockData = AuOptionCategoryDtoArraySchema.parse(auOptionData);
+let validatedExRMockData: ExRTabDto[];
+let validatedAuMockData: AuOptionCategoryDto[];
+
+try {
+  validatedExRMockData = ExRTabDtoArraySchema.parse(exrOptionData);
+  validatedAuMockData = AuOptionCategoryDtoArraySchema.parse(auOptionData);
+} catch (error) {
+  console.error('Mock data validation failed:', error);
+  throw error;
+}
 
 /**
  * 更新されたオプションのモックデータ作成

--- a/src/type.ts
+++ b/src/type.ts
@@ -16,12 +16,12 @@ export const OptionTab = {
 
 export type OptionTab = (typeof OptionTab)[keyof typeof OptionTab];
 
-export const OptionTabSchema = z.union([
-  z.nativeEnum(OptionTab),
-  z.enum(Object.keys(OptionTab) as [string, ...string[]]).transform((val) => {
+export const OptionTabSchema = z.preprocess((val) => {
+  if (typeof val === 'string' && val in OptionTab) {
     return OptionTab[val as keyof typeof OptionTab];
-  }),
-]);
+  }
+  return val;
+}, z.nativeEnum(OptionTab));
 
 /**
  * オプションの範囲メタデータ
@@ -109,12 +109,12 @@ export const OptionValueType = {
 
 export type OptionValueType = (typeof OptionValueType)[keyof typeof OptionValueType];
 
-export const OptionValueTypeSchema = z.union([
-  z.nativeEnum(OptionValueType),
-  z.enum(Object.keys(OptionValueType) as [string, ...string[]]).transform((val) => {
+export const OptionValueTypeSchema = z.preprocess((val) => {
+  if (typeof val === 'string' && val in OptionValueType) {
     return OptionValueType[val as keyof typeof OptionValueType];
-  }),
-]);
+  }
+  return val;
+}, z.nativeEnum(OptionValueType));
 
 export interface AuRoleOption {
   MaxCount: number;

--- a/src/type.ts
+++ b/src/type.ts
@@ -16,7 +16,12 @@ export const OptionTab = {
 
 export type OptionTab = (typeof OptionTab)[keyof typeof OptionTab];
 
-export const OptionTabSchema = z.nativeEnum(OptionTab);
+export const OptionTabSchema = z.union([
+  z.nativeEnum(OptionTab),
+  z.enum(Object.keys(OptionTab) as [string, ...string[]]).transform((val) => {
+    return OptionTab[val as keyof typeof OptionTab];
+  }),
+]);
 
 /**
  * オプションの範囲メタデータ
@@ -104,7 +109,12 @@ export const OptionValueType = {
 
 export type OptionValueType = (typeof OptionValueType)[keyof typeof OptionValueType];
 
-export const OptionValueTypeSchema = z.nativeEnum(OptionValueType);
+export const OptionValueTypeSchema = z.union([
+  z.nativeEnum(OptionValueType),
+  z.enum(Object.keys(OptionValueType) as [string, ...string[]]).transform((val) => {
+    return OptionValueType[val as keyof typeof OptionValueType];
+  }),
+]);
 
 export interface AuRoleOption {
   MaxCount: number;
@@ -139,7 +149,7 @@ export const AuOptionDtoSchema = z.object({
   TranslatedFormat: z.string(),
   Value: z.union([z.number(), z.boolean(), AuRoleOptionSchema]),
   Info: AuOptionInfoSchema,
-  Range: z.array(z.union([z.number(), z.string()])).nullable(),
+  Range: z.array(z.union([z.number(), z.string()])).nullable().optional(),
 });
 
 export interface AuOptionCategoryDto {

--- a/tests/api-validation.test.ts
+++ b/tests/api-validation.test.ts
@@ -49,7 +49,7 @@ describe('ExROptionPutRequest and UpdatedOptions Validation', () => {
         {
           Id: 101,
           IsActive: true,
-          TransedName: 'Test Option',
+          TranslatedName: 'Test Option',
           Selection: 1,
           Format: 'Test Format',
           RangeMeta: {
@@ -132,7 +132,7 @@ describe('UpdatedOptions Validation', () => {
         {
           Id: 201,
           IsActive: true,
-          TransedName: 'Option',
+          TranslatedName: 'Option',
           Selection: 1,
           Format: '{0}',
           RangeMeta: {

--- a/tests/dto-validation.test.ts
+++ b/tests/dto-validation.test.ts
@@ -15,7 +15,7 @@ describe('ExRTabDto Validation', () => {
               {
                 Id: 101,
                 IsActive: true,
-                TransedName: 'Test Option',
+                TranslatedName: 'Test Option',
                 Selection: 1,
                 Format: '{0}',
                 RangeMeta: {
@@ -60,7 +60,7 @@ describe('ExRTabDto Validation', () => {
               {
                 Id: 1,
                 IsActive: true,
-                TransedName: 'O',
+                TranslatedName: 'O',
                 Selection: 0,
                 Format: '',
                 RangeMeta: {
@@ -91,7 +91,7 @@ describe('ExRTabDto Validation', () => {
               {
                 Id: 101,
                 IsActive: true,
-                TransedName: 'Parent',
+                TranslatedName: 'Parent',
                 Selection: 0,
                 Format: '{0}',
                 RangeMeta: { Type: 'Int32', Values: [] },
@@ -99,7 +99,7 @@ describe('ExRTabDto Validation', () => {
                   {
                     Id: 102,
                     IsActive: true,
-                    TransedName: 'Child',
+                    TranslatedName: 'Child',
                     Selection: 0,
                     Format: '{0}',
                     RangeMeta: { Type: 'Int32', Values: [] },


### PR DESCRIPTION
開発中の新しいJSONデータをmocksに追加した際にE2Eテストが動作しなくなった問題を修正しました。

主な修正内容：
1. **型定義の柔軟性向上**: `src/type.ts` において、Zodスキーマが数値のenum値だけでなく、文字列のキー名も受け入れて数値に変換するように変更しました。これにより、JSON側の変更なしでバリデーションを通過できるようになりました。
2. **テストコードの修正**: プロパティ名の不一致（`TransedName` vs `TranslatedName`）を解消し、また新しいJSONデータに含まれる具体的な内容（タブ名やカテゴリ名）に基づいてE2Eテストの期待値を更新しました。
3. **デバッグ性の向上**: MSWのハンドラーにおいて、起動時のデータバリデーション失敗を `console.error` で詳細に出力するようにし、今後の不整合の特定を容易にしました。
4. **E2Eテストの堅牢化**: 環境による読み込み遅延に対応するため、Playwrightの設定でタイムアウトを調整し、画面遷移時の待機条件を最適化しました。

全てのユニットテスト、リンター、およびE2Eテスト（Chromium, Firefox, Webkit）がパスすることを確認済みです。

---
*PR created automatically by Jules for task [9973532702357273311](https://jules.google.com/task/9973532702357273311) started by @yukieiji*