### PR TITLE
プリセット選択時のフォーカス管理の修正

### DIFF
--- a/e2e/preset_focus.spec.ts
+++ b/e2e/preset_focus.spec.ts
@@ -35,7 +35,8 @@ test('Preset input should lose focus when interacting with dropdown', async ({ p
   const preset1Button = page.getByRole('button', { name: '1', exact: true });
   await preset1Button.click();
 
-  // 項目選択後もフォーカスが外れていることを期待
+  // 項目選択後、少し待機してフォーカスを確認
+  await page.waitForTimeout(500);
   await expect(presetInput).not.toBeFocused();
 
   // 4. 再び開いて別の項目を選択
@@ -43,8 +44,8 @@ test('Preset input should lose focus when interacting with dropdown', async ({ p
   const preset2Button = page.getByRole('button', { name: '2', exact: true });
   await preset2Button.click();
 
-  // 別の項目選択後もフォーカスが外れていることを期待
-  // 新しい入力要素がマウントされるため、再度取得する
+  // 別の項目選択後
+  await page.waitForTimeout(500);
   const newPresetInput = page.getByPlaceholder('プリセット名を入力...');
   await expect(newPresetInput).toHaveValue('2');
   await expect(newPresetInput).not.toBeFocused();

--- a/e2e/preset_focus.spec.ts
+++ b/e2e/preset_focus.spec.ts
@@ -16,38 +16,36 @@ test('Preset input should lose focus when interacting with dropdown', async ({ p
   const presetInput = page.getByPlaceholder('プリセット名を入力...');
   await expect(presetInput).toBeVisible();
 
-  const checkFocus = async (label: string) => {
-    const isInputFocused = await page.evaluate(() => document.activeElement?.tagName === 'INPUT');
-    console.log(`Is some input focused [${label}]:`, isInputFocused);
-    return isInputFocused;
-  };
-
   // 1. フォーカスを当てる
   await presetInput.click();
   await expect(presetInput).toBeFocused();
 
   // 2. ドロップダウンボタンをクリックして開く
   const selectButton = page.getByRole('button', { name: 'プリセットを選択' });
-  await selectButton.dispatchEvent('click');
+  await selectButton.click();
+
+  // ドロップダウンが開いていることを確認
   await expect(page.getByRole('button', { name: '2', exact: true })).toBeVisible();
 
-  const focusedAfterOpen = await checkFocus('after opening');
+  // フォーカスが外れていることを期待
+  await expect(presetInput).not.toBeFocused();
 
   // 3. 同じ項目を選択する
   // 初期状態は 1 (index 0) なので、ボタン "1" をクリック
   const preset1Button = page.getByRole('button', { name: '1', exact: true });
-  await preset1Button.dispatchEvent('click');
+  await preset1Button.click();
 
-  const focusedAfterSelectSame = await checkFocus('after selecting same');
+  // 項目選択後もフォーカスが外れていることを期待
+  await expect(presetInput).not.toBeFocused();
 
   // 4. 再び開いて別の項目を選択
-  await selectButton.dispatchEvent('click');
+  await selectButton.click();
   const preset2Button = page.getByRole('button', { name: '2', exact: true });
-  await preset2Button.dispatchEvent('click');
+  await preset2Button.click();
 
-  const focusedAfterSelectDifferent = await checkFocus('after selecting different');
-
-  expect(focusedAfterOpen).toBe(false);
-  expect(focusedAfterSelectSame).toBe(false);
-  expect(focusedAfterSelectDifferent).toBe(false);
+  // 別の項目選択後もフォーカスが外れていることを期待
+  // 新しい入力要素がマウントされるため、再度取得する
+  const newPresetInput = page.getByPlaceholder('プリセット名を入力...');
+  await expect(newPresetInput).toHaveValue('2');
+  await expect(newPresetInput).not.toBeFocused();
 });

--- a/e2e/preset_focus.spec.ts
+++ b/e2e/preset_focus.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 45000 });
+});
+
+test('Preset input should lose focus when interacting with dropdown', async ({ page }) => {
+  const sidebar = page.getByLabel('オプションサイドバー');
+  await expect(sidebar).toBeVisible({ timeout: 30000 });
+
+  const exrButton = sidebar.getByRole('button', { name: 'ExR Options' });
+  await expect(exrButton).toBeVisible({ timeout: 30000 });
+  await exrButton.click();
+
+  const presetInput = page.getByPlaceholder('プリセット名を入力...');
+  await expect(presetInput).toBeVisible();
+
+  const checkFocus = async (label: string) => {
+    const isInputFocused = await page.evaluate(() => document.activeElement?.tagName === 'INPUT');
+    console.log(`Is some input focused [${label}]:`, isInputFocused);
+    return isInputFocused;
+  };
+
+  // 1. フォーカスを当てる
+  await presetInput.click();
+  await expect(presetInput).toBeFocused();
+
+  // 2. ドロップダウンボタンをクリックして開く
+  const selectButton = page.getByRole('button', { name: 'プリセットを選択' });
+  await selectButton.dispatchEvent('click');
+  await expect(page.getByRole('button', { name: '2', exact: true })).toBeVisible();
+
+  const focusedAfterOpen = await checkFocus('after opening');
+
+  // 3. 同じ項目を選択する
+  // 初期状態は 1 (index 0) なので、ボタン "1" をクリック
+  const preset1Button = page.getByRole('button', { name: '1', exact: true });
+  await preset1Button.dispatchEvent('click');
+
+  const focusedAfterSelectSame = await checkFocus('after selecting same');
+
+  // 4. 再び開いて別の項目を選択
+  await selectButton.dispatchEvent('click');
+  const preset2Button = page.getByRole('button', { name: '2', exact: true });
+  await preset2Button.dispatchEvent('click');
+
+  const focusedAfterSelectDifferent = await checkFocus('after selecting different');
+
+  expect(focusedAfterOpen).toBe(false);
+  expect(focusedAfterSelectSame).toBe(false);
+  expect(focusedAfterSelectDifferent).toBe(false);
+});

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -76,6 +76,7 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
   const handlePresetSelect = (index: number) => {
     TEMP_updateExROptionSelection(uniqueId, index);
     setPresetDropdownOpen(false);
+    inputRef.current?.blur();
   };
 
   /**
@@ -105,6 +106,9 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 
   const toggleDropdown = () => {
     setPresetDropdownOpen(!isDropdownOpen);
+    if (!isDropdownOpen) {
+      inputRef.current?.blur();
+    }
   };
 
   return (

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -76,7 +76,10 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
   const handlePresetSelect = (index: number) => {
     TEMP_updateExROptionSelection(uniqueId, index);
     setPresetDropdownOpen(false);
-    inputRef.current?.blur();
+    // 状態更新後に確実にフォーカスを外すため、次のフレームで実行する
+    requestAnimationFrame(() => {
+      inputRef.current?.blur();
+    });
   };
 
   /**
@@ -106,9 +109,10 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 
   const toggleDropdown = () => {
     setPresetDropdownOpen(!isDropdownOpen);
-    if (!isDropdownOpen) {
+    // 状態更新後に確実にフォーカスを外すため、次のフレームで実行する
+    requestAnimationFrame(() => {
       inputRef.current?.blur();
-    }
+    });
   };
 
   return (


### PR DESCRIPTION
プリセット入力中にドロップダウンを開いたり項目を選択したりした際、入力欄からフォーカスが外れずキャレットが残ってしまう問題を修正しました。
`PresetSelector` コンポーネントにおいて、ドロップダウンのトグル時および項目選択時に明示的に `inputRef.current?.blur()` を呼び出すように変更しています。
また、この挙動を検証するための E2E テストを追加しました。

---
*PR created automatically by Jules for task [1533496978070416704](https://jules.google.com/task/1533496978070416704) started by @yukieiji*