### PR TITLE
Group Min/Max Options into Dual Sliders

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -13,7 +13,7 @@ test('ExR Option Accordion behavior', async ({ page }) => {
 
   // 初期状態では閉じている
   const accordionItem = page.locator('div.border.border-gray-700').filter({ hasText: categoryName });
-  const contentContainer = accordionItem.locator('div.grid');
+  const contentContainer = accordionItem.locator('div.grid').first();
   await expect(contentContainer).toHaveClass(/grid-rows-\[0fr\]/);
 
   // 閉じているときはオプション名が表示されていない（lazy rendering）

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -41,7 +41,7 @@ function CategoryAccordion({ category }: CategoryAccordionProps) {
       }}
     >
       <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-        {groupOptions(filteredOptions).map((group, index) => {
+        {groupOptions(filteredOptions).map((group) => {
           if (group.type === 'min-max') {
             return (
               <ExRMinMaxOptionRow

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -2,7 +2,8 @@ import { useStore } from '../useStore';
 import { Accordion } from '../components/parts/Accordion';
 import { ColoredText } from '../components/parts/ColoredText';
 import { ExROptionItem } from './ExROptionItem';
-import { isPresetOption } from '../logics/optionUtils';
+import { ExRMinMaxOptionRow } from './ExRMinMaxOptionRow';
+import { isPresetOption, groupOptions } from '../logics/optionUtils';
 import type { ExRCategoryDto, ExRTabDto } from '../type';
 
 interface CategoryAccordionProps {
@@ -40,9 +41,22 @@ function CategoryAccordion({ category }: CategoryAccordionProps) {
       }}
     >
       <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-        {filteredOptions.map((option) => {
+        {groupOptions(filteredOptions).map((group, index) => {
+          if (group.type === 'min-max') {
+            return (
+              <ExRMinMaxOptionRow
+                key={`${group.minOption.Id}-${group.maxOption.Id}`}
+                categoryId={category.Id}
+                baseName={group.baseName}
+                minOption={group.minOption}
+                minSuffix={group.minSuffix}
+                maxOption={group.maxOption}
+                maxSuffix={group.maxSuffix}
+              />
+            );
+          }
           return (
-            <ExROptionItem key={option.Id} categoryId={category.Id} option={option} />
+            <ExROptionItem key={group.option.Id} categoryId={category.Id} option={group.option} />
           );
         })}
       </div>

--- a/src/feature/ExRMinMaxOptionControl.tsx
+++ b/src/feature/ExRMinMaxOptionControl.tsx
@@ -1,0 +1,71 @@
+import { useStore } from '../useStore';
+import { OptionSliderControl } from '../components/parts/OptionSliderControl';
+import { getUniqueOptionId } from '../logics/optionUtils';
+import type { ExROptionDto } from '../type';
+
+interface ExRMinMaxOptionControlProps {
+  categoryId: number;
+  option: ExROptionDto;
+  type: 'min' | 'max';
+  suffix: string;
+  otherOption: ExROptionDto;
+}
+
+/**
+ * 最小・最大オプション専用のコントロール
+ */
+export function ExRMinMaxOptionControl({
+  categoryId,
+  option,
+  type,
+  suffix,
+  otherOption,
+}: ExRMinMaxOptionControlProps) {
+  const uniqueId = getUniqueOptionId(categoryId, option.Id);
+  const otherUniqueId = getUniqueOptionId(categoryId, otherOption.Id);
+
+  const effectiveSelection = useStore((state) => {
+    return state.effectiveSelections[uniqueId];
+  });
+  const otherEffectiveSelection = useStore((state) => {
+    return state.effectiveSelections[otherUniqueId];
+  });
+
+  const currentSelection = effectiveSelection ?? option.Selection;
+  const otherCurrentSelection = otherEffectiveSelection ?? otherOption.Selection;
+
+  const TEMP_updateMultipleExROptionSelections = useStore((state) => {
+    return state.TEMP_updateMultipleExROptionSelections;
+  });
+
+  const handleChange = (newSelection: number) => {
+    const updates: Record<string, number> = {
+      [uniqueId]: newSelection,
+    };
+
+    // バリデーション: 最小 > 最大 の場合、もう一方も調整する
+    if (type === 'min') {
+      if (newSelection > otherCurrentSelection) {
+        updates[otherUniqueId] = newSelection;
+      }
+    } else {
+      if (newSelection < otherCurrentSelection) {
+        updates[otherUniqueId] = newSelection;
+      }
+    }
+
+    TEMP_updateMultipleExROptionSelections(updates);
+  };
+
+  return (
+    <div className="flex flex-col gap-1 w-full max-w-[12rem]">
+      <span className="text-[10px] text-gray-400 font-bold ml-1">{suffix}</span>
+      <OptionSliderControl
+        selection={currentSelection}
+        values={option.RangeMeta.Values as number[]}
+        format={option.Format}
+        onChange={handleChange}
+      />
+    </div>
+  );
+}

--- a/src/feature/ExRMinMaxOptionRow.tsx
+++ b/src/feature/ExRMinMaxOptionRow.tsx
@@ -1,0 +1,62 @@
+import { OptionItem } from '../components/parts/OptionItem';
+import { OptionNameDisplay } from '../components/parts/OptionNameDisplay';
+import { OptionRowContainer } from '../components/blocks/OptionRowContainer';
+import { ExRMinMaxOptionControl } from './ExRMinMaxOptionControl';
+import type { ExROptionDto } from '../type';
+
+interface ExRMinMaxOptionRowProps {
+  categoryId: number;
+  baseName: string;
+  minOption: ExROptionDto;
+  minSuffix: string;
+  maxOption: ExROptionDto;
+  maxSuffix: string;
+  depth?: number;
+}
+
+/**
+ * 最小と最大のオプションを1行にまとめて表示するコンポーネント
+ */
+export function ExRMinMaxOptionRow({
+  categoryId,
+  baseName,
+  minOption,
+  minSuffix,
+  maxOption,
+  maxSuffix,
+  depth = 0,
+}: ExRMinMaxOptionRowProps) {
+  const content = (
+    <OptionItem className="min-h-[4rem] py-2">
+      <div className="flex-1 min-w-0 mr-4">
+        <span className="text-sm font-medium text-gray-200 break-words">
+          <OptionNameDisplay name={baseName} />
+        </span>
+      </div>
+      <div className="flex-shrink-0 flex items-center gap-4">
+        <ExRMinMaxOptionControl
+          categoryId={categoryId}
+          option={minOption}
+          type="min"
+          suffix={minSuffix}
+          otherOption={maxOption}
+        />
+        <ExRMinMaxOptionControl
+          categoryId={categoryId}
+          option={maxOption}
+          type="max"
+          suffix={maxSuffix}
+          otherOption={minOption}
+        />
+      </div>
+    </OptionItem>
+  );
+
+  return (
+    <OptionRowContainer
+      leading={<span className="text-gray-500 select-none text-xs">・</span>}
+      content={content}
+      className={depth > 0 ? 'border-l-2 border-blue-500/30 ml-4' : ''}
+    />
+  );
+}

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -17,20 +17,20 @@ import type { ExROptionDto } from '../type';
 export type MinMaxType = 'min' | 'max';
 
 const MIN_PATTERNS = [
-  /[ 　]最小$/,
-  /[ 　]最少$/,
-  /[ 　]最小值$/,
-  /[ 　]最小値$/,
-  /[ 　]Min$/,
-  /[ 　]Minimum$/,
+  /[ \u3000]最小$/,
+  /[ \u3000]最少$/,
+  /[ \u3000]最小值$/,
+  /[ \u3000]最小値$/,
+  /[ \u3000]Min$/,
+  /[ \u3000]Minimum$/,
 ];
 const MAX_PATTERNS = [
-  /[ 　]最大$/,
-  /[ 　]最多$/,
-  /[ 　]最大值$/,
-  /[ 　]最大値$/,
-  /[ 　]Max$/,
-  /[ 　]Maximum$/,
+  /[ \u3000]最大$/,
+  /[ \u3000]最多$/,
+  /[ \u3000]最大值$/,
+  /[ \u3000]最大値$/,
+  /[ \u3000]Max$/,
+  /[ \u3000]Maximum$/,
 ];
 
 /**

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -11,3 +11,104 @@ export function getUniqueOptionId(categoryId: number, optionId: number): string 
 export function isPresetOption(categoryId: number, optionId: number): boolean {
   return categoryId === 0 && optionId === 0;
 }
+
+import type { ExROptionDto } from '../type';
+
+export type MinMaxType = 'min' | 'max';
+
+const MIN_PATTERNS = [
+  /[ 　]最小$/,
+  /[ 　]最少$/,
+  /[ 　]最小值$/,
+  /[ 　]最小値$/,
+  /[ 　]Min$/,
+  /[ 　]Minimum$/,
+];
+const MAX_PATTERNS = [
+  /[ 　]最大$/,
+  /[ 　]最多$/,
+  /[ 　]最大值$/,
+  /[ 　]最大値$/,
+  /[ 　]Max$/,
+  /[ 　]Maximum$/,
+];
+
+/**
+ * オプション名から接尾辞（最小/最大など）を除去したベース名と種類、および除去された接尾辞を取得します。
+ */
+export function getBaseNameAndType(
+  name: string
+): { baseName: string; type: MinMaxType; suffix: string } | null {
+  for (const pattern of MIN_PATTERNS) {
+    const match = name.match(pattern);
+    if (match) {
+      return {
+        baseName: name.replace(pattern, '').trim(),
+        type: 'min',
+        suffix: match[0].trim(),
+      };
+    }
+  }
+  for (const pattern of MAX_PATTERNS) {
+    const match = name.match(pattern);
+    if (match) {
+      return {
+        baseName: name.replace(pattern, '').trim(),
+        type: 'max',
+        suffix: match[0].trim(),
+      };
+    }
+  }
+  return null;
+}
+
+export type OptionGroup =
+  | {
+      type: 'single';
+      option: ExROptionDto;
+    }
+  | {
+      type: 'min-max';
+      baseName: string;
+      minOption: ExROptionDto;
+      minSuffix: string;
+      maxOption: ExROptionDto;
+      maxSuffix: string;
+    };
+
+/**
+ * オプションのリストを走査し、連続する「最小」と「最大」のペアをグループ化します。
+ */
+export function groupOptions(options: ExROptionDto[]): OptionGroup[] {
+  const groups: OptionGroup[] = [];
+  for (let i = 0; i < options.length; i++) {
+    const current = options[i];
+    const next = options[i + 1];
+
+    if (next && current.IsActive && next.IsActive) {
+      const currentInfo = getBaseNameAndType(current.TranslatedName);
+      const nextInfo = getBaseNameAndType(next.TranslatedName);
+
+      if (currentInfo && nextInfo && currentInfo.baseName === nextInfo.baseName) {
+        if (currentInfo.type === 'min' && nextInfo.type === 'max') {
+          groups.push({
+            type: 'min-max',
+            baseName: currentInfo.baseName,
+            minOption: current,
+            minSuffix: currentInfo.suffix,
+            maxOption: next,
+            maxSuffix: nextInfo.suffix,
+          });
+          i++; // 次の要素をスキップ
+          continue;
+        }
+      }
+    }
+
+    groups.push({
+      type: 'single',
+      option: current,
+    });
+  }
+  return groups;
+}

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -18,6 +18,7 @@ export interface OptionViewerSlice {
   toggleExRCategory: (categoryId: number) => void;
   toggleExROption: (uniqueOptionId: string) => void;
   TEMP_updateExROptionSelection: (uniqueOptionId: string, selection: number) => void;
+  TEMP_updateMultipleExROptionSelections: (updates: Record<string, number>) => void;
   updatePresetName: (presetIndex: number, name: string) => void;
   setPresetDropdownOpen: (isOpen: boolean) => void;
   resetViewer: () => void;
@@ -57,6 +58,16 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (set) =>
           openedExRCategoryIds: {
             ...state.openedExRCategoryIds,
             [categoryId]: !state.openedExRCategoryIds[categoryId],
+          },
+        };
+      });
+    },
+    TEMP_updateMultipleExROptionSelections: (updates: Record<string, number>) => {
+      set((state) => {
+        return {
+          effectiveSelections: {
+            ...state.effectiveSelections,
+            ...updates,
           },
         };
       });


### PR DESCRIPTION
This change introduces a more compact and intuitive UI for setting ranges by grouping "Minimum" and "Maximum" options into a single row.

Key features:
- **Generic Grouping Logic**: Automatically detects pairs like "Role Count Min" and "Role Count Max" across multiple languages (Japanese, Chinese, English).
- **Synchronized Sliders**: Provides two sliders in one row, where increasing the "Minimum" value beyond the "Maximum" automatically pushes the "Maximum" value up.
- **Improved UI Layout**: Reduces vertical scrolling in categories with many range settings, such as 'Spawn Count' and 'Ghost Role Count'.
- **Language Preservation**: Labels for the sliders ("Min", "Max", etc.) are derived from the original DTO text to ensure multi-language support.

---
*PR created automatically by Jules for task [7323631744868604886](https://jules.google.com/task/7323631744868604886) started by @yukieiji*