### PR TITLE
カラータグと改行のレンダリング対応

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -26,11 +26,12 @@ test('ExR Option Accordion behavior', async ({ page }) => {
 
   // タブを切り替えてもアコーディオンの状態が維持されることを確認
   // ゴーストニュートラルタブに切り替え
-  await page.getByRole('button', { name: 'ゴーストニュートラル役職設定' }).click();
+  // ColoredText を使用しているため、厳密な一致ではなく部分一致で検索する
+  await page.getByRole('button', { name: 'ゴーストニュートラル役職設定', exact: false }).click();
   await expect(page.getByRole('button', { name: 'フォラス' })).toBeVisible();
 
   // グローバル設定タブに戻る
-  await page.getByRole('button', { name: 'グローバル設定' }).click();
+  await page.getByRole('button', { name: 'グローバル設定', exact: false }).click();
   // ゲーム設定アコーディオンがまだ開いていることを確認
   await expect(jsonPre).toBeVisible();
 

--- a/src/components/parts/Accordion.tsx
+++ b/src/components/parts/Accordion.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 interface AccordionProps {
-  title: string;
+  title: ReactNode;
   isOpen: boolean;
   onToggle: () => void;
   children: ReactNode;

--- a/src/components/parts/ColoredText.tsx
+++ b/src/components/parts/ColoredText.tsx
@@ -1,0 +1,72 @@
+import { ReactNode } from 'react';
+
+interface ColoredTextProps {
+  text: string;
+}
+
+/**
+ * カラータグ（<color=#RRGGBB>...</color>）と改行（\n）を反映させるコンポーネント
+ * ネストをサポートします。
+ */
+export function ColoredText({ text }: ColoredTextProps) {
+  if (!text) {
+    return null;
+  }
+
+  // <color=#RRGGBB> または <color=#RRGGBBAA> にマッチする正規表現
+  const regex = /(<color=#[0-9A-F]{6,8}>|<\/color>|\n)/gi;
+  const parts = text.split(regex);
+
+  // ステートフルに解析するためにスタックを使用
+  const stack: { color: string; elements: ReactNode[] }[] = [];
+  let currentElements: ReactNode[] = [];
+
+  parts.forEach((part, index) => {
+    if (!part) {
+      return;
+    }
+
+    const lowerPart = part.toLowerCase();
+    if (lowerPart.startsWith('<color=')) {
+      const colorMatch = part.match(/#[0-9A-F]{6,8}/i);
+      const color = colorMatch ? colorMatch[0] : 'inherit';
+
+      // 現在の要素リストをスタックに保存し、新しい要素リストを開始
+      stack.push({ color, elements: currentElements });
+      currentElements = [];
+    } else if (lowerPart === '</color>') {
+      if (stack.length > 0) {
+        const last = stack.pop()!;
+        const coloredSpan = (
+          <span key={`color-${index}`} style={{ color: last.color }}>
+            {currentElements}
+          </span>
+        );
+        // 親の要素リストに戻り、作成した要素を追加
+        currentElements = last.elements;
+        currentElements.push(coloredSpan);
+      } else {
+        // 閉じタグが余分な場合はテキストとして扱う
+        currentElements.push(part);
+      }
+    } else if (part === '\n') {
+      currentElements.push(<br key={`br-${index}`} />);
+    } else {
+      currentElements.push(part);
+    }
+  });
+
+  // 未閉じのタグがある場合の処理
+  while (stack.length > 0) {
+    const last = stack.pop()!;
+    const coloredSpan = (
+      <span key={`unclosed-${stack.length}`} style={{ color: last.color }}>
+        {currentElements}
+      </span>
+    );
+    currentElements = last.elements;
+    currentElements.push(coloredSpan);
+  }
+
+  return <>{currentElements}</>;
+}

--- a/src/components/parts/ColoredText.tsx
+++ b/src/components/parts/ColoredText.tsx
@@ -5,6 +5,16 @@ interface ColoredTextProps {
 }
 
 /**
+ * カラータグ（<color=#RRGGBB>...</color> または <color=#RRGGBBAA>...</color>）および改行（\n）を検出する正規表現
+ */
+const COLOR_TAG_REGEX = /(<color=#[0-9A-F]{6,8}>|<\/color>|\n)/gi;
+
+/**
+ * カラータグから16進数カラーコードを抽出する正規表現
+ */
+const COLOR_HEX_REGEX = /#[0-9A-F]{6,8}/i;
+
+/**
  * カラータグ（<color=#RRGGBB>...</color>）と改行（\n）を反映させるコンポーネント
  * ネストをサポートします。
  */
@@ -13,9 +23,7 @@ export function ColoredText({ text }: ColoredTextProps) {
     return null;
   }
 
-  // <color=#RRGGBB> または <color=#RRGGBBAA> にマッチする正規表現
-  const regex = /(<color=#[0-9A-F]{6,8}>|<\/color>|\n)/gi;
-  const parts = text.split(regex);
+  const parts = text.split(COLOR_TAG_REGEX);
 
   // ステートフルに解析するためにスタックを使用
   const stack: { color: string; elements: ReactNode[] }[] = [];
@@ -28,7 +36,7 @@ export function ColoredText({ text }: ColoredTextProps) {
 
     const lowerPart = part.toLowerCase();
     if (lowerPart.startsWith('<color=')) {
-      const colorMatch = part.match(/#[0-9A-F]{6,8}/i);
+      const colorMatch = part.match(COLOR_HEX_REGEX);
       const color = colorMatch ? colorMatch[0] : 'inherit';
 
       // 現在の要素リストをスタックに保存し、新しい要素リストを開始

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '../useStore';
 import { Accordion } from '../components/parts/Accordion';
+import { ColoredText } from '../components/parts/ColoredText';
 import type { ExRCategoryDto, ExRTabDto } from '../type';
 
 interface CategoryAccordionProps {
@@ -20,7 +21,7 @@ function CategoryAccordion({ category }: CategoryAccordionProps) {
 
   return (
     <Accordion
-      title={category.Name}
+      title={<ColoredText text={category.Name} />}
       isOpen={isOpen}
       onToggle={() => {
         toggleExRCategory(category.Id);

--- a/src/feature/ExRTabSelector.tsx
+++ b/src/feature/ExRTabSelector.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '../useStore';
+import { ColoredText } from '../components/parts/ColoredText';
 import type { ExRTabDto } from '../type';
 
 interface ExRTabSelectorProps {
@@ -30,7 +31,7 @@ export function ExRTabSelector({ tabs }: ExRTabSelectorProps) {
               ${selectedExRTabId === tab.Id ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}
             `}
           >
-            {tab.Name}
+            <ColoredText text={tab.Name} />
           </button>
         );
       })}

--- a/tests/ColoredText.test.tsx
+++ b/tests/ColoredText.test.tsx
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/react';
+import { ColoredText } from '../src/components/parts/ColoredText';
+import { describe, it, expect } from 'vitest';
+
+describe('ColoredText', () => {
+  it('renders plain text correctly', () => {
+    const { container } = render(<ColoredText text="Hello World" />);
+    expect(container.textContent).toBe('Hello World');
+  });
+
+  it('renders color tags correctly', () => {
+    const { container } = render(<ColoredText text="<color=#FF0000>Red Text</color>" />);
+    const span = container.querySelector('span');
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveStyle({ color: 'rgb(255, 0, 0)' }); // JSDOM converts to rgb
+    expect(span?.textContent).toBe('Red Text');
+  });
+
+  it('renders nested color tags correctly', () => {
+    const { container } = render(
+      <ColoredText text="Outer <color=#FF0000>Red <color=#00FF00>Green</color> Red</color> Outer" />
+    );
+    expect(container.textContent).toBe('Outer Red Green Red Outer');
+
+    const spans = container.querySelectorAll('span');
+    expect(spans.length).toBe(2);
+
+    const outerSpan = Array.from(spans).find(s => s.textContent === 'Red Green Red');
+    expect(outerSpan).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+
+    const innerSpan = outerSpan?.querySelector('span');
+    expect(innerSpan).toHaveStyle({ color: 'rgb(0, 255, 0)' });
+    expect(innerSpan?.textContent).toBe('Green');
+  });
+
+  it('renders newlines as <br />', () => {
+    const { container } = render(<ColoredText text={"Line 1\nLine 2"} />);
+    expect(container.querySelector('br')).toBeInTheDocument();
+    expect(container.textContent).toBe('Line 1Line 2'); // br doesn't add text content
+  });
+
+  it('handles mixed content correctly', () => {
+    const { container } = render(
+      <ColoredText text={"Start\n<color=#0000FF>Blue\nText</color>\nEnd"} />
+    );
+    expect(container.textContent).toBe('StartBlueTextEnd');
+    const span = container.querySelector('span');
+    expect(span).toHaveStyle({ color: 'rgb(0, 0, 255)' });
+    expect(span?.querySelectorAll('br').length).toBe(1);
+    expect(container.querySelectorAll('br').length).toBe(3);
+  });
+
+  it('handles unclosed tags gracefully', () => {
+    const { container } = render(<ColoredText text="<color=#FF0000>Unclosed" />);
+    // expect it to render as colored text
+    const span = container.querySelector('span');
+    expect(span).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+    expect(span?.textContent).toBe('Unclosed');
+  });
+
+  it('handles extra closing tags gracefully', () => {
+    const { container } = render(<ColoredText text="Extra</color>Closing" />);
+    expect(container.textContent).toBe('Extra</color>Closing');
+  });
+
+  it('is case-insensitive for tags', () => {
+    const { container } = render(<ColoredText text="<COLOR=#FF0000>Upper</COLOR>" />);
+    const span = container.querySelector('span');
+    expect(span).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+    expect(span?.textContent).toBe('Upper');
+  });
+});


### PR DESCRIPTION
ExROptions 等のデータに含まれるカラータグ（`<color=#RRGGBB>...</color>` および `<color=#RRGGBBAA>...</color>`）と改行文字（`\n`）を UI 上で正しくレンダリングするための機能を追加しました。

主な変更点:
- `src/components/parts/ColoredText.tsx`: タグと改行を解析し、`<span>` (style指定) と `<br />` に変換する新しいコンポーネント。ネストされたタグもサポートしています。
- `src/components/parts/Accordion.tsx`: タイトル部分にコンポーネントを表示できるよう、`title` プロップの型を `string` から `ReactNode` に拡張。
- `src/feature/ExRTabSelector.tsx` & `src/feature/ExRCategoryList.tsx`: タブ名とカテゴリ名に `ColoredText` を適用。
- `tests/ColoredText.test.tsx`: 新しいコンポーネントの単体テストを追加。
- `e2e/accordion.spec.ts`: `ColoredText` の導入に伴い、ボタンテキストの検索を部分一致（`exact: false`）で行うよう修正。

動作確認:
- `pnpm test` によるユニットテストのパスを確認。
- `pnpm run e2e` による全 E2E テストのパスを確認。
- Playwright による実画面のスクリーンショットで、カラータグが正しく反映されていることを目視確認しました。

---
*PR created automatically by Jules for task [14692481927087247441](https://jules.google.com/task/14692481927087247441) started by @yukieiji*