### PR TITLE
fix: プリセット名が空の場合に初期名に戻すように変更

### DIFF
--- a/e2e/preset_reversion.spec.ts
+++ b/e2e/preset_reversion.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+test('Preset name reversion to default when cleared', async ({ page }) => {
+  test.setTimeout(60000);
+
+  // すべてのテストで API の遅延を設定可能にする
+  await page.addInitScript(() => {
+    // @ts-expect-error - window has no __API_DELAY__ property
+    window.__API_DELAY__ = 100;
+  });
+
+  await page.goto('/');
+
+  // ローディング画面が消えるのを待つ
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 45000 });
+
+  const sidebar = page.getByLabel('オプションサイドバー');
+  await expect(sidebar).toBeVisible({ timeout: 30000 });
+
+  const exrButton = sidebar.getByRole('button', { name: 'ExR Options' });
+  await expect(exrButton).toBeVisible({ timeout: 30000 });
+  await exrButton.click();
+
+  // ヘッダーのプリセットセレクターを確認
+  const presetInput = page.getByPlaceholder('プリセット名を入力...');
+  await expect(presetInput).toBeVisible({ timeout: 15000 });
+
+  // 1. プリセットにカスタム名を付ける
+  await presetInput.fill('Custom Preset');
+  await presetInput.press('Enter');
+  await expect(presetInput).toHaveValue('Custom Preset');
+
+  // 2. 入力欄を空にして確定（Enter）すると初期名に戻るか確認
+  await presetInput.fill('');
+  await presetInput.press('Enter');
+  // 初期値は 1 (index 0) なので "1" に戻るはず
+  await expect(presetInput).toHaveValue('1');
+
+  // 3. 再度カスタム名を付けて、今度は onBlur で戻るか確認
+  await presetInput.fill('Another Name');
+  await presetInput.press('Enter');
+  await expect(presetInput).toHaveValue('Another Name');
+
+  await presetInput.fill('   '); // スペースのみ
+  await presetInput.blur();
+  await expect(presetInput).toHaveValue('1');
+
+  // 4. ページリロード後も初期名（カスタム名なし）が維持されているか確認
+  await page.goto('/');
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 45000 });
+  await expect(sidebar).toBeVisible({ timeout: 30000 });
+  await exrButton.click();
+  await expect(presetInput).toHaveValue('1');
+});

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -83,7 +83,11 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
    */
   const commitNameChange = () => {
     if (inputRef.current) {
-      updatePresetName(currentSelection, inputRef.current.value);
+      const value = inputRef.current.value.trim();
+      updatePresetName(currentSelection, value);
+      if (value === '') {
+        inputRef.current.value = String(currentPresetValue);
+      }
     }
   };
 

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -83,10 +83,13 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (set) =>
     },
     updatePresetName: (presetIndex: number, name: string) => {
       set((state) => {
-        const newPresetNames = {
-          ...state.presetNames,
-          [presetIndex]: name,
-        };
+        const newPresetNames = { ...state.presetNames };
+        const trimmedName = name.trim();
+        if (trimmedName === '') {
+          delete newPresetNames[presetIndex];
+        } else {
+          newPresetNames[presetIndex] = trimmedName;
+        }
         savePresetNamesToCookie(newPresetNames);
         return {
           presetNames: newPresetNames,

--- a/tests/optionViewerSlice.test.ts
+++ b/tests/optionViewerSlice.test.ts
@@ -46,4 +46,17 @@ describe('optionViewerSlice', () => {
     setIsTabPending(false);
     expect(useStore.getState().isTabPending).toBe(false);
   });
+
+  it('should update and delete preset name', () => {
+    const { updatePresetName } = useStore.getState();
+
+    updatePresetName(0, 'Test Preset');
+    expect(useStore.getState().presetNames[0]).toBe('Test Preset');
+
+    updatePresetName(0, '');
+    expect(useStore.getState().presetNames[0]).toBeUndefined();
+
+    updatePresetName(1, '  ');
+    expect(useStore.getState().presetNames[1]).toBeUndefined();
+  });
 });


### PR DESCRIPTION
プリセットの入力欄が空、または空白のみの場合に、自動的に初期の数値名（1, 2など）に戻るように修正しました。

主な変更点：
- `optionViewerSlice.ts`: `updatePresetName` において、名前が空の場合は `presetNames` からそのエントリを削除するように変更。
- `PresetSelector.tsx`: `commitNameChange` 時に値をトリムし、空になった場合はUI上の入力値を即座に初期値にリセットするように変更。
- ユニットテストの追加: `tests/optionViewerSlice.test.ts`
- E2Eテストの追加: `e2e/preset_reversion.spec.ts`

---
*PR created automatically by Jules for task [14552745339292179750](https://jules.google.com/task/14552745339292179750) started by @yukieiji*