### PR TITLE
プリセット選択時のフォーカス解除の修正とE2Eテストの追加

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -12,8 +12,11 @@ test('ExR Option Accordion behavior', async ({ page }) => {
   await expect(accordionButton).toBeVisible();
 
   // 初期状態では閉じている
-  const accordionItem = page.locator('div.border.border-gray-700').filter({ hasText: categoryName });
-  const contentContainer = accordionItem.locator('div.grid');
+  const accordionButtonLocator = page.getByRole('button', { name: categoryName });
+  // Accordion component has the structure: div > button, div.grid
+  // Use first() to avoid strict mode violation if there are nested accordions
+  const accordionContainer = page.locator('div.border.border-gray-700').filter({ has: accordionButtonLocator }).first();
+  const contentContainer = accordionContainer.locator('> div.grid');
   await expect(contentContainer).toHaveClass(/grid-rows-\[0fr\]/);
 
   // 閉じているときはオプション名が表示されていない（lazy rendering）

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -3,9 +3,12 @@ import { test, expect } from '@playwright/test';
 test('has sidebar and json viewer', async ({ page }) => {
   await page.goto('/');
 
+  // ローディング画面が消えるのを待つ
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 45000 });
+
   // サイドバーが表示されていることを確認
   const sidebar = page.getByLabel('オプションサイドバー');
-  await expect(sidebar).toBeVisible({ timeout: 10000 });
+  await expect(sidebar).toBeVisible({ timeout: 30000 });
 
   // サイドバー内のボタンを明示的に指定
   await expect(sidebar.getByRole('button', { name: 'Au Options' })).toBeVisible();

--- a/e2e/preset_focus.spec.ts
+++ b/e2e/preset_focus.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+test('Preset input should blur when selecting from dropdown', async ({ page }) => {
+  // タイムアウトを延長
+  test.setTimeout(60000);
+
+  // すべてのテストで API の遅延を設定可能にする（CI 向けに最短に）
+  await page.addInitScript(() => {
+    // @ts-expect-error - window has no __API_DELAY__ property
+    window.__API_DELAY__ = 100;
+  });
+
+  await page.goto('/');
+
+  // ローディング画面が消えるのを待つ
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 45000 });
+
+  const sidebar = page.getByLabel('オプションサイドバー');
+  await expect(sidebar).toBeVisible({ timeout: 30000 });
+
+  const exrButton = sidebar.getByRole('button', { name: 'ExR Options' });
+  await expect(exrButton).toBeVisible({ timeout: 30000 });
+  await exrButton.click();
+
+  // ヘッダーのプリセットセレクターを確認
+  const presetInput = page.getByPlaceholder('プリセット名を入力...');
+  await expect(presetInput).toBeVisible({ timeout: 15000 });
+
+  // 1. 入力欄にフォーカスを当てて、テキストを入力中にする
+  await presetInput.focus();
+  await presetInput.fill('Editing Preset');
+  await expect(presetInput).toBeFocused();
+
+  // 2. ドロップダウンを開く
+  const selectButton = page.getByRole('button', { name: 'プリセットを選択' });
+  await expect(selectButton).toBeVisible();
+  await selectButton.click();
+
+  // 3. 別のプリセットを選択する
+  // 現在は「1」が選択されているはずなので、「2」を選択
+  const dropdown = page.locator('div.absolute.top-full');
+  await expect(dropdown).toBeVisible();
+  const preset2Button = dropdown.getByRole('button', { name: '2', exact: true });
+  await expect(preset2Button).toBeVisible();
+
+  await preset2Button.click();
+
+  // 4. 入力欄のフォーカスが外れていることを確認する
+  // バグが発生している場合は、ここでフォーカスが残ったままになり、テストが失敗することを期待する
+  await expect(presetInput).not.toBeFocused();
+
+  // ついでに、値が切り替わっていることも確認
+  await expect(presetInput).toHaveValue('2');
+});

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -74,6 +74,8 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
   const currentPresetName = presetNames[currentSelection] ?? String(currentPresetValue);
 
   const handlePresetSelect = (index: number) => {
+    // Explicitly blur the input when selecting from dropdown to fix the caret issue
+    inputRef.current?.blur();
     TEMP_updateExROptionSelection(uniqueId, index);
     setPresetDropdownOpen(false);
   };


### PR DESCRIPTION
プリセット入力中にドロップダウンリストから別の項目を選択した際に、入力欄のフォーカスが外れずキャレットが残ってしまう問題を修正しました。

修正内容：
- `src/feature/PresetSelector.tsx` の `handlePresetSelect` 関数内で、明示的に `inputRef.current?.blur()` を呼び出すように変更しました。
- この修正により、項目選択時にフォーカスが解除され、キャレットが表示されたままになる現象が解消されます。

テスト内容：
- 新しく `e2e/preset_focus.spec.ts` を追加しました。
- このテストでは、入力欄にフォーカスを当てた状態でドロップダウンから別のプリセットを選択し、その後入力欄のフォーカスが外れていることを検証します。
- 全ての既存のユニットテストおよび新しく追加した E2E テストがパスすることを確認済みです。

---
*PR created automatically by Jules for task [8276527155995294054](https://jules.google.com/task/8276527155995294054) started by @yukieiji*