### PR TITLE
Implement Editable Preset Dropdown and Hide Original Option

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -6,18 +6,18 @@ test('ExR Option Accordion behavior', async ({ page }) => {
   const sidebar = page.getByLabel('オプションサイドバー');
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();
 
-  // カテゴリ「プリセット」のアコーディオンがあることを確認
-  const accordionButton = page.getByRole('button', { name: 'プリセット' });
+  // プリセットカテゴリは非表示になったため、別のカテゴリ「乱数に関する設定」を使用する
+  const categoryName = '乱数に関する設定';
+  const accordionButton = page.getByRole('button', { name: categoryName });
   await expect(accordionButton).toBeVisible();
 
   // 初期状態では閉じている
-  // アコーディオンの開閉状態を管理するコンテナ（button の次の要素）を取得
-  const accordionItem = page.locator('div.border.border-gray-700').filter({ hasText: 'プリセット' });
+  const accordionItem = page.locator('div.border.border-gray-700').filter({ hasText: categoryName });
   const contentContainer = accordionItem.locator('div.grid');
   await expect(contentContainer).toHaveClass(/grid-rows-\[0fr\]/);
 
   // 閉じているときはオプション名が表示されていない（lazy rendering）
-  const optionName = page.getByText('使用するプリセット');
+  const optionName = page.getByText('強力なシャッフルを使用する');
   await expect(optionName).not.toBeAttached();
 
   // アコーディオンを開く
@@ -26,14 +26,12 @@ test('ExR Option Accordion behavior', async ({ page }) => {
   await expect(optionName).toBeVisible();
 
   // タブを切り替えてもアコーディオンの状態が維持されることを確認
-  // ゴーストニュートラルタブに切り替え
-  // ColoredText を使用しているため、厳密な一致ではなく部分一致で検索する
   await page.getByRole('button', { name: 'ゴーストニュートラル役職設定', exact: false }).click();
   await expect(page.getByRole('button', { name: 'フォラス' })).toBeVisible();
 
   // グローバル設定タブに戻る
   await page.getByRole('button', { name: 'グローバル設定', exact: false }).click();
-  // ゲーム設定アコーディオンがまだ開いていることを確認
+  // アコーディオンがまだ開いていることを確認
   await expect(optionName).toBeVisible();
 
   // サイドバーを切り替えて戻ってきても維持されることを確認

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('has sidebar and json viewer', async ({ page }) => {
-  await page.goto('/', { waitUntil: 'networkidle' });
+  await page.goto('/');
 
   // サイドバーが表示されていることを確認
   const sidebar = page.getByLabel('オプションサイドバー');

--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -7,29 +7,22 @@ test('Options interaction behavior', async ({ page }) => {
   await expect(sidebar).toBeVisible({ timeout: 10000 });
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();
 
-  // カテゴリ「プリセット」を開く
-  const categoryButton = page.getByRole('button', { name: 'プリセット' });
-  await expect(categoryButton).toBeVisible();
-  await categoryButton.click();
+  // ヘッダーのプリセットセレクターを確認
+  const presetInput = page.getByPlaceholder('プリセット名を入力...');
+  await expect(presetInput).toBeVisible();
 
-  // 「使用するプリセット」オプション（Int32/Slider）を確認
-  const optionName = page.getByText('使用するプリセット');
-  await expect(optionName).toBeVisible();
+  // 初期値 (1)
+  await expect(presetInput).toHaveValue('1');
 
-  // 初期値を確認 (Selection 0 -> Value 1)
-  const input = page.locator('input[type="text"]').first();
-  await expect(input).toHaveValue('1');
-  await expect(page.getByText('(Preset 1)')).toBeVisible({ timeout: 10000 });
+  // 名前を変更
+  await presetInput.fill('Test Preset');
+  await presetInput.press('Enter');
 
-  // スライダーを操作（直接入力を変更してストアの更新を確認）
-  await input.fill('5');
-  // スナップされて 5 になるはず
-  await expect(input).toHaveValue('5');
-  await expect(page.getByText('(Preset 5)')).toBeVisible({ timeout: 10000 });
+  // ドロップダウンを開いて名前が反映されているか確認
+  await page.getByRole('button', { name: 'プリセットを選択' }).click();
+  await expect(page.getByText('Test Preset')).toBeVisible();
 
-  // クルーメイトタブに切り替えてドロップダウンをテスト（データ構造に基づく）
-  // 実際には「基本設定」が「プリセット」カテゴリを持っている
-  // 別の「乱数に関する設定」カテゴリの「強力なシャッフルを使用する」をテスト
+  // 別のカテゴリの操作を確認
   const shuffleCategory = page.getByRole('button', { name: '乱数に関する設定' });
   await shuffleCategory.click();
 
@@ -39,7 +32,7 @@ test('Options interaction behavior', async ({ page }) => {
   const dropdown = page.getByRole('combobox');
   await expect(dropdown).toHaveValue('0'); // オフ
 
-  // ドロップダウンを変更 (インデックスで選択。ラベルにはカラータグが含まれているため)
+  // ドロップダウンを変更
   await dropdown.selectOption({ index: 1 });
   await expect(dropdown).toHaveValue('1');
 });

--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Options interaction behavior', async ({ page }) => {
-  await page.goto('/', { waitUntil: 'networkidle' });
+  await page.goto('/');
 
   const sidebar = page.getByLabel('オプションサイドバー');
   await expect(sidebar).toBeVisible({ timeout: 10000 });

--- a/e2e/preset_naming.spec.ts
+++ b/e2e/preset_naming.spec.ts
@@ -1,12 +1,18 @@
 import { test, expect } from '@playwright/test';
 
 test('Preset naming and persistence behavior', async ({ page }) => {
+  // すべてのテストで API の遅延を設定可能にする
+  await page.addInitScript(() => {
+    // @ts-expect-error - window has no __API_DELAY__ property
+    window.__API_DELAY__ = 1000;
+  });
+
   await page.goto('/');
 
   const sidebar = page.getByLabel('オプションサイドバー');
+  await expect(sidebar).toBeVisible({ timeout: 30000 });
+
   const exrButton = sidebar.getByRole('button', { name: 'ExR Options' });
-  // 初期ロードの待機
-  await expect(sidebar).toBeVisible({ timeout: 15000 });
   await expect(exrButton).toBeVisible({ timeout: 15000 });
   await exrButton.click();
 
@@ -39,8 +45,8 @@ test('Preset naming and persistence behavior', async ({ page }) => {
   await page.reload();
 
   // サイドバーの再表示を待つ
-  await expect(sidebar).toBeVisible({ timeout: 15000 });
-  await expect(exrButton).toBeVisible({ timeout: 15000 });
+  await expect(sidebar).toBeVisible({ timeout: 30000 });
+  await expect(exrButton).toBeVisible({ timeout: 30000 });
   await exrButton.click();
 
   // 初期状態では index 0 (プリセット 1) が選択されるはずなので、名前が Hardcore Rules であることを確認

--- a/e2e/preset_naming.spec.ts
+++ b/e2e/preset_naming.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Preset naming and persistence behavior', async ({ page }) => {
-  await page.goto('/', { waitUntil: 'networkidle' });
+  await page.goto('/');
 
   const sidebar = page.getByLabel('オプションサイドバー');
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();
@@ -26,7 +26,7 @@ test('Preset naming and persistence behavior', async ({ page }) => {
   await presetInput.blur(); // onBlur での保存をテスト
 
   // ページをリロードして Cookie から復元されるか確認
-  await page.reload({ waitUntil: 'networkidle' });
+  await page.reload();
 
   // ExR Options を再度開く
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();

--- a/e2e/preset_naming.spec.ts
+++ b/e2e/preset_naming.spec.ts
@@ -4,20 +4,30 @@ test('Preset naming and persistence behavior', async ({ page }) => {
   await page.goto('/');
 
   const sidebar = page.getByLabel('オプションサイドバー');
-  await sidebar.getByRole('button', { name: 'ExR Options' }).click();
+  const exrButton = sidebar.getByRole('button', { name: 'ExR Options' });
+  // 初期ロードの待機
+  await expect(sidebar).toBeVisible({ timeout: 15000 });
+  await expect(exrButton).toBeVisible({ timeout: 15000 });
+  await exrButton.click();
 
   // ヘッダーのプリセットセレクターを確認
   const presetInput = page.getByPlaceholder('プリセット名を入力...');
-  await expect(presetInput).toBeVisible();
+  await expect(presetInput).toBeVisible({ timeout: 15000 });
 
   // プリセット 1 (index 0) に名前を付ける
   await presetInput.fill('Hardcore Rules');
   await presetInput.press('Enter');
 
   // ドロップダウンを開く
-  await page.getByRole('button', { name: 'プリセットを選択' }).click();
+  const selectButton = page.getByRole('button', { name: 'プリセットを選択' });
+  await expect(selectButton).toBeVisible();
+  await selectButton.click();
+
   // プリセット 2 (index 1) に切り替える
-  await page.getByRole('button', { name: '2', exact: true }).click();
+  const preset2Button = page.getByRole('button', { name: '2', exact: true });
+  await expect(preset2Button).toBeVisible();
+  await preset2Button.click();
+
   // 入力欄が index 1 のデフォルト値 "2" になっていることを確認
   await expect(presetInput).toHaveValue('2');
 
@@ -28,17 +38,21 @@ test('Preset naming and persistence behavior', async ({ page }) => {
   // ページをリロードして Cookie から復元されるか確認
   await page.reload();
 
-  // ExR Options を再度開く
-  await sidebar.getByRole('button', { name: 'ExR Options' }).click();
+  // サイドバーの再表示を待つ
+  await expect(sidebar).toBeVisible({ timeout: 15000 });
+  await expect(exrButton).toBeVisible({ timeout: 15000 });
+  await exrButton.click();
 
   // 初期状態では index 0 (プリセット 1) が選択されるはずなので、名前が Hardcore Rules であることを確認
-  await expect(presetInput).toHaveValue('Hardcore Rules');
+  await expect(presetInput).toHaveValue('Hardcore Rules', { timeout: 15000 });
 
   // ドロップダウンを開いて index 1 の名前が保持されていることを確認
-  await page.getByRole('button', { name: 'プリセットを選択' }).click();
-  await expect(page.getByText('Casual Fun')).toBeVisible();
+  await expect(selectButton).toBeVisible();
+  await selectButton.click();
+  const casualFunButton = page.getByRole('button', { name: 'Casual Fun' });
+  await expect(casualFunButton).toBeVisible();
 
   // index 1 (Casual Fun) に切り替える
-  await page.getByRole('button', { name: 'Casual Fun' }).click();
+  await casualFunButton.click();
   await expect(presetInput).toHaveValue('Casual Fun');
 });

--- a/e2e/preset_naming.spec.ts
+++ b/e2e/preset_naming.spec.ts
@@ -1,19 +1,25 @@
 import { test, expect } from '@playwright/test';
 
 test('Preset naming and persistence behavior', async ({ page }) => {
-  // すべてのテストで API の遅延を設定可能にする
+  // タイムアウトを延長
+  test.setTimeout(60000);
+
+  // すべてのテストで API の遅延を設定可能にする（CI 向けに最短に）
   await page.addInitScript(() => {
     // @ts-expect-error - window has no __API_DELAY__ property
-    window.__API_DELAY__ = 1000;
+    window.__API_DELAY__ = 100;
   });
 
   await page.goto('/');
+
+  // ローディング画面が消えるのを待つ
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 45000 });
 
   const sidebar = page.getByLabel('オプションサイドバー');
   await expect(sidebar).toBeVisible({ timeout: 30000 });
 
   const exrButton = sidebar.getByRole('button', { name: 'ExR Options' });
-  await expect(exrButton).toBeVisible({ timeout: 15000 });
+  await expect(exrButton).toBeVisible({ timeout: 30000 });
   await exrButton.click();
 
   // ヘッダーのプリセットセレクターを確認
@@ -42,7 +48,10 @@ test('Preset naming and persistence behavior', async ({ page }) => {
   await presetInput.blur(); // onBlur での保存をテスト
 
   // ページをリロードして Cookie から復元されるか確認
-  await page.reload();
+  await page.goto('/');
+
+  // ローディング画面が消えるのを待つ
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 45000 });
 
   // サイドバーの再表示を待つ
   await expect(sidebar).toBeVisible({ timeout: 30000 });

--- a/e2e/preset_naming.spec.ts
+++ b/e2e/preset_naming.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+test('Preset naming and persistence behavior', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  const sidebar = page.getByLabel('オプションサイドバー');
+  await sidebar.getByRole('button', { name: 'ExR Options' }).click();
+
+  // ヘッダーのプリセットセレクターを確認
+  const presetInput = page.getByPlaceholder('プリセット名を入力...');
+  await expect(presetInput).toBeVisible();
+
+  // プリセット 1 (index 0) に名前を付ける
+  await presetInput.fill('Hardcore Rules');
+  await presetInput.press('Enter');
+
+  // ドロップダウンを開く
+  await page.getByRole('button', { name: 'プリセットを選択' }).click();
+  // プリセット 2 (index 1) に切り替える
+  await page.getByRole('button', { name: '2', exact: true }).click();
+  // 入力欄が index 1 のデフォルト値 "2" になっていることを確認
+  await expect(presetInput).toHaveValue('2');
+
+  // プリセット 2 (index 1) に名前を付ける
+  await presetInput.fill('Casual Fun');
+  await presetInput.blur(); // onBlur での保存をテスト
+
+  // ページをリロードして Cookie から復元されるか確認
+  await page.reload({ waitUntil: 'networkidle' });
+
+  // ExR Options を再度開く
+  await sidebar.getByRole('button', { name: 'ExR Options' }).click();
+
+  // 初期状態では index 0 (プリセット 1) が選択されるはずなので、名前が Hardcore Rules であることを確認
+  await expect(presetInput).toHaveValue('Hardcore Rules');
+
+  // ドロップダウンを開いて index 1 の名前が保持されていることを確認
+  await page.getByRole('button', { name: 'プリセットを選択' }).click();
+  await expect(page.getByText('Casual Fun')).toBeVisible();
+
+  // index 1 (Casual Fun) に切り替える
+  await page.getByRole('button', { name: 'Casual Fun' }).click();
+  await expect(presetInput).toHaveValue('Casual Fun');
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,11 +29,11 @@ function EditorContainer() {
   const exrData = use(getExrOptions());
   const auData = use(getAuOptions());
 
-  return selectedTab === 'ExR' ? (
-    <ExROptionEditor data={exrData} />
-  ) : (
-    <AuOptionEditor data={auData} />
-  );
+  if (selectedTab === 'ExR') {
+    return <ExROptionEditor data={exrData} />;
+  }
+
+  return <AuOptionEditor data={auData} />;
 }
 
 /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,18 @@ import { OptionGroupToggleSidebar } from './feature/OptionGroupToggleSidebar';
 import { LoadingView } from './feature/LoadingView';
 import { ExROptionEditor } from './feature/ExROptionEditor';
 import { AuOptionEditor } from './feature/AuOptionEditor';
+import { PresetSelector } from './feature/PresetSelector';
 import { useStore } from './useStore';
 import { getExrOptions, getAuOptions } from './logics/api';
+
+/**
+ * プリセットセレクターを表示するためのコンテナコンポーネント
+ * データを取得し、Suspense境界内で動作します
+ */
+function PresetSelectorContainer() {
+  const exrData = use(getExrOptions());
+  return <PresetSelector tabs={exrData} />;
+}
 
 /**
  * オプションエディタを表示する内側のコンポーネント
@@ -45,9 +55,14 @@ function MainContent() {
       data-is-pending={isSidebarPending ? "true" : "false"}
     >
       <div className="flex items-center gap-4">
-        <h2 className="text-2xl font-bold">
+        <h2 className="text-2xl font-bold whitespace-nowrap">
           {selectedTab === 'ExR' ? 'ExR Options' : 'Au Options'}
         </h2>
+        {selectedTab === 'ExR' && (
+          <Suspense fallback={<div className="w-48 h-8 bg-gray-700 animate-pulse rounded" />}>
+            <PresetSelectorContainer />
+          </Suspense>
+        )}
         {isSidebarPending && (
           <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
         )}

--- a/src/components/parts/OptionDropdownControl.tsx
+++ b/src/components/parts/OptionDropdownControl.tsx
@@ -15,7 +15,8 @@ export function OptionDropdownControl({
   disabled = false,
 }: OptionDropdownControlProps) {
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    onChange(parseInt(e.target.value, 10));
+    const newValue = parseInt(e.target.value, 10);
+    onChange(newValue);
   };
 
   return (
@@ -25,11 +26,13 @@ export function OptionDropdownControl({
       disabled={disabled}
       className="block w-full sm:w-48 px-3 py-1.5 text-sm bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
     >
-      {values.map((value, index) => (
-        <option key={index} value={index}>
-          {value}
-        </option>
-      ))}
+      {values.map((value, index) => {
+        return (
+          <option key={index} value={index}>
+            {value}
+          </option>
+        );
+      })}
     </select>
   );
 }

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -26,7 +26,9 @@ function CategoryAccordion({ category }: CategoryAccordionProps) {
   });
 
   // 全てのオプションが除外された場合はアコーディオンを表示しない
-  if (filteredOptions.length === 0) return null;
+  if (filteredOptions.length === 0) {
+    return null;
+  }
 
   return (
     <Accordion
@@ -37,9 +39,11 @@ function CategoryAccordion({ category }: CategoryAccordionProps) {
       }}
     >
       <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-        {filteredOptions.map((option) => (
-          <ExROptionItem key={option.Id} categoryId={category.Id} option={option} />
-        ))}
+        {filteredOptions.map((option) => {
+          return (
+            <ExROptionItem key={option.Id} categoryId={category.Id} option={option} />
+          );
+        })}
       </div>
     </Accordion>
   );

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -75,7 +75,7 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
     const filteredOptions = category.Options.filter((option) => {
       return !isPresetOption(category.Id, option.Id);
     });
-    return filteredOptions.length > 0 && filteredOptions.some((opt) => {
+    return filteredOptions.some((opt) => {
       return opt.IsActive;
     });
   });

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -20,6 +20,14 @@ function CategoryAccordion({ category }: CategoryAccordionProps) {
     return state.toggleExRCategory;
   });
 
+  // プリセットカテゴリ (CategoryId: 0) かつ、個別のプリセットオプション (OptionId: 0) を非表示にする
+  const filteredOptions = category.Options.filter((option) => {
+    return !(category.Id === 0 && option.Id === 0);
+  });
+
+  // 全てのオプションが除外された場合はアコーディオンを表示しない
+  if (filteredOptions.length === 0) return null;
+
   return (
     <Accordion
       title={<ColoredText text={category.Name} />}
@@ -29,7 +37,7 @@ function CategoryAccordion({ category }: CategoryAccordionProps) {
       }}
     >
       <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-        {category.Options.map((option) => (
+        {filteredOptions.map((option) => (
           <ExROptionItem key={option.Id} categoryId={category.Id} option={option} />
         ))}
       </div>
@@ -57,8 +65,12 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
   }) || tabs[0];
 
   // オプションが空でない、かつ少なくとも1つのオプションが有効なカテゴリのみを抽出
+  // ※ プリセット (Category 0, Option 0) が唯一のオプションだった場合も考慮してフィルタリング
   const visibleCategories = selectedTab.Categories.filter((category) => {
-    return category.Options.length > 0 && category.Options.some((opt) => {
+    const filteredOptions = category.Options.filter((option) => {
+      return !(category.Id === 0 && option.Id === 0);
+    });
+    return filteredOptions.length > 0 && filteredOptions.some((opt) => {
       return opt.IsActive;
     });
   });

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -2,6 +2,7 @@ import { useStore } from '../useStore';
 import { Accordion } from '../components/parts/Accordion';
 import { ColoredText } from '../components/parts/ColoredText';
 import { ExROptionItem } from './ExROptionItem';
+import { isPresetOption } from '../logics/optionUtils';
 import type { ExRCategoryDto, ExRTabDto } from '../type';
 
 interface CategoryAccordionProps {
@@ -20,9 +21,9 @@ function CategoryAccordion({ category }: CategoryAccordionProps) {
     return state.toggleExRCategory;
   });
 
-  // プリセットカテゴリ (CategoryId: 0) かつ、個別のプリセットオプション (OptionId: 0) を非表示にする
+  // プリセット設定（Category 0, Option 0）を非表示にする
   const filteredOptions = category.Options.filter((option) => {
-    return !(category.Id === 0 && option.Id === 0);
+    return !isPresetOption(category.Id, option.Id);
   });
 
   // 全てのオプションが除外された場合はアコーディオンを表示しない
@@ -69,10 +70,10 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
   }) || tabs[0];
 
   // オプションが空でない、かつ少なくとも1つのオプションが有効なカテゴリのみを抽出
-  // ※ プリセット (Category 0, Option 0) が唯一のオプションだった場合も考慮してフィルタリング
+  // ※ プリセット設定が唯一のオプションだった場合も考慮してフィルタリング
   const visibleCategories = selectedTab.Categories.filter((category) => {
     const filteredOptions = category.Options.filter((option) => {
-      return !(category.Id === 0 && option.Id === 0);
+      return !isPresetOption(category.Id, option.Id);
     });
     return filteredOptions.length > 0 && filteredOptions.some((opt) => {
       return opt.IsActive;

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -65,15 +65,20 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
     return state.isTabPending;
   });
 
-  const selectedTab = tabs.find((tab) => {
+  let selectedTab = tabs.find((tab) => {
     return tab.Id === selectedExRTabId;
-  }) || tabs[0];
+  });
+
+  if (!selectedTab) {
+    selectedTab = tabs[0];
+  }
 
   // オプションが空でない、かつ少なくとも1つのオプションが有効なカテゴリのみを抽出
   // ※ プリセット設定が唯一のオプションだった場合も考慮してフィルタリング
   const visibleCategories = selectedTab.Categories.filter((category) => {
     const filteredOptions = category.Options.filter((option) => {
-      return !isPresetOption(category.Id, option.Id);
+      const isPreset = isPresetOption(category.Id, option.Id);
+      return !isPreset;
     });
     return filteredOptions.some((opt) => {
       return opt.IsActive;

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -14,9 +14,10 @@ interface ExROptionControlProps {
  */
 export function ExROptionControl({ categoryId, option }: ExROptionControlProps) {
   const uniqueId = getUniqueOptionId(categoryId, option.Id);
-  const currentSelection = useStore((state) => {
-    return state.effectiveSelections[uniqueId] ?? option.Selection;
+  const effectiveSelection = useStore((state) => {
+    return state.effectiveSelections[uniqueId];
   });
+  const currentSelection = effectiveSelection ?? option.Selection;
   const TEMP_updateExROptionSelection = useStore((state) => {
     return state.TEMP_updateExROptionSelection;
   });

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -11,6 +11,9 @@ interface PresetSelectorProps {
  * プリセットを選択・編集するためのコンポーネント。
  * CategoryId: 0, OptionId: 0 の設定を操作します。
  * AGENT.md のガイドラインに従い、useState を使用せず、グローバルストアで状態を管理します。
+ *
+ * 入力更新の最適化:
+ * ユーザー入力ごとの Cookie 書き込みを避けるため、onBlur または Enter キー入力時に更新を行います。
  */
 export function PresetSelector({ tabs }: PresetSelectorProps) {
   // GeneralTab (Id: 0) から プリセットカテゴリ (Id: 0) を探す
@@ -29,6 +32,7 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
     return state.effectiveSelections[uniqueId];
   });
   const currentSelection = effectiveSelection ?? presetOption?.Selection ?? 0;
+
   const presetNames = useStore((state) => {
     return state.presetNames;
   });
@@ -46,6 +50,7 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
   });
 
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // 外部クリックでドロップダウンを閉じる
   useEffect(() => {
@@ -73,8 +78,25 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
     setPresetDropdownOpen(false);
   };
 
-  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    updatePresetName(currentSelection, e.target.value);
+  /**
+   * ストアと Cookie を更新する
+   */
+  const commitNameChange = () => {
+    if (inputRef.current) {
+      updatePresetName(currentSelection, inputRef.current.value);
+    }
+  };
+
+  const handleBlur = () => {
+    commitNameChange();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      commitNameChange();
+      // Enter 入力後はフォーカスを外して確定を視覚的に示す
+      e.currentTarget.blur();
+    }
   };
 
   const toggleDropdown = () => {
@@ -85,9 +107,12 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
     <div className="relative flex items-center gap-2" ref={dropdownRef}>
       <div className="relative flex items-center bg-gray-800 border border-gray-700 rounded overflow-hidden focus-within:border-blue-500">
         <input
+          ref={inputRef}
           type="text"
-          value={currentPresetName}
-          onChange={handleNameChange}
+          key={currentSelection}
+          defaultValue={currentPresetName}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
           className="px-3 py-1.5 text-sm bg-transparent text-gray-200 outline-none w-48"
           placeholder="プリセット名を入力..."
         />

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useStore } from '../useStore';
 import { getUniqueOptionId } from '../logics/optionUtils';
 import type { ExRTabDto } from '../type';
@@ -10,48 +10,74 @@ interface PresetSelectorProps {
 /**
  * プリセットを選択・編集するためのコンポーネント。
  * CategoryId: 0, OptionId: 0 の設定を操作します。
+ * AGENT.md のガイドラインに従い、useState を使用せず、グローバルストアで状態を管理します。
  */
 export function PresetSelector({ tabs }: PresetSelectorProps) {
   // GeneralTab (Id: 0) から プリセットカテゴリ (Id: 0) を探す
-  const generalTab = tabs.find((t) => t.Id === 0);
-  const presetCategory = generalTab?.Categories.find((c) => c.Id === 0);
-  const presetOption = presetCategory?.Options.find((o) => o.Id === 0);
+  const generalTab = tabs.find((t) => {
+    return t.Id === 0;
+  });
+  const presetCategory = generalTab?.Categories.find((c) => {
+    return c.Id === 0;
+  });
+  const presetOption = presetCategory?.Options.find((o) => {
+    return o.Id === 0;
+  });
 
   const uniqueId = getUniqueOptionId(0, 0);
   const currentSelection = useStore((state) => {
     return state.effectiveSelections[uniqueId] ?? presetOption?.Selection ?? 0;
   });
-  const presetNames = useStore((state) => state.presetNames);
-  const updatePresetName = useStore((state) => state.updatePresetName);
-  const TEMP_updateExROptionSelection = useStore((state) => state.TEMP_updateExROptionSelection);
+  const presetNames = useStore((state) => {
+    return state.presetNames;
+  });
+  const isDropdownOpen = useStore((state) => {
+    return state.isPresetDropdownOpen;
+  });
+  const updatePresetName = useStore((state) => {
+    return state.updatePresetName;
+  });
+  const TEMP_updateExROptionSelection = useStore((state) => {
+    return state.TEMP_updateExROptionSelection;
+  });
+  const setPresetDropdownOpen = useStore((state) => {
+    return state.setPresetDropdownOpen;
+  });
 
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // 外部クリックでドロップダウンを閉じる
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsDropdownOpen(false);
+        setPresetDropdownOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [setPresetDropdownOpen]);
 
-  if (!presetOption) return null;
+  if (!presetOption) {
+    return null;
+  }
 
-  const presetValues = presetOption.RangeMeta.Values as (number | string)[];
+  const presetValues = presetOption.RangeMeta.Values as number[];
   const currentPresetValue = presetValues[currentSelection];
   const currentPresetName = presetNames[currentSelection] ?? String(currentPresetValue);
 
   const handlePresetSelect = (index: number) => {
     TEMP_updateExROptionSelection(uniqueId, index);
-    setIsDropdownOpen(false);
+    setPresetDropdownOpen(false);
   };
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     updatePresetName(currentSelection, e.target.value);
+  };
+
+  const toggleDropdown = () => {
+    setPresetDropdownOpen(!isDropdownOpen);
   };
 
   return (
@@ -65,7 +91,7 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
           placeholder="プリセット名を入力..."
         />
         <button
-          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+          onClick={toggleDropdown}
           className="px-2 py-1.5 bg-gray-700 hover:bg-gray-600 border-l border-gray-600 transition-colors"
           aria-label="プリセットを選択"
         >
@@ -88,7 +114,9 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
             return (
               <button
                 key={index}
-                onClick={() => handlePresetSelect(index)}
+                onClick={() => {
+                  handlePresetSelect(index);
+                }}
                 className={`
                   w-full text-left px-3 py-2 text-sm transition-colors
                   ${isSelected ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-gray-700'}
@@ -96,7 +124,9 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
               >
                 <div className="flex justify-between items-center">
                   <span>{name}</span>
-                  {name !== String(val) && <span className="text-xs opacity-50 ml-2">({val})</span>}
+                  {name !== String(val) && (
+                    <span className="text-xs opacity-50 ml-2">({val})</span>
+                  )}
                 </div>
               </button>
             );

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -25,9 +25,10 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
   });
 
   const uniqueId = getUniqueOptionId(0, 0);
-  const currentSelection = useStore((state) => {
-    return state.effectiveSelections[uniqueId] ?? presetOption?.Selection ?? 0;
+  const effectiveSelection = useStore((state) => {
+    return state.effectiveSelections[uniqueId];
   });
+  const currentSelection = effectiveSelection ?? presetOption?.Selection ?? 0;
   const presetNames = useStore((state) => {
     return state.presetNames;
   });

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect, useRef } from 'react';
+import { useStore } from '../useStore';
+import { getUniqueOptionId } from '../logics/optionUtils';
+import type { ExRTabDto } from '../type';
+
+interface PresetSelectorProps {
+  tabs: ExRTabDto[];
+}
+
+/**
+ * プリセットを選択・編集するためのコンポーネント。
+ * CategoryId: 0, OptionId: 0 の設定を操作します。
+ */
+export function PresetSelector({ tabs }: PresetSelectorProps) {
+  // GeneralTab (Id: 0) から プリセットカテゴリ (Id: 0) を探す
+  const generalTab = tabs.find((t) => t.Id === 0);
+  const presetCategory = generalTab?.Categories.find((c) => c.Id === 0);
+  const presetOption = presetCategory?.Options.find((o) => o.Id === 0);
+
+  const uniqueId = getUniqueOptionId(0, 0);
+  const currentSelection = useStore((state) => {
+    return state.effectiveSelections[uniqueId] ?? presetOption?.Selection ?? 0;
+  });
+  const presetNames = useStore((state) => state.presetNames);
+  const updatePresetName = useStore((state) => state.updatePresetName);
+  const TEMP_updateExROptionSelection = useStore((state) => state.TEMP_updateExROptionSelection);
+
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // 外部クリックでドロップダウンを閉じる
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  if (!presetOption) return null;
+
+  const presetValues = presetOption.RangeMeta.Values as (number | string)[];
+  const currentPresetValue = presetValues[currentSelection];
+  const currentPresetName = presetNames[currentSelection] ?? String(currentPresetValue);
+
+  const handlePresetSelect = (index: number) => {
+    TEMP_updateExROptionSelection(uniqueId, index);
+    setIsDropdownOpen(false);
+  };
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updatePresetName(currentSelection, e.target.value);
+  };
+
+  return (
+    <div className="relative flex items-center gap-2" ref={dropdownRef}>
+      <div className="relative flex items-center bg-gray-800 border border-gray-700 rounded overflow-hidden focus-within:border-blue-500">
+        <input
+          type="text"
+          value={currentPresetName}
+          onChange={handleNameChange}
+          className="px-3 py-1.5 text-sm bg-transparent text-gray-200 outline-none w-48"
+          placeholder="プリセット名を入力..."
+        />
+        <button
+          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+          className="px-2 py-1.5 bg-gray-700 hover:bg-gray-600 border-l border-gray-600 transition-colors"
+          aria-label="プリセットを選択"
+        >
+          <svg
+            className={`w-4 h-4 text-gray-400 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      </div>
+
+      {isDropdownOpen && (
+        <div className="absolute top-full left-0 mt-1 w-full bg-gray-800 border border-gray-700 rounded shadow-xl z-50 max-h-60 overflow-y-auto">
+          {presetValues.map((val, index) => {
+            const name = presetNames[index] ?? String(val);
+            const isSelected = index === currentSelection;
+            return (
+              <button
+                key={index}
+                onClick={() => handlePresetSelect(index)}
+                className={`
+                  w-full text-left px-3 py-2 text-sm transition-colors
+                  ${isSelected ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-gray-700'}
+                `}
+              >
+                <div className="flex justify-between items-center">
+                  <span>{name}</span>
+                  {name !== String(val) && <span className="text-xs opacity-50 ml-2">({val})</span>}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/logics/cookieUtils.ts
+++ b/src/logics/cookieUtils.ts
@@ -20,7 +20,10 @@ export function getCookie(name: string): string | null {
       return decodeURIComponent(cookie.substring(nameLenPlus));
     });
 
-  return result[0] || null;
+  if (result.length > 0) {
+    return result[0];
+  }
+  return null;
 }
 
 /**

--- a/src/logics/cookieUtils.ts
+++ b/src/logics/cookieUtils.ts
@@ -1,3 +1,5 @@
+import { PresetNamesSchema } from '../type';
+
 /**
  * クッキーを取得する
  */
@@ -53,14 +55,12 @@ export function loadPresetNamesFromCookie(): Record<number, string> {
   }
   try {
     const parsed = JSON.parse(cookieValue);
-    // キーを数値に変換して返す
-    const result: Record<number, string> = {};
-    for (const key in parsed) {
-      if (Object.prototype.hasOwnProperty.call(parsed, key)) {
-        result[Number(key)] = parsed[key];
-      }
+    const result = PresetNamesSchema.safeParse(parsed);
+    if (result.success) {
+      return result.data;
     }
-    return result;
+    console.error('Failed to validate preset names from cookie', result.error);
+    return {};
   } catch (e) {
     console.error('Failed to parse preset names from cookie', e);
     return {};

--- a/src/logics/cookieUtils.ts
+++ b/src/logics/cookieUtils.ts
@@ -2,26 +2,32 @@
  * クッキーを取得する
  */
 export function getCookie(name: string): string | null {
-  if (typeof document === 'undefined') return null;
+  if (typeof document === 'undefined') {
+    return null;
+  }
   const nameLenPlus = name.length + 1;
-  return (
-    document.cookie
-      .split(';')
-      .map((c) => c.trim())
-      .filter((cookie) => {
-        return cookie.substring(0, nameLenPlus) === `${name}=`;
-      })
-      .map((cookie) => {
-        return decodeURIComponent(cookie.substring(nameLenPlus));
-      })[0] || null
-  );
+  const result = document.cookie
+    .split(';')
+    .map((c) => {
+      return c.trim();
+    })
+    .filter((cookie) => {
+      return cookie.substring(0, nameLenPlus) === `${name}=`;
+    })
+    .map((cookie) => {
+      return decodeURIComponent(cookie.substring(nameLenPlus));
+    });
+
+  return result[0] || null;
 }
 
 /**
  * クッキーを設定する
  */
 export function setCookie(name: string, value: string, days: number = 365) {
-  if (typeof document === 'undefined') return;
+  if (typeof document === 'undefined') {
+    return;
+  }
   const date = new Date();
   date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
   const expires = `; expires=${date.toUTCString()}`;
@@ -42,13 +48,17 @@ export function savePresetNamesToCookie(names: Record<number, string>) {
  */
 export function loadPresetNamesFromCookie(): Record<number, string> {
   const cookieValue = getCookie(PRESET_NAMES_COOKIE_NAME);
-  if (!cookieValue) return {};
+  if (!cookieValue) {
+    return {};
+  }
   try {
     const parsed = JSON.parse(cookieValue);
     // キーを数値に変換して返す
     const result: Record<number, string> = {};
     for (const key in parsed) {
-      result[Number(key)] = parsed[key];
+      if (Object.prototype.hasOwnProperty.call(parsed, key)) {
+        result[Number(key)] = parsed[key];
+      }
     }
     return result;
   } catch (e) {

--- a/src/logics/cookieUtils.ts
+++ b/src/logics/cookieUtils.ts
@@ -1,0 +1,58 @@
+/**
+ * クッキーを取得する
+ */
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const nameLenPlus = name.length + 1;
+  return (
+    document.cookie
+      .split(';')
+      .map((c) => c.trim())
+      .filter((cookie) => {
+        return cookie.substring(0, nameLenPlus) === `${name}=`;
+      })
+      .map((cookie) => {
+        return decodeURIComponent(cookie.substring(nameLenPlus));
+      })[0] || null
+  );
+}
+
+/**
+ * クッキーを設定する
+ */
+export function setCookie(name: string, value: string, days: number = 365) {
+  if (typeof document === 'undefined') return;
+  const date = new Date();
+  date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+  const expires = `; expires=${date.toUTCString()}`;
+  document.cookie = `${name}=${encodeURIComponent(value)}${expires}; path=/; SameSite=Lax`;
+}
+
+const PRESET_NAMES_COOKIE_NAME = 'exr_preset_names';
+
+/**
+ * プリセット名のリストをクッキーに保存する
+ */
+export function savePresetNamesToCookie(names: Record<number, string>) {
+  setCookie(PRESET_NAMES_COOKIE_NAME, JSON.stringify(names));
+}
+
+/**
+ * プリセット名のリストをクッキーから読み込む
+ */
+export function loadPresetNamesFromCookie(): Record<number, string> {
+  const cookieValue = getCookie(PRESET_NAMES_COOKIE_NAME);
+  if (!cookieValue) return {};
+  try {
+    const parsed = JSON.parse(cookieValue);
+    // キーを数値に変換して返す
+    const result: Record<number, string> = {};
+    for (const key in parsed) {
+      result[Number(key)] = parsed[key];
+    }
+    return result;
+  } catch (e) {
+    console.error('Failed to parse preset names from cookie', e);
+    return {};
+  }
+}

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -4,3 +4,10 @@
 export function getUniqueOptionId(categoryId: number, optionId: number): string {
   return `${categoryId}-${optionId}`;
 }
+
+/**
+ * 指定されたカテゴリIDとオプションIDがプリセット設定（Category 0, Option 0）であるか判定します。
+ */
+export function isPresetOption(categoryId: number, optionId: number): boolean {
+  return categoryId === 0 && optionId === 0;
+}

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -12,12 +12,14 @@ export interface OptionViewerSlice {
   openedExROptionIds: Record<string, boolean>;
   effectiveSelections: Record<string, number>;
   presetNames: Record<number, string>;
+  isPresetDropdownOpen: boolean;
   setSelectedExRTabId: (id: OptionTab) => void;
   setIsTabPending: (isPending: boolean) => void;
   toggleExRCategory: (categoryId: number) => void;
   toggleExROption: (uniqueOptionId: string) => void;
   TEMP_updateExROptionSelection: (uniqueOptionId: string, selection: number) => void;
   updatePresetName: (presetIndex: number, name: string) => void;
+  setPresetDropdownOpen: (isOpen: boolean) => void;
   resetViewer: () => void;
 }
 
@@ -32,6 +34,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (set) =>
     openedExROptionIds: {},
     effectiveSelections: {},
     presetNames: loadPresetNamesFromCookie(),
+    isPresetDropdownOpen: false,
     setSelectedExRTabId: (id: OptionTab) => {
       set({ selectedExRTabId: id });
     },
@@ -45,6 +48,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (set) =>
         openedExRCategoryIds: {},
         openedExROptionIds: {},
         effectiveSelections: {},
+        isPresetDropdownOpen: false,
       });
     },
     toggleExRCategory: (categoryId: number) => {
@@ -88,6 +92,9 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (set) =>
           presetNames: newPresetNames,
         };
       });
+    },
+    setPresetDropdownOpen: (isOpen: boolean) => {
+      set({ isPresetDropdownOpen: isOpen });
     },
   };
 };

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand';
 import type { OptionTab } from '../type';
+import { loadPresetNamesFromCookie, savePresetNamesToCookie } from '../logics/cookieUtils';
 
 /**
  * オプション表示エリア（ExR オプションのタブなど）の状態を管理するスライスのインターフェース
@@ -10,11 +11,13 @@ export interface OptionViewerSlice {
   openedExRCategoryIds: Record<number, boolean>;
   openedExROptionIds: Record<string, boolean>;
   effectiveSelections: Record<string, number>;
+  presetNames: Record<number, string>;
   setSelectedExRTabId: (id: OptionTab) => void;
   setIsTabPending: (isPending: boolean) => void;
   toggleExRCategory: (categoryId: number) => void;
   toggleExROption: (uniqueOptionId: string) => void;
   TEMP_updateExROptionSelection: (uniqueOptionId: string, selection: number) => void;
+  updatePresetName: (presetIndex: number, name: string) => void;
   resetViewer: () => void;
 }
 
@@ -28,6 +31,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (set) =>
     openedExRCategoryIds: {},
     openedExROptionIds: {},
     effectiveSelections: {},
+    presetNames: loadPresetNamesFromCookie(),
     setSelectedExRTabId: (id: OptionTab) => {
       set({ selectedExRTabId: id });
     },
@@ -70,6 +74,18 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (set) =>
             ...state.effectiveSelections,
             [uniqueOptionId]: selection,
           },
+        };
+      });
+    },
+    updatePresetName: (presetIndex: number, name: string) => {
+      set((state) => {
+        const newPresetNames = {
+          ...state.presetNames,
+          [presetIndex]: name,
+        };
+        savePresetNamesToCookie(newPresetNames);
+        return {
+          presetNames: newPresetNames,
         };
       });
     },

--- a/src/type.ts
+++ b/src/type.ts
@@ -205,3 +205,22 @@ export const UpdatedOptionsSchema = z.object({
   UpdatedCategory: ExRCategoryDtoSchema.nullable(),
   ChainUpdatedOption: z.array(ExROptionDtoSchema),
 });
+
+/**
+ * プリセット名管理用のスキーマ
+ * キーが数値（文字列としてシリアライズされる）、値がユーザー入力の文字列
+ */
+export const PresetNamesSchema = z.record(z.string(), z.string()).transform((val) => {
+  const result: Record<number, string> = {};
+  for (const key in val) {
+    if (Object.prototype.hasOwnProperty.call(val, key)) {
+      const numKey = Number(key);
+      if (!isNaN(numKey)) {
+        result[numKey] = val[key];
+      }
+    }
+  }
+  return result;
+});
+
+export type PresetNames = z.infer<typeof PresetNamesSchema>;

--- a/tests/ExROptionEditor.test.tsx
+++ b/tests/ExROptionEditor.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ExROptionEditor } from '../src/feature/ExROptionEditor';
 import type { ExRTabDto } from '../src/type';
+import { useStore } from '../src/useStore';
 
 describe('ExROptionEditor', () => {
   const mockData: ExRTabDto[] = [
@@ -20,6 +21,21 @@ describe('ExROptionEditor', () => {
               Selection: 0,
               Format: '{0}',
               RangeMeta: { Type: 'Int32', Values: [0, 10, 20] },
+              Childs: [],
+            },
+          ],
+        },
+        {
+          Id: 0,
+          Name: 'Preset Category',
+          Options: [
+            {
+              Id: 0,
+              IsActive: true,
+              TranslatedName: '使用するプリセット',
+              Selection: 0,
+              Format: 'Preset',
+              RangeMeta: { Type: 'Int32', Values: [1, 2, 3] },
               Childs: [],
             },
           ],
@@ -69,12 +85,19 @@ describe('ExROptionEditor', () => {
     },
   ];
 
-  it('should only show visible categories (not empty, at least one active option)', () => {
+  beforeEach(() => {
+    useStore.getState().resetViewer();
+  });
+
+  it('should only show visible categories (not empty, at least one active option) and hide preset', () => {
     render(<ExROptionEditor data={mockData} />);
 
     expect(screen.getByText('Category 1')).toBeInTheDocument();
     expect(screen.queryByText('Empty Category')).not.toBeInTheDocument();
     expect(screen.queryByText('Inactive Category')).not.toBeInTheDocument();
+
+    // プリセットカテゴリは非表示になっていることを確認
+    expect(screen.queryByText('Preset Category')).not.toBeInTheDocument();
   });
 
   it('should switch tabs and show correct categories', () => {
@@ -92,10 +115,6 @@ describe('ExROptionEditor', () => {
 
   it('should toggle accordion and show options UI', () => {
     const { unmount } = render(<ExROptionEditor data={mockData} />);
-
-    // Tab 1 を選択状態にする（初期値がずれている可能性があるため）
-    const tab1Button = screen.getByText('Tab 1');
-    fireEvent.click(tab1Button);
 
     const categoryButton = screen.getByText('Category 1');
 

--- a/tests/cookieUtils.test.ts
+++ b/tests/cookieUtils.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { savePresetNamesToCookie, loadPresetNamesFromCookie, getCookie, setCookie } from '../src/logics/cookieUtils';
+
+describe('cookieUtils', () => {
+  beforeEach(() => {
+    // クッキーをクリア
+    document.cookie.split(';').forEach((c) => {
+      document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/');
+    });
+    vi.clearAllMocks();
+  });
+
+  it('should save and load preset names correctly', () => {
+    const names = { 0: 'Default', 5: 'Pro Mode' };
+    savePresetNamesToCookie(names);
+
+    const loaded = loadPresetNamesFromCookie();
+    expect(loaded).toEqual(names);
+  });
+
+  it('should return empty object if cookie is missing', () => {
+    const loaded = loadPresetNamesFromCookie();
+    expect(loaded).toEqual({});
+  });
+
+  it('should handle corrupted cookie data by returning empty object', () => {
+    setCookie('exr_preset_names', 'invalid-json');
+    const loaded = loadPresetNamesFromCookie();
+    expect(loaded).toEqual({});
+  });
+
+  it('should handle schema mismatch by returning empty object', () => {
+    // 値が文字列ではない場合
+    setCookie('exr_preset_names', JSON.stringify({ 0: 123 }));
+    const loaded = loadPresetNamesFromCookie();
+    expect(loaded).toEqual({});
+  });
+
+  it('should handle getCookie correctly', () => {
+    setCookie('test_cookie', 'test_value');
+    expect(getCookie('test_cookie')).toBe('test_value');
+    expect(getCookie('non_existent')).toBeNull();
+  });
+});

--- a/tests/preset-schema.test.ts
+++ b/tests/preset-schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { PresetNamesSchema } from '../src/type';
+
+describe('PresetNamesSchema', () => {
+  it('should validate valid preset names object', () => {
+    const validData = {
+      '0': 'Hardcore',
+      '1': 'Casual',
+    };
+    const result = PresetNamesSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(validData);
+    }
+  });
+
+  it('should reject non-object data', () => {
+    const invalidData = 'not an object';
+    const result = PresetNamesSchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject non-string values', () => {
+    const invalidData = {
+      '0': 123,
+    };
+    const result = PresetNamesSchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
+  });
+
+  it('should allow empty object', () => {
+    const emptyData = {};
+    const result = PresetNamesSchema.safeParse(emptyData);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(emptyData);
+    }
+  });
+});


### PR DESCRIPTION
This change hides the numbered preset option (CategoryId 0, OptionId 0) from the main ExR options list and replaces it with an editable dropdown in the header next to the 'ExR Options' title. Users can now assign custom names to each preset index, which are saved in browser cookies and synchronized with the global state. Choosing a preset in the dropdown correctly updates the underlying option selection via the existing store logic.

---
*PR created automatically by Jules for task [4383733496407876043](https://jules.google.com/task/4383733496407876043) started by @yukieiji*