### PR TITLE
Implement toggle switch for specific ExR options

### DIFF
--- a/mocks/get/exr/option.json
+++ b/mocks/get/exr/option.json
@@ -39,7 +39,7 @@
             "Format": "{0}",
             "RangeMeta": {
               "Type": "String",
-              "Values": ["無効", "有効"]
+              "Values": ["<color=#FF0000>無効</color>", "<color=#00FF00>有効</color>"]
             },
             "Childs": [
               {

--- a/src/components/parts/OptionToggleControl.tsx
+++ b/src/components/parts/OptionToggleControl.tsx
@@ -1,0 +1,49 @@
+interface OptionToggleControlProps {
+  selection: number;
+  onChange: (selection: number) => void;
+  disabled?: boolean;
+}
+
+/**
+ * 2値（0, 1）のトグルスイッチコンポーネント
+ * Selection が 1 のとき ON、0 のとき OFF
+ */
+export function OptionToggleControl({
+  selection,
+  onChange,
+  disabled = false,
+}: OptionToggleControlProps) {
+  const isChecked = selection === 1;
+
+  const handleToggle = () => {
+    if (disabled) {
+      return;
+    }
+    onChange(isChecked ? 0 : 1);
+  };
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isChecked}
+      disabled={disabled}
+      onClick={handleToggle}
+      className={`
+        relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent
+        transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-gray-900
+        ${isChecked ? 'bg-blue-600' : 'bg-gray-700'}
+        ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+      `}
+    >
+      <span
+        aria-hidden="true"
+        className={`
+          pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0
+          transition duration-200 ease-in-out
+          ${isChecked ? 'translate-x-5' : 'translate-x-0'}
+        `}
+      />
+    </button>
+  );
+}

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -1,7 +1,8 @@
 import { useStore } from '../useStore';
 import { OptionSliderControl } from '../components/parts/OptionSliderControl';
 import { OptionDropdownControl } from '../components/parts/OptionDropdownControl';
-import { getUniqueOptionId } from '../logics/optionUtils';
+import { OptionToggleControl } from '../components/parts/OptionToggleControl';
+import { getUniqueOptionId, isToggleOption } from '../logics/optionUtils';
 import type { ExROptionDto } from '../type';
 
 interface ExROptionControlProps {
@@ -29,6 +30,15 @@ export function ExROptionControl({ categoryId, option }: ExROptionControlProps) 
   const { Type, Values } = option.RangeMeta;
 
   if (Type === 'String') {
+    if (isToggleOption(option)) {
+      return (
+        <OptionToggleControl
+          selection={currentSelection}
+          onChange={handleChange}
+        />
+      );
+    }
+
     return (
       <OptionDropdownControl
         selection={currentSelection}

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -1,3 +1,5 @@
+import type { ExROptionDto } from '../type';
+
 /**
  * カテゴリIDとオプションIDを組み合わせて、アプリケーション内で一意なIDを生成します。
  */
@@ -10,4 +12,30 @@ export function getUniqueOptionId(categoryId: number, optionId: number): string 
  */
 export function isPresetOption(categoryId: number, optionId: number): boolean {
   return categoryId === 0 && optionId === 0;
+}
+
+/**
+ * カラータグ（<color=#RRGGBB>...</color>）が含まれているか判定します。
+ */
+export function hasColorTag(text: string): boolean {
+  return /<color=#[0-9A-F]{6,8}>/i.test(text) && /<\/color>/i.test(text);
+}
+
+/**
+ * オプションがトグルスイッチとして表示されるべきか判定します。
+ * 条件:
+ * 1. Type が "String" である
+ * 2. Values の長さがちょうど 2 である
+ * 3. 両方の値にカラータグが含まれている
+ */
+export function isToggleOption(option: ExROptionDto): boolean {
+  const { Type, Values } = option.RangeMeta;
+
+  if (Type !== 'String' || Values.length !== 2) {
+    return false;
+  }
+
+  return Values.every((value) => {
+    return typeof value === 'string' && hasColorTag(value);
+  });
 }


### PR DESCRIPTION
I have implemented the requested feature where specific ExR options are rendered as toggle switches.

- **Detection Logic**: I added a utility function `isToggleOption` in `src/logics/optionUtils.ts` that identifies if an option should be a toggle based on your criteria (Type: "String", 2 values, both with color tags).
- **Toggle Component**: Created `OptionToggleControl.tsx`, a stateless React component using Tailwind CSS to render a standard toggle switch. It maps `Selection: 1` to the ON state and `Selection: 0` to OFF.
- **Integration**: Updated `ExROptionControl.tsx` to use the new toggle control when the criteria are met, falling back to the existing dropdown otherwise.
- **Verification**: I updated the mock data to include an option with color tags and verified visually using Playwright that it appears correctly as a switch and functions as intended. Unit tests also pass.

---
*PR created automatically by Jules for task [18061057984467238765](https://jules.google.com/task/18061057984467238765) started by @yukieiji*