### PR TITLE
E2Eテストの修正と安定化

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-test('ExR Option Accordion behavior', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
+  // すべてのテストで API の遅延を設定可能にする
   await page.addInitScript(() => {
     // @ts-expect-error - window has no __API_DELAY__ property
     window.__API_DELAY__ = 100;
@@ -10,7 +11,9 @@ test('ExR Option Accordion behavior', async ({ page }) => {
 
   // ローディング画面が消えるのを待つ
   await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 30000 });
+});
 
+test('ExR Option Accordion behavior', async ({ page }) => {
   const sidebar = page.getByLabel('オプションサイドバー');
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();
 

--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -1,7 +1,15 @@
 import { test, expect } from '@playwright/test';
 
 test('ExR Option Accordion behavior', async ({ page }) => {
+  await page.addInitScript(() => {
+    // @ts-expect-error - window has no __API_DELAY__ property
+    window.__API_DELAY__ = 100;
+  });
+
   await page.goto('/');
+
+  // ローディング画面が消えるのを待つ
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 30000 });
 
   const sidebar = page.getByLabel('オプションサイドバー');
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();
@@ -13,7 +21,7 @@ test('ExR Option Accordion behavior', async ({ page }) => {
 
   // 初期状態では閉じている
   const accordionItem = page.locator('div.border.border-gray-700').filter({ hasText: categoryName });
-  const contentContainer = accordionItem.locator('div.grid');
+  const contentContainer = accordionItem.getByTestId('accordion-content');
   await expect(contentContainer).toHaveClass(/grid-rows-\[0fr\]/);
 
   // 閉じているときはオプション名が表示されていない（lazy rendering）

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,11 +1,20 @@
 import { test, expect } from '@playwright/test';
 
 test('has sidebar and json viewer', async ({ page }) => {
+  // デフォルトで API 遅延がある可能性があるため、明示的に設定
+  await page.addInitScript(() => {
+    // @ts-expect-error - window has no __API_DELAY__ property
+    window.__API_DELAY__ = 100;
+  });
+
   await page.goto('/');
+
+  // ローディング画面が消えるのを待つ
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 30000 });
 
   // サイドバーが表示されていることを確認
   const sidebar = page.getByLabel('オプションサイドバー');
-  await expect(sidebar).toBeVisible({ timeout: 10000 });
+  await expect(sidebar).toBeVisible({ timeout: 15000 });
 
   // サイドバー内のボタンを明示的に指定
   await expect(sidebar.getByRole('button', { name: 'Au Options' })).toBeVisible();
@@ -24,8 +33,8 @@ test('has sidebar and json viewer', async ({ page }) => {
 
   // サイドバーの開閉
   await page.getByRole('button', { name: 'サイドバーを閉じる' }).click();
-  await expect(sidebar.getByRole('navigation')).not.toBeVisible();
+  await expect(sidebar.getByRole('navigation')).not.toBeAttached({ timeout: 10000 });
 
   await page.getByRole('button', { name: 'サイドバーを開く' }).click();
-  await expect(sidebar.getByRole('navigation')).toBeVisible();
+  await expect(sidebar.getByRole('navigation')).toBeVisible({ timeout: 10000 });
 });

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-test('has sidebar and json viewer', async ({ page }) => {
-  // デフォルトで API 遅延がある可能性があるため、明示的に設定
+test.beforeEach(async ({ page }) => {
+  // すべてのテストで API の遅延を設定可能にする
   await page.addInitScript(() => {
     // @ts-expect-error - window has no __API_DELAY__ property
     window.__API_DELAY__ = 100;
@@ -11,7 +11,9 @@ test('has sidebar and json viewer', async ({ page }) => {
 
   // ローディング画面が消えるのを待つ
   await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 30000 });
+});
 
+test('has sidebar and json viewer', async ({ page }) => {
   // サイドバーが表示されていることを確認
   const sidebar = page.getByLabel('オプションサイドバー');
   await expect(sidebar).toBeVisible({ timeout: 15000 });

--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -1,10 +1,18 @@
 import { test, expect } from '@playwright/test';
 
 test('Options interaction behavior', async ({ page }) => {
+  await page.addInitScript(() => {
+    // @ts-expect-error - window has no __API_DELAY__ property
+    window.__API_DELAY__ = 100;
+  });
+
   await page.goto('/');
 
+  // ローディング画面が消えるのを待つ
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 30000 });
+
   const sidebar = page.getByLabel('オプションサイドバー');
-  await expect(sidebar).toBeVisible({ timeout: 10000 });
+  await expect(sidebar.getByRole('navigation')).toBeVisible({ timeout: 10000 });
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();
 
   // ヘッダーのプリセットセレクターを確認

--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-test('Options interaction behavior', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
+  // すべてのテストで API の遅延を設定可能にする
   await page.addInitScript(() => {
     // @ts-expect-error - window has no __API_DELAY__ property
     window.__API_DELAY__ = 100;
@@ -10,9 +11,11 @@ test('Options interaction behavior', async ({ page }) => {
 
   // ローディング画面が消えるのを待つ
   await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 30000 });
+});
 
+test('Options interaction behavior', async ({ page }) => {
   const sidebar = page.getByLabel('オプションサイドバー');
-  await expect(sidebar.getByRole('navigation')).toBeVisible({ timeout: 10000 });
+  await expect(sidebar.getByRole('navigation')).toBeVisible({ timeout: 20000 });
   await sidebar.getByRole('button', { name: 'ExR Options' }).click();
 
   // ヘッダーのプリセットセレクターを確認

--- a/e2e/preset_naming.spec.ts
+++ b/e2e/preset_naming.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '@playwright/test';
 
-test('Preset naming and persistence behavior', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   // タイムアウトを延長
   test.setTimeout(60000);
 
-  // すべてのテストで API の遅延を設定可能にする（CI 向けに最短に）
+  // すべてのテストで API の遅延を設定可能にする
   await page.addInitScript(() => {
     // @ts-expect-error - window has no __API_DELAY__ property
     window.__API_DELAY__ = 100;
@@ -14,7 +14,9 @@ test('Preset naming and persistence behavior', async ({ page }) => {
 
   // ローディング画面が消えるのを待つ
   await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 45000 });
+});
 
+test('Preset naming and persistence behavior', async ({ page }) => {
   const sidebar = page.getByLabel('オプションサイドバー');
   await expect(sidebar).toBeVisible({ timeout: 30000 });
 

--- a/e2e/preset_reversion.spec.ts
+++ b/e2e/preset_reversion.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('Preset name reversion to default when cleared', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   test.setTimeout(60000);
 
   // すべてのテストで API の遅延を設定可能にする
@@ -13,7 +13,9 @@ test('Preset name reversion to default when cleared', async ({ page }) => {
 
   // ローディング画面が消えるのを待つ
   await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 45000 });
+});
 
+test('Preset name reversion to default when cleared', async ({ page }) => {
   const sidebar = page.getByLabel('オプションサイドバー');
   await expect(sidebar).toBeVisible({ timeout: 30000 });
 

--- a/src/components/blocks/OptionAccordion.tsx
+++ b/src/components/blocks/OptionAccordion.tsx
@@ -53,6 +53,7 @@ export function OptionAccordion({
 
       {/* 子要素（ネストされたオプション） */}
       <div
+        data-testid="option-accordion-content"
         className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
           isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
         }`}

--- a/src/components/parts/Accordion.tsx
+++ b/src/components/parts/Accordion.tsx
@@ -30,6 +30,7 @@ export function Accordion({ title, isOpen, onToggle, children }: AccordionProps)
         <span className="font-semibold text-gray-200">{title}</span>
       </button>
       <div
+        data-testid="accordion-content"
         className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
           isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
         }`}


### PR DESCRIPTION
E2Eテスト（Playwright）が複数のブラウザで失敗していた問題を修正しました。主な原因は、データの読み込み待ちが不足していたこと、およびネストされたアコーディオン構造により要素の特定が曖昧になっていたことです。

修正内容：
1. **コンポーネントの改善**: `Accordion` と `OptionAccordion` に `data-testid` を付与し、テストから一意に特定できるようにしました。
2. **テストの安定化**:
   - `page.goto('/')` の直後に "Loading data..." が消えるまで待機する処理を追加しました。
   - `addInitScript` を用いて `window.__API_DELAY__` を設定し、モックAPIの応答速度をテストに適した値に固定しました。
   - WebKit等で発生していたサイドバーの可視性判定の不一致を、ARIAロールや `toBeAttached` を併用することで解消しました。
3. **カバレッジ**: `app.spec.ts`, `accordion.spec.ts`, `options_interaction.spec.ts` のすべてにおいて、Chromium, Firefox, WebKit でのパスを確認済みです。

---
*PR created automatically by Jules for task [17581992935662565053](https://jules.google.com/task/17581992935662565053) started by @yukieiji*