### PR TITLE
Move Spawn Rate and Spawn Count to ExR Role Category Headers

### DIFF
--- a/e2e/exr_role_spawn_options.spec.ts
+++ b/e2e/exr_role_spawn_options.spec.ts
@@ -16,53 +16,55 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('ExR Role Spawn Options in Header', () => {
+  const SHERIFF_ID = '270';
+
   test('should display spawn rate in category header of role tabs', async ({ page }) => {
     // 役職タブ（クルーメイト）に切り替え
     await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
 
-    // カテゴリ（例：シェリフ）のヘッダーに「レート」が表示されていることを確認
-    const sheriffCategory = page.locator('.border-gray-700.rounded-lg').filter({ hasText: 'シェリフ' }).first();
-    await expect(sheriffCategory.getByText('レート')).toBeVisible();
+    // カテゴリ（シェリフ）のヘッダーに「レート」が表示されていることを確認
+    const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+    await expect(sheriffCategory.getByTestId('spawn-rate-control')).toBeVisible();
   });
 
   test('should show spawn count only when spawn rate is 1 or more', async ({ page }) => {
     await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
 
-    const sheriffCategory = page.locator('.border-gray-700.rounded-lg').filter({ hasText: 'シェリフ' }).first();
+    const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
 
     // 初期状態（レート 0）では「数」は表示されていないはず
-    await expect(sheriffCategory.getByText('数')).not.toBeVisible();
+    await expect(sheriffCategory.getByTestId('spawn-count-control')).not.toBeVisible();
 
     // レートのスライダーを操作して 1 以上にする
-    const rateSlider = sheriffCategory.locator('input[type="range"]').first();
+    const rateSlider = sheriffCategory.getByTestId('spawn-rate-control').locator('input[type="range"]');
     await rateSlider.fill('10');
 
     // 「数」が表示されることを確認
-    await expect(sheriffCategory.getByText('数')).toBeVisible();
+    await expect(sheriffCategory.getByTestId('spawn-count-control')).toBeVisible();
 
     // レートを 0 に戻すと「数」が消えることを確認
     await rateSlider.fill('0');
-    await expect(sheriffCategory.getByText('数')).not.toBeVisible();
+    await expect(sheriffCategory.getByTestId('spawn-count-control')).not.toBeVisible();
   });
 
   test('interacting with header controls should not toggle accordion', async ({ page }) => {
     await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
 
-    const sheriffCategory = page.locator('.border-gray-700.rounded-lg').filter({ hasText: 'シェリフ' }).first();
-    const content = sheriffCategory.locator('.bg-gray-900'); // RoleCategoryItem の中身
+    const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+    const content = sheriffCategory.locator('.bg-gray-900'); // Body area
 
     // 最初は閉じている
     await expect(content).not.toBeVisible();
 
     // レートのスライダーを操作
-    const rateSlider = sheriffCategory.locator('input[type="range"]').first();
+    const rateSlider = sheriffCategory.getByTestId('spawn-rate-control').locator('input[type="range"]');
     await rateSlider.fill('10');
 
     // まだ閉じているはず（stopPropagationが効いている）
     await expect(content).not.toBeVisible();
 
     // 数が表示されたのでそちらも操作してみる
-    const countSlider = sheriffCategory.locator('input[type="range"]').nth(1);
+    const countSlider = sheriffCategory.getByTestId('spawn-count-control').locator('input[type="range"]');
     await countSlider.fill('2');
 
     // まだ閉じているはず
@@ -76,7 +78,7 @@ test.describe('ExR Role Spawn Options in Header', () => {
   test('spawn rate and count should be filtered out from accordion body', async ({ page }) => {
     await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
 
-    const sheriffCategory = page.locator('.border-gray-700.rounded-lg').filter({ hasText: 'シェリフ' }).first();
+    const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
 
     // アコーディオンを開く
     await sheriffCategory.getByRole('button', { name: 'シェリフ' }).click();

--- a/e2e/exr_role_spawn_options.spec.ts
+++ b/e2e/exr_role_spawn_options.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  // API遅延を最小限にしてテストを高速化
+  await page.addInitScript(() => {
+    // @ts-expect-error - window has no __API_DELAY__ property
+    window.__API_DELAY__ = 0;
+  });
+  await page.goto('/');
+  // ローディング画面が消えるのを待つ
+  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 30000 });
+
+  // ExR Options タブに切り替え
+  await page.getByRole('button', { name: 'ExR Options' }).click();
+  await page.waitForSelector('[data-testid="exr-category-list"]');
+});
+
+test.describe('ExR Role Spawn Options in Header', () => {
+  test('should display spawn rate in category header of role tabs', async ({ page }) => {
+    // 役職タブ（クルーメイト）に切り替え
+    await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
+
+    // カテゴリ（例：シェリフ）のヘッダーに「レート」が表示されていることを確認
+    const sheriffCategory = page.locator('.border-gray-700.rounded-lg').filter({ hasText: 'シェリフ' }).first();
+    await expect(sheriffCategory.getByText('レート')).toBeVisible();
+  });
+
+  test('should show spawn count only when spawn rate is 1 or more', async ({ page }) => {
+    await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
+
+    const sheriffCategory = page.locator('.border-gray-700.rounded-lg').filter({ hasText: 'シェリフ' }).first();
+
+    // 初期状態（レート 0）では「数」は表示されていないはず
+    await expect(sheriffCategory.getByText('数')).not.toBeVisible();
+
+    // レートのスライダーを操作して 1 以上にする
+    const rateSlider = sheriffCategory.locator('input[type="range"]').first();
+    await rateSlider.fill('10');
+
+    // 「数」が表示されることを確認
+    await expect(sheriffCategory.getByText('数')).toBeVisible();
+
+    // レートを 0 に戻すと「数」が消えることを確認
+    await rateSlider.fill('0');
+    await expect(sheriffCategory.getByText('数')).not.toBeVisible();
+  });
+
+  test('interacting with header controls should not toggle accordion', async ({ page }) => {
+    await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
+
+    const sheriffCategory = page.locator('.border-gray-700.rounded-lg').filter({ hasText: 'シェリフ' }).first();
+    const content = sheriffCategory.locator('.bg-gray-900'); // RoleCategoryItem の中身
+
+    // 最初は閉じている
+    await expect(content).not.toBeVisible();
+
+    // レートのスライダーを操作
+    const rateSlider = sheriffCategory.locator('input[type="range"]').first();
+    await rateSlider.fill('10');
+
+    // まだ閉じているはず（stopPropagationが効いている）
+    await expect(content).not.toBeVisible();
+
+    // 数が表示されたのでそちらも操作してみる
+    const countSlider = sheriffCategory.locator('input[type="range"]').nth(1);
+    await countSlider.fill('2');
+
+    // まだ閉じているはず
+    await expect(content).not.toBeVisible();
+
+    // ヘッダー名をクリックすれば開く
+    await sheriffCategory.getByRole('button', { name: 'シェリフ' }).click();
+    await expect(content).toBeVisible();
+  });
+
+  test('spawn rate and count should be filtered out from accordion body', async ({ page }) => {
+    await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
+
+    const sheriffCategory = page.locator('.border-gray-700.rounded-lg').filter({ hasText: 'シェリフ' }).first();
+
+    // アコーディオンを開く
+    await sheriffCategory.getByRole('button', { name: 'シェリフ' }).click();
+    const content = sheriffCategory.locator('.bg-gray-900');
+    await expect(content).toBeVisible();
+
+    // 中身に「スポーンレート」や「スポーン数」というテキストが無いことを確認
+    await expect(content.getByText('スポーンレート')).not.toBeVisible();
+    await expect(content.getByText('スポーン数')).not.toBeVisible();
+  });
+});

--- a/e2e/exr_role_spawn_options.spec.ts
+++ b/e2e/exr_role_spawn_options.spec.ts
@@ -18,33 +18,53 @@ test.beforeEach(async ({ page }) => {
 test.describe('ExR Role Spawn Options in Header', () => {
   const SHERIFF_ID = '270';
 
-  test('should display spawn rate in category header of role tabs', async ({ page }) => {
+  test('should display both spawn rate and count in category header of role tabs', async ({ page }) => {
     // 役職タブ（クルーメイト）に切り替え
     await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
 
-    // カテゴリ（シェリフ）のヘッダーに「レート」が表示されていることを確認
+    // カテゴリ（シェリフ）のヘッダーに「レート」と「数」が表示されていることを確認
     const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
     await expect(sheriffCategory.getByTestId('spawn-rate-control')).toBeVisible();
+    await expect(sheriffCategory.getByTestId('spawn-count-control')).toBeVisible();
   });
 
-  test('should show spawn count only when spawn rate is 1 or more', async ({ page }) => {
+  test('should synchronize spawn rate and count', async ({ page }) => {
     await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
 
     const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+    const rateControl = sheriffCategory.getByTestId('spawn-rate-control');
+    const countControl = sheriffCategory.getByTestId('spawn-count-control');
 
-    // 初期状態（レート 0）では「数」は表示されていないはず
-    await expect(sheriffCategory.getByTestId('spawn-count-control')).not.toBeVisible();
+    const rateInput = rateControl.locator('input[type="text"]');
+    const countInput = countControl.locator('input[type="text"]');
+    const rateSlider = rateControl.locator('input[type="range"]');
+    const countSlider = countControl.locator('input[type="range"]');
 
-    // レートのスライダーを操作して 1 以上にする
-    const rateSlider = sheriffCategory.getByTestId('spawn-rate-control').locator('input[type="range"]');
-    await rateSlider.fill('10');
-
-    // 「数」が表示されることを確認
-    await expect(sheriffCategory.getByTestId('spawn-count-control')).toBeVisible();
-
-    // レートを 0 に戻すと「数」が消えることを確認
+    // 初期状態が 0, 0 であることを確認（モックデータ依存だが、このテストスイートではそう仮定）
+    // もしモックが違うなら、まず 0 にする
     await rateSlider.fill('0');
-    await expect(sheriffCategory.getByTestId('spawn-count-control')).not.toBeVisible();
+    await expect(rateInput).toHaveValue('0');
+    await expect(countInput).toHaveValue('0');
+
+    // 1. スポーン数を変更するとスポーンレートを10％へ
+    await countSlider.fill('1'); // インデックス1 = 値1 (0番目は0)
+    await expect(countInput).toHaveValue('1');
+    await expect(rateInput).toHaveValue('10');
+
+    // 2. スポーンレートを0％にするとスポーン数を0
+    await rateSlider.fill('0');
+    await expect(rateInput).toHaveValue('0');
+    await expect(countInput).toHaveValue('0');
+
+    // 3. スポーン数を0へ変更するとスポーンレートが0％へ
+    // まず 10%, 1 に戻す
+    await countSlider.fill('1');
+    await expect(rateInput).toHaveValue('10');
+    await expect(countInput).toHaveValue('1');
+    // 0へ変更
+    await countSlider.fill('0');
+    await expect(countInput).toHaveValue('0');
+    await expect(rateInput).toHaveValue('0');
   });
 
   test('interacting with header controls should not toggle accordion', async ({ page }) => {
@@ -63,7 +83,7 @@ test.describe('ExR Role Spawn Options in Header', () => {
     // まだ閉じているはず（stopPropagationが効いている）
     await expect(content).not.toBeVisible();
 
-    // 数が表示されたのでそちらも操作してみる
+    // 数も操作してみる
     const countSlider = sheriffCategory.getByTestId('spawn-count-control').locator('input[type="range"]');
     await countSlider.fill('2');
 

--- a/e2e/exr_role_spawn_options.spec.ts
+++ b/e2e/exr_role_spawn_options.spec.ts
@@ -1,112 +1,136 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
-  // API遅延を最小限にしてテストを高速化
-  await page.addInitScript(() => {
-    // @ts-expect-error - window has no __API_DELAY__ property
-    window.__API_DELAY__ = 0;
-  });
-  await page.goto('/');
-  // ローディング画面が消えるのを待つ
-  await expect(page.getByText('Loading data...')).not.toBeVisible({ timeout: 30000 });
+	// API遅延を最小限にしてテストを高速化
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 0;
+	});
+	await page.goto("/");
+	// ローディング画面が消えるのを待つ
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
 
-  // ExR Options タブに切り替え
-  await page.getByRole('button', { name: 'ExR Options' }).click();
-  await page.waitForSelector('[data-testid="exr-category-list"]');
+	// ExR Options タブに切り替え
+	await page.getByRole("button", { name: "ExR Options" }).click();
+	await page.waitForSelector('[data-testid="exr-category-list"]');
 });
 
-test.describe('ExR Role Spawn Options in Header', () => {
-  const SHERIFF_ID = '270';
+test.describe("ExR Role Spawn Options in Header", () => {
+	const SHERIFF_ID = "270";
 
-  test('should display both spawn rate and count in category header of role tabs', async ({ page }) => {
-    // 役職タブ（クルーメイト）に切り替え
-    await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
+	test("should display both spawn rate and count in category header of role tabs", async ({
+		page,
+	}) => {
+		// 役職タブ（クルーメイト）に切り替え
+		await page
+			.getByRole("button", { name: "クルーメイト役職設定", exact: true })
+			.click();
 
-    // カテゴリ（シェリフ）のヘッダーに「レート」と「数」が表示されていることを確認
-    const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
-    await expect(sheriffCategory.getByTestId('spawn-rate-control')).toBeVisible();
-    await expect(sheriffCategory.getByTestId('spawn-count-control')).toBeVisible();
-  });
+		// カテゴリ（シェリフ）のヘッダーに「レート」と「数」が表示されていることを確認
+		const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+		await expect(
+			sheriffCategory.getByTestId("spawn-rate-control"),
+		).toBeVisible();
+		await expect(
+			sheriffCategory.getByTestId("spawn-count-control"),
+		).toBeVisible();
+	});
 
-  test('should synchronize spawn rate and count', async ({ page }) => {
-    await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
+	test("should synchronize spawn rate and count", async ({ page }) => {
+		await page
+			.getByRole("button", { name: "クルーメイト役職設定", exact: true })
+			.click();
 
-    const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
-    const rateControl = sheriffCategory.getByTestId('spawn-rate-control');
-    const countControl = sheriffCategory.getByTestId('spawn-count-control');
+		const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+		const rateControl = sheriffCategory.getByTestId("spawn-rate-control");
+		const countControl = sheriffCategory.getByTestId("spawn-count-control");
 
-    const rateInput = rateControl.locator('input[type="text"]');
-    const countInput = countControl.locator('input[type="text"]');
-    const rateSlider = rateControl.locator('input[type="range"]');
-    const countSlider = countControl.locator('input[type="range"]');
+		const rateInput = rateControl.locator('input[type="text"]');
+		const countInput = countControl.locator('input[type="text"]');
+		const rateSlider = rateControl.locator('input[type="range"]');
+		const countSlider = countControl.locator('input[type="range"]');
 
-    // 初期状態が 0, 0 であることを確認（モックデータ依存だが、このテストスイートではそう仮定）
-    // もしモックが違うなら、まず 0 にする
-    await rateSlider.fill('0');
-    await expect(rateInput).toHaveValue('0');
-    await expect(countInput).toHaveValue('0');
+		// 初期状態が 0, 0 であることを確認（モックデータ依存だが、このテストスイートではそう仮定）
+		// もしモックが違うなら、まず 0 にする
+		await rateSlider.fill("0");
+		await expect(rateInput).toHaveValue("0");
+		await expect(countInput).toHaveValue("0");
 
-    // 1. スポーン数を変更するとスポーンレートを10％へ
-    await countSlider.fill('1'); // インデックス1 = 値1 (0番目は0)
-    await expect(countInput).toHaveValue('1');
-    await expect(rateInput).toHaveValue('10');
+		// 1. スポーン数を変更するとスポーンレートを10％へ
+		await countSlider.fill("1"); // インデックス1 = 値1 (0番目は0)
+		await expect(countInput).toHaveValue("1");
+		await expect(rateInput).toHaveValue("10");
 
-    // 2. スポーンレートを0％にするとスポーン数を0
-    await rateSlider.fill('0');
-    await expect(rateInput).toHaveValue('0');
-    await expect(countInput).toHaveValue('0');
+		// 2. スポーンレートを0％にするとスポーン数を0
+		await rateSlider.fill("0");
+		await expect(rateInput).toHaveValue("0");
+		await expect(countInput).toHaveValue("0");
 
-    // 3. スポーン数を0へ変更するとスポーンレートが0％へ
-    // まず 10%, 1 に戻す
-    await countSlider.fill('1');
-    await expect(rateInput).toHaveValue('10');
-    await expect(countInput).toHaveValue('1');
-    // 0へ変更
-    await countSlider.fill('0');
-    await expect(countInput).toHaveValue('0');
-    await expect(rateInput).toHaveValue('0');
-  });
+		// 3. スポーン数を0へ変更するとスポーンレートが0％へ
+		// まず 10%, 1 に戻す
+		await countSlider.fill("1");
+		await expect(rateInput).toHaveValue("10");
+		await expect(countInput).toHaveValue("1");
+		// 0へ変更
+		await countSlider.fill("0");
+		await expect(countInput).toHaveValue("0");
+		await expect(rateInput).toHaveValue("0");
+	});
 
-  test('interacting with header controls should not toggle accordion', async ({ page }) => {
-    await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
+	test("interacting with header controls should not toggle accordion", async ({
+		page,
+	}) => {
+		await page
+			.getByRole("button", { name: "クルーメイト役職設定", exact: true })
+			.click();
 
-    const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
-    const content = sheriffCategory.locator('.bg-gray-900'); // Body area
+		const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+		const content = sheriffCategory.locator(".bg-gray-900"); // Body area
 
-    // 最初は閉じている
-    await expect(content).not.toBeVisible();
+		// 最初は閉じている
+		await expect(content).not.toBeVisible();
 
-    // レートのスライダーを操作
-    const rateSlider = sheriffCategory.getByTestId('spawn-rate-control').locator('input[type="range"]');
-    await rateSlider.fill('10');
+		// レートのスライダーを操作
+		const rateSlider = sheriffCategory
+			.getByTestId("spawn-rate-control")
+			.locator('input[type="range"]');
+		await rateSlider.fill("10");
 
-    // まだ閉じているはず（stopPropagationが効いている）
-    await expect(content).not.toBeVisible();
+		// まだ閉じているはず（stopPropagationが効いている）
+		await expect(content).not.toBeVisible();
 
-    // 数も操作してみる
-    const countSlider = sheriffCategory.getByTestId('spawn-count-control').locator('input[type="range"]');
-    await countSlider.fill('2');
+		// 数も操作してみる
+		const countSlider = sheriffCategory
+			.getByTestId("spawn-count-control")
+			.locator('input[type="range"]');
+		await countSlider.fill("2");
 
-    // まだ閉じているはず
-    await expect(content).not.toBeVisible();
+		// まだ閉じているはず
+		await expect(content).not.toBeVisible();
 
-    // ヘッダー名をクリックすれば開く
-    await sheriffCategory.getByRole('button', { name: 'シェリフ' }).click();
-    await expect(content).toBeVisible();
-  });
+		// ヘッダー名をクリックすれば開く
+		await sheriffCategory.getByRole("button", { name: "シェリフ" }).click();
+		await expect(content).toBeVisible();
+	});
 
-  test('spawn rate and count should be filtered out from accordion body', async ({ page }) => {
-    await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
+	test("spawn rate and count should be filtered out from accordion body", async ({
+		page,
+	}) => {
+		await page
+			.getByRole("button", { name: "クルーメイト役職設定", exact: true })
+			.click();
 
-    const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+		const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
 
-    // アコーディオンを開く
-    await sheriffCategory.getByRole('button', { name: 'シェリフ' }).click();
-    const content = sheriffCategory.locator('.bg-gray-900');
-    await expect(content).toBeVisible();
+		// アコーディオンを開く
+		await sheriffCategory.getByRole("button", { name: "シェリフ" }).click();
+		const content = sheriffCategory.locator(".bg-gray-900");
+		await expect(content).toBeVisible();
 
-    // 中身に「スポーンレート」や「スポーン数」というテキストが無いことを確認
-    await expect(content.getByText('スポーンレート')).not.toBeVisible();
-    await expect(content.getByText('スポーン数')).not.toBeVisible();
-  });
+		// 中身に「スポーンレート」や「スポーン数」というテキストが無いことを確認
+		await expect(content.getByText("スポーンレート")).not.toBeVisible();
+		await expect(content.getByText("スポーン数")).not.toBeVisible();
+	});
 });

--- a/src/components/parts/Accordion.tsx
+++ b/src/components/parts/Accordion.tsx
@@ -1,48 +1,58 @@
 import type { ReactNode } from "react";
 
 interface AccordionProps {
-  title: ReactNode;
-  isOpen: boolean;
-  onToggle: () => void;
-  children: ReactNode;
+	title: ReactNode;
+	isOpen: boolean;
+	onToggle: () => void;
+	children: ReactNode;
 }
 
 /**
  * ステートレスなアコーディオンコンポーネント
  */
-export function Accordion({ title, isOpen, onToggle, children }: AccordionProps) {
-  return (
-    <div className="border border-gray-700 rounded-lg overflow-hidden mb-2">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="w-full flex items-center gap-3 p-4 bg-gray-800 hover:bg-gray-700 transition-colors text-left"
-        aria-expanded={isOpen}
-      >
-        <svg
-          className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpen ? 'rotate-180' : ''}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
-        <span className="font-semibold text-gray-200">{title}</span>
-      </button>
-      <div
-        data-testid="accordion-content"
-        className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
-          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
-        }`}
-      >
-        <div className="min-h-0">
-          {isOpen && (
-            <div className="p-4 bg-gray-900 border-t border-gray-700">
-              {children}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
+export function Accordion({
+	title,
+	isOpen,
+	onToggle,
+	children,
+}: AccordionProps) {
+	return (
+		<div className="border border-gray-700 rounded-lg overflow-hidden mb-2">
+			<button
+				type="button"
+				onClick={onToggle}
+				className="w-full flex items-center gap-3 p-4 bg-gray-800 hover:bg-gray-700 transition-colors text-left"
+				aria-expanded={isOpen}
+			>
+				<svg
+					className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpen ? "rotate-180" : ""}`}
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						strokeWidth={2}
+						d="M19 9l-7 7-7-7"
+					/>
+				</svg>
+				<span className="font-semibold text-gray-200">{title}</span>
+			</button>
+			<div
+				data-testid="accordion-content"
+				className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
+					isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+				}`}
+			>
+				<div className="min-h-0">
+					{isOpen && (
+						<div className="p-4 bg-gray-900 border-t border-gray-700">
+							{children}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/components/parts/Accordion.tsx
+++ b/src/components/parts/Accordion.tsx
@@ -1,60 +1,48 @@
 import type { ReactNode } from "react";
 
 interface AccordionProps {
-	title: ReactNode;
-  headerExtra?: ReactNode;
-	isOpen: boolean;
-	onToggle: () => void;
-	children: ReactNode;
+  title: ReactNode;
+  isOpen: boolean;
+  onToggle: () => void;
+  children: ReactNode;
 }
 
 /**
  * ステートレスなアコーディオンコンポーネント
  */
-export function Accordion({
-	title,
-	isOpen,
-	onToggle,
-	children,
-}: AccordionProps) {
-	return (
-		<div className="border border-gray-700 rounded-lg overflow-hidden mb-2">
-			<button
-				type="button"
-				onClick={onToggle}
-				className="w-full flex items-center gap-3 p-4 bg-gray-800 hover:bg-gray-700 transition-colors text-left"
-				aria-expanded={isOpen}
-			>
-				<svg
-					className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpen ? "rotate-180" : ""}`}
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke="currentColor"
-					aria-hidden="true"
-				>
-					<path
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						strokeWidth={2}
-						d="M19 9l-7 7-7-7"
-					/>
-				</svg>
-				<span className="font-semibold text-gray-200">{title}</span>
-			</button>
-			<div
-				data-testid="accordion-content"
-				className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
-					isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
-				}`}
-			>
-				<div className="min-h-0">
-					{isOpen && (
-						<div className="p-4 bg-gray-900 border-t border-gray-700">
-							{children}
-						</div>
-					)}
-				</div>
-			</div>
-		</div>
-	);
+export function Accordion({ title, isOpen, onToggle, children }: AccordionProps) {
+  return (
+    <div className="border border-gray-700 rounded-lg overflow-hidden mb-2">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center gap-3 p-4 bg-gray-800 hover:bg-gray-700 transition-colors text-left"
+        aria-expanded={isOpen}
+      >
+        <svg
+          className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+        <span className="font-semibold text-gray-200">{title}</span>
+      </button>
+      <div
+        data-testid="accordion-content"
+        className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
+          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        }`}
+      >
+        <div className="min-h-0">
+          {isOpen && (
+            <div className="p-4 bg-gray-900 border-t border-gray-700">
+              {children}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/parts/Accordion.tsx
+++ b/src/components/parts/Accordion.tsx
@@ -30,6 +30,7 @@ export function Accordion({
 					viewBox="0 0 24 24"
 					stroke="currentColor"
 				>
+					<title>{isOpen ? "Collapse" : "Expand"}</title>
 					<path
 						strokeLinecap="round"
 						strokeLinejoin="round"

--- a/src/components/parts/Accordion.tsx
+++ b/src/components/parts/Accordion.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 interface AccordionProps {
 	title: ReactNode;
+  headerExtra?: ReactNode;
 	isOpen: boolean;
 	onToggle: () => void;
 	children: ReactNode;

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -32,20 +32,22 @@ export function CompactSlider({
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		e.stopPropagation();
 		const val = parseFloat(e.target.value);
-		if (!isNaN(val)) {
+		if (!Number.isNaN(val)) {
 			onInputChange(val);
 		}
 	};
 
-	const handleClick = (e: React.MouseEvent) => {
+	const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
 		// アコーディオンの開閉を防ぐ
 		e.stopPropagation();
 	};
 
 	return (
-		<div
-			className="flex flex-col gap-1 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
+		<fieldset
+			className="flex flex-col gap-1 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50 text-left cursor-default"
 			onClick={handleClick}
+			onKeyDown={handleClick}
+			aria-label={label}
 			data-testid={testId}
 		>
 			<div className="flex items-center justify-between gap-2">
@@ -68,6 +70,6 @@ export function CompactSlider({
 				onChange={handleSliderChange}
 				className="w-20 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
 			/>
-		</div>
+		</fieldset>
 	);
 }

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -12,6 +12,7 @@ interface CompactSliderProps {
 /**
  * カテゴリアコーディオンのヘッダーなどで使用する、コンパクトなスライダーとテキスト入力のセット
  * (純粋なUIコンポーネント)
+ * 入力欄はスライダーの上に表示されるようにレイアウト
  */
 export function CompactSlider({
   label,
@@ -43,11 +44,19 @@ export function CompactSlider({
 
   return (
     <div
-      className="flex items-center gap-2 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
+      className="flex flex-col gap-1 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
       onClick={handleClick}
       data-testid={testId}
     >
-      <span className="text-xs font-medium text-gray-400 whitespace-nowrap">{label}</span>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] font-medium text-gray-400 whitespace-nowrap leading-none">{label}</span>
+        <input
+          type="text"
+          value={currentValue}
+          onChange={handleInputChange}
+          className="w-8 px-0.5 py-0 text-right text-[10px] bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500 leading-none"
+        />
+      </div>
       <input
         type="range"
         min={0}
@@ -55,13 +64,7 @@ export function CompactSlider({
         step={1}
         value={currentSelection}
         onChange={handleSliderChange}
-        className="w-20 h-1.5 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-      />
-      <input
-        type="text"
-        value={currentValue}
-        onChange={handleInputChange}
-        className="w-10 px-1 py-0.5 text-right text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
+        className="w-20 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
       />
     </div>
   );

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+interface CompactSliderProps {
+  label: string;
+  values: number[];
+  currentSelection: number;
+  onSelectionChange: (selection: number) => void;
+  onInputChange: (value: number) => void;
+  testId?: string;
+}
+
+/**
+ * カテゴリアコーディオンのヘッダーなどで使用する、コンパクトなスライダーとテキスト入力のセット
+ * (純粋なUIコンポーネント)
+ */
+export function CompactSlider({
+  label,
+  values,
+  currentSelection,
+  onSelectionChange,
+  onInputChange,
+  testId,
+}: CompactSliderProps) {
+  const currentValue = values[currentSelection] ?? values[0] ?? 0;
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    onSelectionChange(parseInt(e.target.value, 10));
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    const val = parseFloat(e.target.value);
+    if (!isNaN(val)) {
+      onInputChange(val);
+    }
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    // アコーディオンの開閉を防ぐ
+    e.stopPropagation();
+  };
+
+  return (
+    <div
+      className="flex items-center gap-2 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
+      onClick={handleClick}
+      data-testid={testId}
+    >
+      <span className="text-xs font-medium text-gray-400 whitespace-nowrap">{label}</span>
+      <input
+        type="range"
+        min={0}
+        max={values.length - 1}
+        step={1}
+        value={currentSelection}
+        onChange={handleSliderChange}
+        className="w-20 h-1.5 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
+      />
+      <input
+        type="text"
+        value={currentValue}
+        onChange={handleInputChange}
+        className="w-10 px-1 py-0.5 text-right text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
+      />
+    </div>
+  );
+}

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import type React from "react";
 
 interface CompactSliderProps {
-  label: string;
-  values: number[];
-  currentSelection: number;
-  onSelectionChange: (selection: number) => void;
-  onInputChange: (value: number) => void;
-  testId?: string;
+	label: string;
+	values: number[];
+	currentSelection: number;
+	onSelectionChange: (selection: number) => void;
+	onInputChange: (value: number) => void;
+	testId?: string;
 }
 
 /**
@@ -15,57 +15,59 @@ interface CompactSliderProps {
  * 入力欄はスライダーの上に表示されるようにレイアウト
  */
 export function CompactSlider({
-  label,
-  values,
-  currentSelection,
-  onSelectionChange,
-  onInputChange,
-  testId,
+	label,
+	values,
+	currentSelection,
+	onSelectionChange,
+	onInputChange,
+	testId,
 }: CompactSliderProps) {
-  const currentValue = values[currentSelection] ?? values[0] ?? 0;
+	const currentValue = values[currentSelection] ?? values[0] ?? 0;
 
-  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-    onSelectionChange(parseInt(e.target.value, 10));
-  };
+	const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		e.stopPropagation();
+		onSelectionChange(parseInt(e.target.value, 10));
+	};
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-    const val = parseFloat(e.target.value);
-    if (!isNaN(val)) {
-      onInputChange(val);
-    }
-  };
+	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		e.stopPropagation();
+		const val = parseFloat(e.target.value);
+		if (!isNaN(val)) {
+			onInputChange(val);
+		}
+	};
 
-  const handleClick = (e: React.MouseEvent) => {
-    // アコーディオンの開閉を防ぐ
-    e.stopPropagation();
-  };
+	const handleClick = (e: React.MouseEvent) => {
+		// アコーディオンの開閉を防ぐ
+		e.stopPropagation();
+	};
 
-  return (
-    <div
-      className="flex flex-col gap-1 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
-      onClick={handleClick}
-      data-testid={testId}
-    >
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-[10px] font-medium text-gray-400 whitespace-nowrap leading-none">{label}</span>
-        <input
-          type="text"
-          value={currentValue}
-          onChange={handleInputChange}
-          className="w-8 px-0.5 py-0 text-right text-[10px] bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500 leading-none"
-        />
-      </div>
-      <input
-        type="range"
-        min={0}
-        max={values.length - 1}
-        step={1}
-        value={currentSelection}
-        onChange={handleSliderChange}
-        className="w-20 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-      />
-    </div>
-  );
+	return (
+		<div
+			className="flex flex-col gap-1 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
+			onClick={handleClick}
+			data-testid={testId}
+		>
+			<div className="flex items-center justify-between gap-2">
+				<span className="text-[10px] font-medium text-gray-400 whitespace-nowrap leading-none">
+					{label}
+				</span>
+				<input
+					type="text"
+					value={currentValue}
+					onChange={handleInputChange}
+					className="w-8 px-0.5 py-0 text-right text-[10px] bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500 leading-none"
+				/>
+			</div>
+			<input
+				type="range"
+				min={0}
+				max={values.length - 1}
+				step={1}
+				value={currentSelection}
+				onChange={handleSliderChange}
+				className="w-20 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
+			/>
+		</div>
+	);
 }

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { useStore } from '../useStore';
 import { Accordion } from '../components/parts/Accordion';
 import { ColoredText } from '../components/parts/ColoredText';

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -1,10 +1,12 @@
-import { Accordion } from "../components/parts/Accordion";
-import { ColoredText } from "../components/parts/ColoredText";
-import { groupOptionPairs, isPresetOption } from "../logics/optionUtils";
-import type { ExRCategoryDto, ExRTabDto } from "../type";
-import { useStore } from "../useStore";
-import { ExROptionItem } from "./ExROptionItem";
-import { ExRPairedOptionRow } from "./ExRPairedOptionRow";
+import { useStore } from '../useStore';
+import { Accordion } from '../components/parts/Accordion';
+import { ColoredText } from '../components/parts/ColoredText';
+import { ExROptionItem } from './ExROptionItem';
+import { ExRPairedOptionRow } from './ExRPairedOptionRow';
+import { ExRHeaderOptionControl } from './ExRHeaderOptionControl';
+import { isPresetOption, groupOptionPairs, getUniqueOptionId } from '../logics/optionUtils';
+import { OptionTab } from '../type';
+import type { ExRCategoryDto, ExRTabDto } from '../type';
 
 /**
  * グループ化表示（最小・最大ペア）を有効にするカテゴリIDのリスト
@@ -12,25 +14,58 @@ import { ExRPairedOptionRow } from "./ExRPairedOptionRow";
 const GROUPED_CATEGORY_IDS = [5, 6];
 
 interface CategoryAccordionProps {
-	category: ExRCategoryDto;
+  tabId: OptionTab;
+  category: ExRCategoryDto;
 }
 
 /**
  * 個別のカテゴリを表示するコンポーネント
  * 特定のカテゴリの開閉状態のみを監視することで、再レンダリングを最小限に抑えます。
  */
-function CategoryAccordion({ category }: CategoryAccordionProps) {
-	const isOpen = useStore((state) => {
-		return state.openedExRCategoryIds[category.Id] ?? false;
-	});
-	const toggleExRCategory = useStore((state) => {
-		return state.toggleExRCategory;
-	});
+function CategoryAccordion({ tabId, category }: CategoryAccordionProps) {
+  const isOpen = useStore((state) => {
+    return state.openedExRCategoryIds[category.Id] ?? false;
+  });
+  const toggleExRCategory = useStore((state) => {
+    return state.toggleExRCategory;
+  });
 
-	// プリセット設定（Category 0, Option 0）を非表示にする
-	const filteredOptions = category.Options.filter((option) => {
-		return !isPresetOption(category.Id, option.Id);
-	});
+  // スポーンレート(50)のセレクション状態を監視
+  const spawnRateSelection = useStore((state) => {
+    const uniqueId = getUniqueOptionId(category.Id, 50);
+    const effectiveSelection = state.effectiveSelections[uniqueId];
+    if (effectiveSelection !== undefined) {
+      return effectiveSelection;
+    }
+    const option = category.Options.find((opt) => {
+      return opt.Id === 50;
+    });
+    return option?.Selection ?? 0;
+  });
+
+  // 役職タブ（GeneralTab以外）の場合は、Id: 50, 51 を特別扱いする
+  const isRoleTab = tabId !== OptionTab.GeneralTab;
+  const spawnRateOption = isRoleTab
+    ? category.Options.find((opt) => {
+        return opt.Id === 50;
+      })
+    : null;
+  const spawnCountOption = isRoleTab
+    ? category.Options.find((opt) => {
+        return opt.Id === 51;
+      })
+    : null;
+
+  // プリセット設定（Category 0, Option 0）およびヘッダーに移動した 50, 51 を非表示にする
+  const filteredOptions = category.Options.filter((option) => {
+    if (isPresetOption(category.Id, option.Id)) {
+      return false;
+    }
+    if (isRoleTab && (option.Id === 50 || option.Id === 51)) {
+      return false;
+    }
+    return true;
+  });
 
 	// 全てのオプションが除外された場合はアコーディオンを表示しない
 	if (filteredOptions.length === 0) {
@@ -42,40 +77,54 @@ function CategoryAccordion({ category }: CategoryAccordionProps) {
 		? groupOptionPairs(filteredOptions)
 		: filteredOptions;
 
-	return (
-		<Accordion
-			title={<ColoredText text={category.Name} />}
-			isOpen={isOpen}
-			onToggle={() => {
-				toggleExRCategory(category.Id);
-			}}
-		>
-			<div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-				{groupedItems.map((item) => {
-					if ("type" in item && item.type === "pair") {
-						return (
-							<ExRPairedOptionRow
-								key={`pair-${item.baseName}`}
-								categoryId={category.Id}
-								baseName={item.baseName}
-								min={item.min}
-								max={item.max}
-								minLabel={item.minLabel}
-								maxLabel={item.maxLabel}
-							/>
-						);
-					}
-					return (
-						<ExROptionItem
-							key={item.Id}
-							categoryId={category.Id}
-							option={item}
-						/>
-					);
-				})}
-			</div>
-		</Accordion>
-	);
+  const headerExtra = (isRoleTab && spawnRateOption) ? (
+    <div className="flex items-center gap-4">
+      <ExRHeaderOptionControl
+        categoryId={category.Id}
+        option={spawnRateOption}
+        label="レート"
+      />
+      {spawnRateSelection >= 1 && spawnCountOption && (
+        <ExRHeaderOptionControl
+          categoryId={category.Id}
+          option={spawnCountOption}
+          label="数"
+        />
+      )}
+    </div>
+  ) : undefined;
+
+  return (
+    <Accordion
+      title={<ColoredText text={category.Name} />}
+      headerExtra={headerExtra}
+      isOpen={isOpen}
+      onToggle={() => {
+        toggleExRCategory(category.Id);
+      }}
+    >
+      <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
+        {groupedItems.map((item, idx) => {
+          if ('type' in item && item.type === 'pair') {
+            return (
+              <ExRPairedOptionRow
+                key={`pair-${idx}`}
+                categoryId={category.Id}
+                baseName={item.baseName}
+                min={item.min}
+                max={item.max}
+                minLabel={item.minLabel}
+                maxLabel={item.maxLabel}
+              />
+            );
+          }
+          return (
+            <ExROptionItem key={item.Id} categoryId={category.Id} option={item} />
+          );
+        })}
+      </div>
+    </Accordion>
+  );
 }
 
 interface ExRCategoryListProps {
@@ -113,20 +162,26 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
 		});
 	});
 
-	return (
-		<div
-			data-testid="exr-category-list"
-			className={`flex flex-col relative transition-opacity duration-200 ${isTabPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
-			data-is-pending={isTabPending ? "true" : "false"}
-		>
-			{isTabPending && (
-				<div className="absolute inset-0 flex items-center justify-center z-10">
-					<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
-				</div>
-			)}
-			{visibleCategories.map((category) => {
-				return <CategoryAccordion key={category.Id} category={category} />;
-			})}
-		</div>
-	);
+  return (
+    <div
+      data-testid="exr-category-list"
+      className={`flex flex-col relative transition-opacity duration-200 ${isTabPending ? 'is-pending opacity-50 pointer-events-none' : 'opacity-100'}`}
+      data-is-pending={isTabPending ? "true" : "false"}
+    >
+      {isTabPending && (
+        <div className="absolute inset-0 flex items-center justify-center z-10">
+          <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+        </div>
+      )}
+      {visibleCategories.map((category) => {
+        return (
+          <CategoryAccordion
+            key={category.Id}
+            tabId={selectedExRTabId}
+            category={category}
+          />
+        );
+      })}
+    </div>
+  );
 }

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -1,9 +1,9 @@
-import { useStore } from '../useStore';
-import { ExRStandardCategoryItem } from './ExRStandardCategoryItem';
-import { ExRRoleCategoryItem } from './ExRRoleCategoryItem';
-import { isPresetOption } from '../logics/optionUtils';
-import { OptionTab } from '../type';
-import type { ExRTabDto } from '../type';
+import { isPresetOption } from "../logics/optionUtils";
+import type { ExRTabDto } from "../type";
+import { OptionTab } from "../type";
+import { useStore } from "../useStore";
+import { ExRRoleCategoryItem } from "./ExRRoleCategoryItem";
+import { ExRStandardCategoryItem } from "./ExRStandardCategoryItem";
 
 interface ExRCategoryListProps {
 	tabs: ExRTabDto[];
@@ -28,47 +28,47 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
 		selectedTab = tabs[0];
 	}
 
-  const isRoleTab = selectedExRTabId !== OptionTab.GeneralTab;
+	const isRoleTab = selectedExRTabId !== OptionTab.GeneralTab;
 
-  // オプションが空でない、かつ少なくとも1つのオプションが有効なカテゴリのみを抽出
-  // ※ プリセット設定が唯一のオプションだった場合も考慮してフィルタリング
-  const visibleCategories = selectedTab.Categories.filter((category) => {
-    const filteredOptions = category.Options.filter((option) => {
-      const isPreset = isPresetOption(category.Id, option.Id);
-      return !isPreset;
-    });
-    return filteredOptions.some((opt) => {
-      return opt.IsActive;
-    });
-  });
+	// オプションが空でない、かつ少なくとも1つのオプションが有効なカテゴリのみを抽出
+	// ※ プリセット設定が唯一のオプションだった場合も考慮してフィルタリング
+	const visibleCategories = selectedTab.Categories.filter((category) => {
+		const filteredOptions = category.Options.filter((option) => {
+			const isPreset = isPresetOption(category.Id, option.Id);
+			return !isPreset;
+		});
+		return filteredOptions.some((opt) => {
+			return opt.IsActive;
+		});
+	});
 
-  return (
-    <div
-      data-testid="exr-category-list"
-      className={`flex flex-col relative transition-opacity duration-200 ${isTabPending ? 'is-pending opacity-50 pointer-events-none' : 'opacity-100'}`}
-      data-is-pending={isTabPending ? 'true' : 'false'}
-    >
-      {isTabPending && (
-        <div className="absolute inset-0 flex items-center justify-center z-10">
-          <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
-        </div>
-      )}
-      {visibleCategories.map((category) => {
-        if (isRoleTab) {
-          return (
-            <ExRRoleCategoryItem
-              key={`${selectedExRTabId}-${category.Id}`}
-              category={category}
-            />
-          );
-        }
-        return (
-          <ExRStandardCategoryItem
-            key={`${selectedExRTabId}-${category.Id}`}
-            category={category}
-          />
-        );
-      })}
-    </div>
-  );
+	return (
+		<div
+			data-testid="exr-category-list"
+			className={`flex flex-col relative transition-opacity duration-200 ${isTabPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
+			data-is-pending={isTabPending ? "true" : "false"}
+		>
+			{isTabPending && (
+				<div className="absolute inset-0 flex items-center justify-center z-10">
+					<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+				</div>
+			)}
+			{visibleCategories.map((category) => {
+				if (isRoleTab) {
+					return (
+						<ExRRoleCategoryItem
+							key={`${selectedExRTabId}-${category.Id}`}
+							category={category}
+						/>
+					);
+				}
+				return (
+					<ExRStandardCategoryItem
+						key={`${selectedExRTabId}-${category.Id}`}
+						category={category}
+					/>
+				);
+			})}
+		</div>
+	);
 }

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -1,153 +1,9 @@
 import { useStore } from '../useStore';
-import { Accordion } from '../components/parts/Accordion';
-import { ColoredText } from '../components/parts/ColoredText';
-import { ExROptionItem } from './ExROptionItem';
-import { ExRPairedOptionRow } from './ExRPairedOptionRow';
-import { ExRHeaderOptionControl } from './ExRHeaderOptionControl';
-import { isPresetOption, groupOptionPairs, getUniqueOptionId } from '../logics/optionUtils';
+import { ExRStandardCategoryItem } from './ExRStandardCategoryItem';
+import { ExRRoleCategoryItem } from './ExRRoleCategoryItem';
+import { isPresetOption } from '../logics/optionUtils';
 import { OptionTab } from '../type';
-import type { ExRCategoryDto, ExRTabDto, ExROptionDto } from '../type';
-
-/**
- * グループ化表示（最小・最大ペア）を有効にするカテゴリIDのリスト
- */
-const GROUPED_CATEGORY_IDS = [5, 6];
-
-interface ExRCategoryHeaderSpawnControlsProps {
-  categoryId: number;
-  spawnRateOption: ExROptionDto;
-  spawnCountOption: ExROptionDto | null;
-}
-
-/**
- * カテゴリヘッダー内のスポーンレート・数コントロール
- */
-function ExRCategoryHeaderSpawnControls({
-  categoryId,
-  spawnRateOption,
-  spawnCountOption,
-}: ExRCategoryHeaderSpawnControlsProps) {
-  const spawnRateSelection = useStore((state) => {
-    const uniqueId = getUniqueOptionId(categoryId, 50);
-    return state.effectiveSelections[uniqueId] ?? spawnRateOption.Selection;
-  });
-
-  return (
-    <div className="flex items-center gap-4">
-      <ExRHeaderOptionControl
-        categoryId={categoryId}
-        option={spawnRateOption}
-        label="レート"
-      />
-      {spawnRateSelection >= 1 && spawnCountOption && (
-        <ExRHeaderOptionControl
-          categoryId={categoryId}
-          option={spawnCountOption}
-          label="数"
-        />
-      )}
-    </div>
-  );
-}
-
-interface ExRCategoryOptionListProps {
-  categoryId: number;
-  options: ExROptionDto[];
-}
-
-/**
- * カテゴリ内のオプション一覧を表示するコンポーネント
- */
-function ExRCategoryOptionList({ categoryId, options }: ExRCategoryOptionListProps) {
-  const shouldGroup = GROUPED_CATEGORY_IDS.includes(categoryId);
-  const groupedItems = shouldGroup ? groupOptionPairs(options) : options;
-
-  return (
-    <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-      {groupedItems.map((item, idx) => {
-        if ('type' in item && item.type === 'pair') {
-          return (
-            <ExRPairedOptionRow
-              key={`pair-${idx}`}
-              categoryId={categoryId}
-              baseName={item.baseName}
-              min={item.min}
-              max={item.max}
-              minLabel={item.minLabel}
-              maxLabel={item.maxLabel}
-            />
-          );
-        }
-        return <ExROptionItem key={item.Id} categoryId={categoryId} option={item} />;
-      })}
-    </div>
-  );
-}
-
-interface ExRCategoryItemProps {
-  tabId: OptionTab;
-  category: ExRCategoryDto;
-}
-
-/**
- * カテゴリ項目の構成を行うコンポーネント
- */
-function ExRCategoryItem({ tabId, category }: ExRCategoryItemProps) {
-  const isOpen = useStore((state) => {
-    return state.openedExRCategoryIds[category.Id] ?? false;
-  });
-  const toggleExRCategory = useStore((state) => {
-    return state.toggleExRCategory;
-  });
-
-  const isRoleTab = tabId !== OptionTab.GeneralTab;
-  const spawnRateOption = isRoleTab
-    ? category.Options.find((opt) => {
-        return opt.Id === 50;
-      })
-    : null;
-  const spawnCountOption = isRoleTab
-    ? category.Options.find((opt) => {
-        return opt.Id === 51;
-      })
-    : null;
-
-  const filteredOptions = category.Options.filter((option) => {
-    if (isPresetOption(category.Id, option.Id)) {
-      return false;
-    }
-    if (isRoleTab && (option.Id === 50 || option.Id === 51)) {
-      return false;
-    }
-    return true;
-  });
-
-  if (filteredOptions.length === 0) {
-    return null;
-  }
-
-  const headerExtra =
-    isRoleTab && spawnRateOption ? (
-      <ExRCategoryHeaderSpawnControls
-        categoryId={category.Id}
-        spawnRateOption={spawnRateOption}
-        spawnCountOption={spawnCountOption}
-      />
-    ) : undefined;
-
-  return (
-    <Accordion
-      title={<ColoredText text={category.Name} />}
-      headerExtra={headerExtra}
-      isOpen={isOpen}
-      onToggle={() => {
-        toggleExRCategory(category.Id);
-      }}
-    >
-      <ExRCategoryOptionList categoryId={category.Id} options={filteredOptions} />
-    </Accordion>
-  );
-}
+import type { ExRTabDto } from '../type';
 
 interface ExRCategoryListProps {
 	tabs: ExRTabDto[];
@@ -172,6 +28,10 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
 		selectedTab = tabs[0];
 	}
 
+  const isRoleTab = selectedExRTabId !== OptionTab.GeneralTab;
+
+  // オプションが空でない、かつ少なくとも1つのオプションが有効なカテゴリのみを抽出
+  // ※ プリセット設定が唯一のオプションだった場合も考慮してフィルタリング
   const visibleCategories = selectedTab.Categories.filter((category) => {
     const filteredOptions = category.Options.filter((option) => {
       const isPreset = isPresetOption(category.Id, option.Id);
@@ -194,10 +54,17 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
         </div>
       )}
       {visibleCategories.map((category) => {
+        if (isRoleTab) {
+          return (
+            <ExRRoleCategoryItem
+              key={`${selectedExRTabId}-${category.Id}`}
+              category={category}
+            />
+          );
+        }
         return (
-          <ExRCategoryItem
-            key={category.Id}
-            tabId={selectedExRTabId}
+          <ExRStandardCategoryItem
+            key={`${selectedExRTabId}-${category.Id}`}
             category={category}
           />
         );

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { useStore } from '../useStore';
 import { Accordion } from '../components/parts/Accordion';
 import { ColoredText } from '../components/parts/ColoredText';
@@ -6,23 +7,93 @@ import { ExRPairedOptionRow } from './ExRPairedOptionRow';
 import { ExRHeaderOptionControl } from './ExRHeaderOptionControl';
 import { isPresetOption, groupOptionPairs, getUniqueOptionId } from '../logics/optionUtils';
 import { OptionTab } from '../type';
-import type { ExRCategoryDto, ExRTabDto } from '../type';
+import type { ExRCategoryDto, ExRTabDto, ExROptionDto } from '../type';
 
 /**
  * グループ化表示（最小・最大ペア）を有効にするカテゴリIDのリスト
  */
 const GROUPED_CATEGORY_IDS = [5, 6];
 
-interface CategoryAccordionProps {
+interface ExRCategoryHeaderSpawnControlsProps {
+  categoryId: number;
+  spawnRateOption: ExROptionDto;
+  spawnCountOption: ExROptionDto | null;
+}
+
+/**
+ * カテゴリヘッダー内のスポーンレート・数コントロール
+ */
+function ExRCategoryHeaderSpawnControls({
+  categoryId,
+  spawnRateOption,
+  spawnCountOption,
+}: ExRCategoryHeaderSpawnControlsProps) {
+  const spawnRateSelection = useStore((state) => {
+    const uniqueId = getUniqueOptionId(categoryId, 50);
+    return state.effectiveSelections[uniqueId] ?? spawnRateOption.Selection;
+  });
+
+  return (
+    <div className="flex items-center gap-4">
+      <ExRHeaderOptionControl
+        categoryId={categoryId}
+        option={spawnRateOption}
+        label="レート"
+      />
+      {spawnRateSelection >= 1 && spawnCountOption && (
+        <ExRHeaderOptionControl
+          categoryId={categoryId}
+          option={spawnCountOption}
+          label="数"
+        />
+      )}
+    </div>
+  );
+}
+
+interface ExRCategoryOptionListProps {
+  categoryId: number;
+  options: ExROptionDto[];
+}
+
+/**
+ * カテゴリ内のオプション一覧を表示するコンポーネント
+ */
+function ExRCategoryOptionList({ categoryId, options }: ExRCategoryOptionListProps) {
+  const shouldGroup = GROUPED_CATEGORY_IDS.includes(categoryId);
+  const groupedItems = shouldGroup ? groupOptionPairs(options) : options;
+
+  return (
+    <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
+      {groupedItems.map((item, idx) => {
+        if ('type' in item && item.type === 'pair') {
+          return (
+            <ExRPairedOptionRow
+              key={`pair-${idx}`}
+              categoryId={categoryId}
+              baseName={item.baseName}
+              min={item.min}
+              max={item.max}
+              minLabel={item.minLabel}
+              maxLabel={item.maxLabel}
+            />
+          );
+        }
+        return <ExROptionItem key={item.Id} categoryId={categoryId} option={item} />;
+      })}
+    </div>
+  );
+}
+
+interface ExRCategoryItemProps {
   tabId: OptionTab;
   category: ExRCategoryDto;
 }
 
 /**
- * 個別のカテゴリを表示するコンポーネント
- * 特定のカテゴリの開閉状態のみを監視することで、再レンダリングを最小限に抑えます。
+ * カテゴリ項目の構成を行うコンポーネント
  */
-function CategoryAccordion({ tabId, category }: CategoryAccordionProps) {
+function ExRCategoryItem({ tabId, category }: ExRCategoryItemProps) {
   const isOpen = useStore((state) => {
     return state.openedExRCategoryIds[category.Id] ?? false;
   });
@@ -30,20 +101,6 @@ function CategoryAccordion({ tabId, category }: CategoryAccordionProps) {
     return state.toggleExRCategory;
   });
 
-  // スポーンレート(50)のセレクション状態を監視
-  const spawnRateSelection = useStore((state) => {
-    const uniqueId = getUniqueOptionId(category.Id, 50);
-    const effectiveSelection = state.effectiveSelections[uniqueId];
-    if (effectiveSelection !== undefined) {
-      return effectiveSelection;
-    }
-    const option = category.Options.find((opt) => {
-      return opt.Id === 50;
-    });
-    return option?.Selection ?? 0;
-  });
-
-  // 役職タブ（GeneralTab以外）の場合は、Id: 50, 51 を特別扱いする
   const isRoleTab = tabId !== OptionTab.GeneralTab;
   const spawnRateOption = isRoleTab
     ? category.Options.find((opt) => {
@@ -56,7 +113,6 @@ function CategoryAccordion({ tabId, category }: CategoryAccordionProps) {
       })
     : null;
 
-  // プリセット設定（Category 0, Option 0）およびヘッダーに移動した 50, 51 を非表示にする
   const filteredOptions = category.Options.filter((option) => {
     if (isPresetOption(category.Id, option.Id)) {
       return false;
@@ -67,32 +123,18 @@ function CategoryAccordion({ tabId, category }: CategoryAccordionProps) {
     return true;
   });
 
-	// 全てのオプションが除外された場合はアコーディオンを表示しない
-	if (filteredOptions.length === 0) {
-		return null;
-	}
+  if (filteredOptions.length === 0) {
+    return null;
+  }
 
-	const shouldGroup = GROUPED_CATEGORY_IDS.includes(category.Id);
-	const groupedItems = shouldGroup
-		? groupOptionPairs(filteredOptions)
-		: filteredOptions;
-
-  const headerExtra = (isRoleTab && spawnRateOption) ? (
-    <div className="flex items-center gap-4">
-      <ExRHeaderOptionControl
+  const headerExtra =
+    isRoleTab && spawnRateOption ? (
+      <ExRCategoryHeaderSpawnControls
         categoryId={category.Id}
-        option={spawnRateOption}
-        label="レート"
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
       />
-      {spawnRateSelection >= 1 && spawnCountOption && (
-        <ExRHeaderOptionControl
-          categoryId={category.Id}
-          option={spawnCountOption}
-          label="数"
-        />
-      )}
-    </div>
-  ) : undefined;
+    ) : undefined;
 
   return (
     <Accordion
@@ -103,26 +145,7 @@ function CategoryAccordion({ tabId, category }: CategoryAccordionProps) {
         toggleExRCategory(category.Id);
       }}
     >
-      <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-        {groupedItems.map((item, idx) => {
-          if ('type' in item && item.type === 'pair') {
-            return (
-              <ExRPairedOptionRow
-                key={`pair-${idx}`}
-                categoryId={category.Id}
-                baseName={item.baseName}
-                min={item.min}
-                max={item.max}
-                minLabel={item.minLabel}
-                maxLabel={item.maxLabel}
-              />
-            );
-          }
-          return (
-            <ExROptionItem key={item.Id} categoryId={category.Id} option={item} />
-          );
-        })}
-      </div>
+      <ExRCategoryOptionList categoryId={category.Id} options={filteredOptions} />
     </Accordion>
   );
 }
@@ -150,23 +173,21 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
 		selectedTab = tabs[0];
 	}
 
-	// オプションが空でない、かつ少なくとも1つのオプションが有効なカテゴリのみを抽出
-	// ※ プリセット設定が唯一のオプションだった場合も考慮してフィルタリング
-	const visibleCategories = selectedTab.Categories.filter((category) => {
-		const filteredOptions = category.Options.filter((option) => {
-			const isPreset = isPresetOption(category.Id, option.Id);
-			return !isPreset;
-		});
-		return filteredOptions.some((opt) => {
-			return opt.IsActive;
-		});
-	});
+  const visibleCategories = selectedTab.Categories.filter((category) => {
+    const filteredOptions = category.Options.filter((option) => {
+      const isPreset = isPresetOption(category.Id, option.Id);
+      return !isPreset;
+    });
+    return filteredOptions.some((opt) => {
+      return opt.IsActive;
+    });
+  });
 
   return (
     <div
       data-testid="exr-category-list"
       className={`flex flex-col relative transition-opacity duration-200 ${isTabPending ? 'is-pending opacity-50 pointer-events-none' : 'opacity-100'}`}
-      data-is-pending={isTabPending ? "true" : "false"}
+      data-is-pending={isTabPending ? 'true' : 'false'}
     >
       {isTabPending && (
         <div className="absolute inset-0 flex items-center justify-center z-10">
@@ -175,7 +196,7 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
       )}
       {visibleCategories.map((category) => {
         return (
-          <CategoryAccordion
+          <ExRCategoryItem
             key={category.Id}
             tabId={selectedExRTabId}
             category={category}

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -1,0 +1,42 @@
+import { ExROptionItem } from './ExROptionItem';
+import { ExRPairedOptionRow } from './ExRPairedOptionRow';
+import { groupOptionPairs } from '../logics/optionUtils';
+import type { ExROptionDto } from '../type';
+
+const GROUPED_CATEGORY_IDS = [5, 6];
+
+interface ExRCategoryOptionListProps {
+  categoryId: number;
+  options: ExROptionDto[];
+}
+
+/**
+ * カテゴリ内のオプション一覧を表示する共通コンポーネント
+ */
+export function ExRCategoryOptionList({ categoryId, options }: ExRCategoryOptionListProps) {
+  const shouldGroup = GROUPED_CATEGORY_IDS.includes(categoryId);
+  const groupedItems = shouldGroup ? groupOptionPairs(options) : options;
+
+  return (
+    <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
+      {groupedItems.map((item, idx) => {
+        if ('type' in item && item.type === 'pair') {
+          return (
+            <ExRPairedOptionRow
+              key={`pair-${idx}`}
+              categoryId={categoryId}
+              baseName={item.baseName}
+              min={item.min}
+              max={item.max}
+              minLabel={item.minLabel}
+              maxLabel={item.maxLabel}
+            />
+          );
+        }
+        return (
+          <ExROptionItem key={item.Id} categoryId={categoryId} option={item} />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -22,11 +22,11 @@ export function ExRCategoryOptionList({
 
 	return (
 		<div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-			{groupedItems.map((item, idx) => {
+			{groupedItems.map((item) => {
 				if ("type" in item && item.type === "pair") {
 					return (
 						<ExRPairedOptionRow
-							key={`pair-${idx}`}
+							key={`pair-${item.baseName}`}
 							categoryId={categoryId}
 							baseName={item.baseName}
 							min={item.min}

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -1,42 +1,45 @@
-import { ExROptionItem } from './ExROptionItem';
-import { ExRPairedOptionRow } from './ExRPairedOptionRow';
-import { groupOptionPairs } from '../logics/optionUtils';
-import type { ExROptionDto } from '../type';
+import { groupOptionPairs } from "../logics/optionUtils";
+import type { ExROptionDto } from "../type";
+import { ExROptionItem } from "./ExROptionItem";
+import { ExRPairedOptionRow } from "./ExRPairedOptionRow";
 
 const GROUPED_CATEGORY_IDS = [5, 6];
 
 interface ExRCategoryOptionListProps {
-  categoryId: number;
-  options: ExROptionDto[];
+	categoryId: number;
+	options: ExROptionDto[];
 }
 
 /**
  * カテゴリ内のオプション一覧を表示する共通コンポーネント
  */
-export function ExRCategoryOptionList({ categoryId, options }: ExRCategoryOptionListProps) {
-  const shouldGroup = GROUPED_CATEGORY_IDS.includes(categoryId);
-  const groupedItems = shouldGroup ? groupOptionPairs(options) : options;
+export function ExRCategoryOptionList({
+	categoryId,
+	options,
+}: ExRCategoryOptionListProps) {
+	const shouldGroup = GROUPED_CATEGORY_IDS.includes(categoryId);
+	const groupedItems = shouldGroup ? groupOptionPairs(options) : options;
 
-  return (
-    <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-      {groupedItems.map((item, idx) => {
-        if ('type' in item && item.type === 'pair') {
-          return (
-            <ExRPairedOptionRow
-              key={`pair-${idx}`}
-              categoryId={categoryId}
-              baseName={item.baseName}
-              min={item.min}
-              max={item.max}
-              minLabel={item.minLabel}
-              maxLabel={item.maxLabel}
-            />
-          );
-        }
-        return (
-          <ExROptionItem key={item.Id} categoryId={categoryId} option={item} />
-        );
-      })}
-    </div>
-  );
+	return (
+		<div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
+			{groupedItems.map((item, idx) => {
+				if ("type" in item && item.type === "pair") {
+					return (
+						<ExRPairedOptionRow
+							key={`pair-${idx}`}
+							categoryId={categoryId}
+							baseName={item.baseName}
+							min={item.min}
+							max={item.max}
+							minLabel={item.minLabel}
+							maxLabel={item.maxLabel}
+						/>
+					);
+				}
+				return (
+					<ExROptionItem key={item.Id} categoryId={categoryId} option={item} />
+				);
+			})}
+		</div>
+	);
 }

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -1,0 +1,71 @@
+import { useStore } from '../useStore';
+import { getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
+import type { ExROptionDto } from '../type';
+
+interface ExRHeaderOptionControlProps {
+  categoryId: number;
+  option: ExROptionDto;
+  label: string;
+}
+
+/**
+ * カテゴリアコーディオンのヘッダーに表示するためのコンパクトなスライダーコントロール
+ */
+export function ExRHeaderOptionControl({
+  categoryId,
+  option,
+  label,
+}: ExRHeaderOptionControlProps) {
+  const uniqueId = getUniqueOptionId(categoryId, option.Id);
+  const effectiveSelection = useStore((state) => {
+    return state.effectiveSelections[uniqueId];
+  });
+  const currentSelection = effectiveSelection ?? option.Selection;
+  const TEMP_updateExROptionSelection = useStore((state) => {
+    return state.TEMP_updateExROptionSelection;
+  });
+
+  const { Values } = option.RangeMeta;
+  const values = Values as number[];
+  const currentValue = values[currentSelection] ?? values[0] ?? 0;
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    TEMP_updateExROptionSelection(uniqueId, parseInt(e.target.value, 10));
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    const val = parseFloat(e.target.value);
+    if (isNaN(val)) {
+      return;
+    }
+    TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    // アコーディオンの開閉を防ぐ
+    e.stopPropagation();
+  };
+
+  return (
+    <div className="flex items-center gap-2 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50" onClick={handleClick}>
+      <span className="text-xs font-medium text-gray-400 whitespace-nowrap">{label}</span>
+      <input
+        type="range"
+        min={0}
+        max={values.length - 1}
+        step={1}
+        value={currentSelection}
+        onChange={handleSliderChange}
+        className="w-20 h-1.5 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
+      />
+      <input
+        type="text"
+        value={currentValue}
+        onChange={handleInputChange}
+        className="w-10 px-1 py-0.5 text-right text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
+      />
+    </div>
+  );
+}

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -1,12 +1,12 @@
-import { useStore } from '../useStore';
-import { getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
-import { CompactSlider } from '../components/parts/CompactSlider';
-import type { ExROptionDto } from '../type';
+import { CompactSlider } from "../components/parts/CompactSlider";
+import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
+import type { ExROptionDto } from "../type";
+import { useStore } from "../useStore";
 
 interface ExRHeaderOptionControlProps {
-  categoryId: number;
-  option: ExROptionDto;
-  label: string;
+	categoryId: number;
+	option: ExROptionDto;
+	label: string;
 }
 
 /**
@@ -14,36 +14,36 @@ interface ExRHeaderOptionControlProps {
  * (ストア接続済みラッパー)
  */
 export function ExRHeaderOptionControl({
-  categoryId,
-  option,
-  label,
+	categoryId,
+	option,
+	label,
 }: ExRHeaderOptionControlProps) {
-  const uniqueId = getUniqueOptionId(categoryId, option.Id);
-  const effectiveSelection = useStore((state) => {
-    return state.effectiveSelections[uniqueId];
-  });
-  const currentSelection = effectiveSelection ?? option.Selection;
-  const TEMP_updateExROptionSelection = useStore((state) => {
-    return state.TEMP_updateExROptionSelection;
-  });
+	const uniqueId = getUniqueOptionId(categoryId, option.Id);
+	const effectiveSelection = useStore((state) => {
+		return state.effectiveSelections[uniqueId];
+	});
+	const currentSelection = effectiveSelection ?? option.Selection;
+	const TEMP_updateExROptionSelection = useStore((state) => {
+		return state.TEMP_updateExROptionSelection;
+	});
 
-  const values = option.RangeMeta.Values as number[];
+	const values = option.RangeMeta.Values as number[];
 
-  const handleSelectionChange = (newSelection: number) => {
-    TEMP_updateExROptionSelection(uniqueId, newSelection);
-  };
+	const handleSelectionChange = (newSelection: number) => {
+		TEMP_updateExROptionSelection(uniqueId, newSelection);
+	};
 
-  const handleInputChange = (val: number) => {
-    TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
-  };
+	const handleInputChange = (val: number) => {
+		TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+	};
 
-  return (
-    <CompactSlider
-      label={label}
-      values={values}
-      currentSelection={currentSelection}
-      onSelectionChange={handleSelectionChange}
-      onInputChange={handleInputChange}
-    />
-  );
+	return (
+		<CompactSlider
+			label={label}
+			values={values}
+			currentSelection={currentSelection}
+			onSelectionChange={handleSelectionChange}
+			onInputChange={handleInputChange}
+		/>
+	);
 }

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -6,6 +6,9 @@ interface ExRHeaderOptionControlProps {
   categoryId: number;
   option: ExROptionDto;
   label: string;
+  customValues?: number[];
+  customSelection?: number;
+  onSelectionChange?: (selection: number) => void;
 }
 
 /**
@@ -15,23 +18,33 @@ export function ExRHeaderOptionControl({
   categoryId,
   option,
   label,
+  customValues,
+  customSelection,
+  onSelectionChange,
 }: ExRHeaderOptionControlProps) {
   const uniqueId = getUniqueOptionId(categoryId, option.Id);
   const effectiveSelection = useStore((state) => {
     return state.effectiveSelections[uniqueId];
   });
-  const currentSelection = effectiveSelection ?? option.Selection;
   const TEMP_updateExROptionSelection = useStore((state) => {
     return state.TEMP_updateExROptionSelection;
   });
 
-  const { Values } = option.RangeMeta;
-  const values = Values as number[];
+  const values = customValues ?? (option.RangeMeta.Values as number[]);
+  const currentSelection = customSelection ?? effectiveSelection ?? option.Selection;
   const currentValue = values[currentSelection] ?? values[0] ?? 0;
+
+  const handleSelectionUpdate = (newSelection: number) => {
+    if (onSelectionChange) {
+      onSelectionChange(newSelection);
+    } else {
+      TEMP_updateExROptionSelection(uniqueId, newSelection);
+    }
+  };
 
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
-    TEMP_updateExROptionSelection(uniqueId, parseInt(e.target.value, 10));
+    handleSelectionUpdate(parseInt(e.target.value, 10));
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,7 +53,7 @@ export function ExRHeaderOptionControl({
     if (isNaN(val)) {
       return;
     }
-    TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+    handleSelectionUpdate(findClosestIndex(values, val));
   };
 
   const handleClick = (e: React.MouseEvent) => {

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -1,84 +1,49 @@
 import { useStore } from '../useStore';
 import { getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
+import { CompactSlider } from '../components/parts/CompactSlider';
 import type { ExROptionDto } from '../type';
 
 interface ExRHeaderOptionControlProps {
   categoryId: number;
   option: ExROptionDto;
   label: string;
-  customValues?: number[];
-  customSelection?: number;
-  onSelectionChange?: (selection: number) => void;
 }
 
 /**
  * カテゴリアコーディオンのヘッダーに表示するためのコンパクトなスライダーコントロール
+ * (ストア接続済みラッパー)
  */
 export function ExRHeaderOptionControl({
   categoryId,
   option,
   label,
-  customValues,
-  customSelection,
-  onSelectionChange,
 }: ExRHeaderOptionControlProps) {
   const uniqueId = getUniqueOptionId(categoryId, option.Id);
   const effectiveSelection = useStore((state) => {
     return state.effectiveSelections[uniqueId];
   });
+  const currentSelection = effectiveSelection ?? option.Selection;
   const TEMP_updateExROptionSelection = useStore((state) => {
     return state.TEMP_updateExROptionSelection;
   });
 
-  const values = customValues ?? (option.RangeMeta.Values as number[]);
-  const currentSelection = customSelection ?? effectiveSelection ?? option.Selection;
-  const currentValue = values[currentSelection] ?? values[0] ?? 0;
+  const values = option.RangeMeta.Values as number[];
 
-  const handleSelectionUpdate = (newSelection: number) => {
-    if (onSelectionChange) {
-      onSelectionChange(newSelection);
-    } else {
-      TEMP_updateExROptionSelection(uniqueId, newSelection);
-    }
+  const handleSelectionChange = (newSelection: number) => {
+    TEMP_updateExROptionSelection(uniqueId, newSelection);
   };
 
-  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-    handleSelectionUpdate(parseInt(e.target.value, 10));
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-    const val = parseFloat(e.target.value);
-    if (isNaN(val)) {
-      return;
-    }
-    handleSelectionUpdate(findClosestIndex(values, val));
-  };
-
-  const handleClick = (e: React.MouseEvent) => {
-    // アコーディオンの開閉を防ぐ
-    e.stopPropagation();
+  const handleInputChange = (val: number) => {
+    TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
   };
 
   return (
-    <div className="flex items-center gap-2 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50" onClick={handleClick}>
-      <span className="text-xs font-medium text-gray-400 whitespace-nowrap">{label}</span>
-      <input
-        type="range"
-        min={0}
-        max={values.length - 1}
-        step={1}
-        value={currentSelection}
-        onChange={handleSliderChange}
-        className="w-20 h-1.5 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-      />
-      <input
-        type="text"
-        value={currentValue}
-        onChange={handleInputChange}
-        className="w-10 px-1 py-0.5 text-right text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
-      />
-    </div>
+    <CompactSlider
+      label={label}
+      values={values}
+      currentSelection={currentSelection}
+      onSelectionChange={handleSelectionChange}
+      onInputChange={handleInputChange}
+    />
   );
 }

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -47,7 +47,10 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
   }
 
   return (
-    <div className="border border-gray-700 rounded-lg overflow-hidden mb-2">
+    <div
+      className="border border-gray-700 rounded-lg overflow-hidden mb-2"
+      data-testid={`exr-category-${category.Id}`}
+    >
       <div className="flex items-center bg-gray-800 hover:bg-gray-700 transition-colors">
         <button
           type="button"
@@ -77,18 +80,22 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 
         <div className="flex items-center px-4 gap-4">
           {spawnRateOption && (
-            <ExRHeaderOptionControl
-              categoryId={category.Id}
-              option={spawnRateOption}
-              label="レート"
-            />
+            <div data-testid="spawn-rate-control">
+              <ExRHeaderOptionControl
+                categoryId={category.Id}
+                option={spawnRateOption}
+                label="レート"
+              />
+            </div>
           )}
           {spawnRateSelection >= 1 && spawnCountOption && (
-            <ExRHeaderOptionControl
-              categoryId={category.Id}
-              option={spawnCountOption}
-              label="数"
-            />
+            <div data-testid="spawn-count-control">
+              <ExRHeaderOptionControl
+                categoryId={category.Id}
+                option={spawnCountOption}
+                label="数"
+              />
+            </div>
           )}
         </div>
       </div>

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,0 +1,136 @@
+import { useStore } from '../useStore';
+import { ColoredText } from '../components/parts/ColoredText';
+import { ExROptionItem } from './ExROptionItem';
+import { ExRPairedOptionRow } from './ExRPairedOptionRow';
+import { ExRHeaderOptionControl } from './ExRHeaderOptionControl';
+import { isPresetOption, groupOptionPairs, getUniqueOptionId } from '../logics/optionUtils';
+import type { ExRCategoryDto } from '../type';
+
+const GROUPED_CATEGORY_IDS = [5, 6];
+
+interface ExRRoleCategoryItemProps {
+  category: ExRCategoryDto;
+}
+
+/**
+ * 役職タブで使用される、スポーン設定をヘッダーに持つカテゴリ表示コンポーネント
+ */
+export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
+  const isOpen = useStore((state) => {
+    return state.openedExRCategoryIds[category.Id] ?? false;
+  });
+  const toggleExRCategory = useStore((state) => {
+    return state.toggleExRCategory;
+  });
+
+  const spawnRateOption = category.Options.find((opt) => {
+    return opt.Id === 50;
+  });
+  const spawnCountOption = category.Options.find((opt) => {
+    return opt.Id === 51;
+  });
+
+  const spawnRateSelection = useStore((state) => {
+    const uniqueId = getUniqueOptionId(category.Id, 50);
+    return state.effectiveSelections[uniqueId] ?? spawnRateOption?.Selection ?? 0;
+  });
+
+  const filteredOptions = category.Options.filter((option) => {
+    if (isPresetOption(category.Id, option.Id)) {
+      return false;
+    }
+    if (option.Id === 50 || option.Id === 51) {
+      return false;
+    }
+    return true;
+  });
+
+  if (filteredOptions.length === 0) {
+    return null;
+  }
+
+  const shouldGroup = GROUPED_CATEGORY_IDS.includes(category.Id);
+  const groupedItems = shouldGroup ? groupOptionPairs(filteredOptions) : filteredOptions;
+
+  return (
+    <div className="border border-gray-700 rounded-lg overflow-hidden mb-2">
+      <div className="flex items-center bg-gray-800 hover:bg-gray-700 transition-colors">
+        <button
+          type="button"
+          onClick={() => {
+            toggleExRCategory(category.Id);
+          }}
+          className="flex-1 flex items-center gap-3 p-4 text-left"
+          aria-expanded={isOpen}
+        >
+          <svg
+            className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpen ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+          <span className="font-semibold text-gray-200">
+            <ColoredText text={category.Name} />
+          </span>
+        </button>
+
+        <div className="flex items-center px-4 gap-4">
+          {spawnRateOption && (
+            <ExRHeaderOptionControl
+              categoryId={category.Id}
+              option={spawnRateOption}
+              label="レート"
+            />
+          )}
+          {spawnRateSelection >= 1 && spawnCountOption && (
+            <ExRHeaderOptionControl
+              categoryId={category.Id}
+              option={spawnCountOption}
+              label="数"
+            />
+          )}
+        </div>
+      </div>
+
+      <div
+        className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
+          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        }`}
+      >
+        <div className="min-h-0">
+          {isOpen && (
+            <div className="p-4 bg-gray-900 border-t border-gray-700">
+              <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
+                {groupedItems.map((item, idx) => {
+                  if ('type' in item && item.type === 'pair') {
+                    return (
+                      <ExRPairedOptionRow
+                        key={`pair-${idx}`}
+                        categoryId={category.Id}
+                        baseName={item.baseName}
+                        min={item.min}
+                        max={item.max}
+                        minLabel={item.minLabel}
+                        maxLabel={item.maxLabel}
+                      />
+                    );
+                  }
+                  return (
+                    <ExROptionItem key={item.Id} categoryId={category.Id} option={item} />
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,12 +1,9 @@
 import { useStore } from '../useStore';
 import { ColoredText } from '../components/parts/ColoredText';
-import { ExROptionItem } from './ExROptionItem';
-import { ExRPairedOptionRow } from './ExRPairedOptionRow';
+import { ExRCategoryOptionList } from './ExRCategoryOptionList';
 import { ExRHeaderOptionControl } from './ExRHeaderOptionControl';
-import { isPresetOption, groupOptionPairs, getUniqueOptionId } from '../logics/optionUtils';
+import { isPresetOption, getUniqueOptionId } from '../logics/optionUtils';
 import type { ExRCategoryDto } from '../type';
-
-const GROUPED_CATEGORY_IDS = [5, 6];
 
 interface ExRRoleCategoryItemProps {
   category: ExRCategoryDto;
@@ -48,9 +45,6 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
   if (filteredOptions.length === 0) {
     return null;
   }
-
-  const shouldGroup = GROUPED_CATEGORY_IDS.includes(category.Id);
-  const groupedItems = shouldGroup ? groupOptionPairs(filteredOptions) : filteredOptions;
 
   return (
     <div className="border border-gray-700 rounded-lg overflow-hidden mb-2">
@@ -107,26 +101,7 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
         <div className="min-h-0">
           {isOpen && (
             <div className="p-4 bg-gray-900 border-t border-gray-700">
-              <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-                {groupedItems.map((item, idx) => {
-                  if ('type' in item && item.type === 'pair') {
-                    return (
-                      <ExRPairedOptionRow
-                        key={`pair-${idx}`}
-                        categoryId={category.Id}
-                        baseName={item.baseName}
-                        min={item.min}
-                        max={item.max}
-                        minLabel={item.minLabel}
-                        maxLabel={item.maxLabel}
-                      />
-                    );
-                  }
-                  return (
-                    <ExROptionItem key={item.Id} categoryId={category.Id} option={item} />
-                  );
-                })}
-              </div>
+              <ExRCategoryOptionList categoryId={category.Id} options={filteredOptions} />
             </div>
           )}
         </div>

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,102 +1,105 @@
-import { useStore } from '../useStore';
-import { ColoredText } from '../components/parts/ColoredText';
-import { ExRCategoryOptionList } from './ExRCategoryOptionList';
-import { ExRRoleSpawnControls } from './ExRRoleSpawnControls';
-import { isPresetOption } from '../logics/optionUtils';
-import type { ExRCategoryDto } from '../type';
+import { ColoredText } from "../components/parts/ColoredText";
+import { isPresetOption } from "../logics/optionUtils";
+import type { ExRCategoryDto } from "../type";
+import { useStore } from "../useStore";
+import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
+import { ExRRoleSpawnControls } from "./ExRRoleSpawnControls";
 
 interface ExRRoleCategoryItemProps {
-  category: ExRCategoryDto;
+	category: ExRCategoryDto;
 }
 
 /**
  * 役職タブで使用される、スポーン設定をヘッダーに持つカテゴリ表示コンポーネント
  */
 export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
-  const isOpen = useStore((state) => {
-    return state.openedExRCategoryIds[category.Id] ?? false;
-  });
-  const toggleExRCategory = useStore((state) => {
-    return state.toggleExRCategory;
-  });
+	const isOpen = useStore((state) => {
+		return state.openedExRCategoryIds[category.Id] ?? false;
+	});
+	const toggleExRCategory = useStore((state) => {
+		return state.toggleExRCategory;
+	});
 
-  const spawnRateOption = category.Options.find((opt) => {
-    return opt.Id === 50;
-  });
-  const spawnCountOption = category.Options.find((opt) => {
-    return opt.Id === 51;
-  });
+	const spawnRateOption = category.Options.find((opt) => {
+		return opt.Id === 50;
+	});
+	const spawnCountOption = category.Options.find((opt) => {
+		return opt.Id === 51;
+	});
 
-  const filteredOptions = category.Options.filter((option) => {
-    if (isPresetOption(category.Id, option.Id)) {
-      return false;
-    }
-    if (option.Id === 50 || option.Id === 51) {
-      return false;
-    }
-    return true;
-  });
+	const filteredOptions = category.Options.filter((option) => {
+		if (isPresetOption(category.Id, option.Id)) {
+			return false;
+		}
+		if (option.Id === 50 || option.Id === 51) {
+			return false;
+		}
+		return true;
+	});
 
-  if (filteredOptions.length === 0) {
-    return null;
-  }
+	if (filteredOptions.length === 0) {
+		return null;
+	}
 
-  return (
-    <div
-      className="border border-gray-700 rounded-lg overflow-hidden mb-2"
-      data-testid={`exr-category-${category.Id}`}
-    >
-      <div className="flex items-center bg-gray-800 hover:bg-gray-700 transition-colors">
-        <button
-          type="button"
-          onClick={() => {
-            toggleExRCategory(category.Id);
-          }}
-          className="flex-1 flex items-center gap-3 p-4 text-left"
-          aria-expanded={isOpen}
-        >
-          <svg
-            className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpen ? 'rotate-180' : ''}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
-          <span className="font-semibold text-gray-200">
-            <ColoredText text={category.Name} />
-          </span>
-        </button>
+	return (
+		<div
+			className="border border-gray-700 rounded-lg overflow-hidden mb-2"
+			data-testid={`exr-category-${category.Id}`}
+		>
+			<div className="flex items-center bg-gray-800 hover:bg-gray-700 transition-colors">
+				<button
+					type="button"
+					onClick={() => {
+						toggleExRCategory(category.Id);
+					}}
+					className="flex-1 flex items-center gap-3 p-4 text-left"
+					aria-expanded={isOpen}
+				>
+					<svg
+						className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpen ? "rotate-180" : ""}`}
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							strokeWidth={2}
+							d="M19 9l-7 7-7-7"
+						/>
+					</svg>
+					<span className="font-semibold text-gray-200">
+						<ColoredText text={category.Name} />
+					</span>
+				</button>
 
-        <div className="flex items-center px-4">
-          {spawnRateOption && spawnCountOption && (
-            <ExRRoleSpawnControls
-              categoryId={category.Id}
-              spawnRateOption={spawnRateOption}
-              spawnCountOption={spawnCountOption}
-            />
-          )}
-        </div>
-      </div>
+				<div className="flex items-center px-4">
+					{spawnRateOption && spawnCountOption && (
+						<ExRRoleSpawnControls
+							categoryId={category.Id}
+							spawnRateOption={spawnRateOption}
+							spawnCountOption={spawnCountOption}
+						/>
+					)}
+				</div>
+			</div>
 
-      <div
-        className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
-          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
-        }`}
-      >
-        <div className="min-h-0">
-          {isOpen && (
-            <div className="p-4 bg-gray-900 border-t border-gray-700">
-              <ExRCategoryOptionList categoryId={category.Id} options={filteredOptions} />
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
+			<div
+				className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
+					isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+				}`}
+			>
+				<div className="min-h-0">
+					{isOpen && (
+						<div className="p-4 bg-gray-900 border-t border-gray-700">
+							<ExRCategoryOptionList
+								categoryId={category.Id}
+								options={filteredOptions}
+							/>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,8 +1,8 @@
 import { useStore } from '../useStore';
 import { ColoredText } from '../components/parts/ColoredText';
 import { ExRCategoryOptionList } from './ExRCategoryOptionList';
-import { ExRHeaderOptionControl } from './ExRHeaderOptionControl';
-import { isPresetOption, getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
+import { ExRRoleSpawnControls } from './ExRRoleSpawnControls';
+import { isPresetOption } from '../logics/optionUtils';
 import type { ExRCategoryDto } from '../type';
 
 interface ExRRoleCategoryItemProps {
@@ -19,9 +19,6 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
   const toggleExRCategory = useStore((state) => {
     return state.toggleExRCategory;
   });
-  const TEMP_updateExROptionSelection = useStore((state) => {
-    return state.TEMP_updateExROptionSelection;
-  });
 
   const spawnRateOption = category.Options.find((opt) => {
     return opt.Id === 50;
@@ -29,62 +26,6 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
   const spawnCountOption = category.Options.find((opt) => {
     return opt.Id === 51;
   });
-
-  const spawnRateSelection = useStore((state) => {
-    const uniqueId = getUniqueOptionId(category.Id, 50);
-    return state.effectiveSelections[uniqueId] ?? spawnRateOption?.Selection ?? 0;
-  });
-
-  const spawnCountSelection = useStore((state) => {
-    const uniqueId = getUniqueOptionId(category.Id, 51);
-    return state.effectiveSelections[uniqueId] ?? spawnCountOption?.Selection ?? 0;
-  });
-
-  // スポーンレートが0のときはスポーン数も0として扱うための仮想的な値リスト
-  const originalSpawnCountValues = (spawnCountOption?.RangeMeta.Values as number[]) ?? [];
-  const virtualSpawnCountValues = [0, ...originalSpawnCountValues];
-
-  // 現在のスポーンレートが0%なら、表示上のスポーン数も0にする
-  const spawnRateValues = (spawnRateOption?.RangeMeta.Values as number[]) ?? [0];
-  const isSpawnRateZero = spawnRateValues[spawnRateSelection] === 0;
-
-  const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
-
-  const handleRateChange = (newSelection: number) => {
-    if (!spawnRateOption) {
-      return;
-    }
-    const uniqueRateId = getUniqueOptionId(category.Id, 50);
-    TEMP_updateExROptionSelection(uniqueRateId, newSelection);
-
-    // スポーンレートを0%にするとスポーン数を0に（内部的にはレートが0なら数も0と見なす）
-    const newRateValue = spawnRateValues[newSelection] ?? 0;
-    if (newRateValue === 0 && spawnCountOption) {
-      const uniqueCountId = getUniqueOptionId(category.Id, 51);
-      // スポーン数を0にする（レート0のときは表示上0になるので、内部値は適当でも良いが、一応最小値にしておく）
-      TEMP_updateExROptionSelection(uniqueCountId, 0);
-    }
-  };
-
-  const handleCountUIChange = (newUISelection: number) => {
-    if (!spawnCountOption || !spawnRateOption) {
-      return;
-    }
-    const uniqueCountId = getUniqueOptionId(category.Id, 51);
-    const uniqueRateId = getUniqueOptionId(category.Id, 50);
-
-    if (newUISelection === 0) {
-      // スポーン数を0へ変更するとスポーンレートが0%へ
-      TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(spawnRateValues, 0));
-      TEMP_updateExROptionSelection(uniqueCountId, 0);
-    } else {
-      // スポーン数を変更（0以外）するとスポーンレートを10％へ（元が0%の場合のみ）
-      if (isSpawnRateZero) {
-        TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(spawnRateValues, 10));
-      }
-      TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
-    }
-  };
 
   const filteredOptions = category.Options.filter((option) => {
     if (isPresetOption(category.Id, option.Id)) {
@@ -132,29 +73,13 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
           </span>
         </button>
 
-        <div className="flex items-center px-4 gap-4">
-          {spawnRateOption && (
-            <div data-testid="spawn-rate-control">
-              <ExRHeaderOptionControl
-                categoryId={category.Id}
-                option={spawnRateOption}
-                label="レート"
-                customSelection={spawnRateSelection}
-                onSelectionChange={handleRateChange}
-              />
-            </div>
-          )}
-          {spawnCountOption && (
-            <div data-testid="spawn-count-control">
-              <ExRHeaderOptionControl
-                categoryId={category.Id}
-                option={spawnCountOption}
-                label="数"
-                customValues={virtualSpawnCountValues}
-                customSelection={currentCountUISelection}
-                onSelectionChange={handleCountUIChange}
-              />
-            </div>
+        <div className="flex items-center px-4">
+          {spawnRateOption && spawnCountOption && (
+            <ExRRoleSpawnControls
+              categoryId={category.Id}
+              spawnRateOption={spawnRateOption}
+              spawnCountOption={spawnCountOption}
+            />
           )}
         </div>
       </div>

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -2,7 +2,7 @@ import { useStore } from '../useStore';
 import { ColoredText } from '../components/parts/ColoredText';
 import { ExRCategoryOptionList } from './ExRCategoryOptionList';
 import { ExRHeaderOptionControl } from './ExRHeaderOptionControl';
-import { isPresetOption, getUniqueOptionId } from '../logics/optionUtils';
+import { isPresetOption, getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
 import type { ExRCategoryDto } from '../type';
 
 interface ExRRoleCategoryItemProps {
@@ -19,6 +19,9 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
   const toggleExRCategory = useStore((state) => {
     return state.toggleExRCategory;
   });
+  const TEMP_updateExROptionSelection = useStore((state) => {
+    return state.TEMP_updateExROptionSelection;
+  });
 
   const spawnRateOption = category.Options.find((opt) => {
     return opt.Id === 50;
@@ -31,6 +34,57 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
     const uniqueId = getUniqueOptionId(category.Id, 50);
     return state.effectiveSelections[uniqueId] ?? spawnRateOption?.Selection ?? 0;
   });
+
+  const spawnCountSelection = useStore((state) => {
+    const uniqueId = getUniqueOptionId(category.Id, 51);
+    return state.effectiveSelections[uniqueId] ?? spawnCountOption?.Selection ?? 0;
+  });
+
+  // スポーンレートが0のときはスポーン数も0として扱うための仮想的な値リスト
+  const originalSpawnCountValues = (spawnCountOption?.RangeMeta.Values as number[]) ?? [];
+  const virtualSpawnCountValues = [0, ...originalSpawnCountValues];
+
+  // 現在のスポーンレートが0%なら、表示上のスポーン数も0にする
+  const spawnRateValues = (spawnRateOption?.RangeMeta.Values as number[]) ?? [0];
+  const isSpawnRateZero = spawnRateValues[spawnRateSelection] === 0;
+
+  const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
+
+  const handleRateChange = (newSelection: number) => {
+    if (!spawnRateOption) {
+      return;
+    }
+    const uniqueRateId = getUniqueOptionId(category.Id, 50);
+    TEMP_updateExROptionSelection(uniqueRateId, newSelection);
+
+    // スポーンレートを0%にするとスポーン数を0に（内部的にはレートが0なら数も0と見なす）
+    const newRateValue = spawnRateValues[newSelection] ?? 0;
+    if (newRateValue === 0 && spawnCountOption) {
+      const uniqueCountId = getUniqueOptionId(category.Id, 51);
+      // スポーン数を0にする（レート0のときは表示上0になるので、内部値は適当でも良いが、一応最小値にしておく）
+      TEMP_updateExROptionSelection(uniqueCountId, 0);
+    }
+  };
+
+  const handleCountUIChange = (newUISelection: number) => {
+    if (!spawnCountOption || !spawnRateOption) {
+      return;
+    }
+    const uniqueCountId = getUniqueOptionId(category.Id, 51);
+    const uniqueRateId = getUniqueOptionId(category.Id, 50);
+
+    if (newUISelection === 0) {
+      // スポーン数を0へ変更するとスポーンレートが0%へ
+      TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(spawnRateValues, 0));
+      TEMP_updateExROptionSelection(uniqueCountId, 0);
+    } else {
+      // スポーン数を変更（0以外）するとスポーンレートを10％へ（元が0%の場合のみ）
+      if (isSpawnRateZero) {
+        TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(spawnRateValues, 10));
+      }
+      TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
+    }
+  };
 
   const filteredOptions = category.Options.filter((option) => {
     if (isPresetOption(category.Id, option.Id)) {
@@ -85,15 +139,20 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
                 categoryId={category.Id}
                 option={spawnRateOption}
                 label="レート"
+                customSelection={spawnRateSelection}
+                onSelectionChange={handleRateChange}
               />
             </div>
           )}
-          {spawnRateSelection >= 1 && spawnCountOption && (
+          {spawnCountOption && (
             <div data-testid="spawn-count-control">
               <ExRHeaderOptionControl
                 categoryId={category.Id}
                 option={spawnCountOption}
                 label="数"
+                customValues={virtualSpawnCountValues}
+                customSelection={currentCountUISelection}
+                onSelectionChange={handleCountUIChange}
               />
             </div>
           )}

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -61,6 +61,7 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 						viewBox="0 0 24 24"
 						stroke="currentColor"
 					>
+						<title>{isOpen ? "Collapse" : "Expand"}</title>
 						<path
 							strokeLinecap="round"
 							strokeLinejoin="round"

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -1,0 +1,96 @@
+import { useStore } from '../useStore';
+import { getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
+import { CompactSlider } from '../components/parts/CompactSlider';
+import type { ExROptionDto } from '../type';
+
+interface ExRRoleSpawnControlsProps {
+  categoryId: number;
+  spawnRateOption: ExROptionDto;
+  spawnCountOption: ExROptionDto;
+}
+
+/**
+ * 役職のスポーンレートとスポーン数をセットで管理し、同期させるためのコンポーネント
+ */
+export function ExRRoleSpawnControls({
+  categoryId,
+  spawnRateOption,
+  spawnCountOption,
+}: ExRRoleSpawnControlsProps) {
+  const uniqueRateId = getUniqueOptionId(categoryId, 50);
+  const uniqueCountId = getUniqueOptionId(categoryId, 51);
+
+  const spawnRateSelection = useStore((state) => {
+    return state.effectiveSelections[uniqueRateId] ?? spawnRateOption.Selection ?? 0;
+  });
+
+  const spawnCountSelection = useStore((state) => {
+    return state.effectiveSelections[uniqueCountId] ?? spawnCountOption.Selection ?? 0;
+  });
+
+  const TEMP_updateExROptionSelection = useStore((state) => {
+    return state.TEMP_updateExROptionSelection;
+  });
+
+  const rateValues = spawnRateOption.RangeMeta.Values as number[];
+  const originalCountValues = spawnCountOption.RangeMeta.Values as number[];
+
+  // スポーン数が0をサポートするための仮想的な値リスト
+  const virtualCountValues = [0, ...originalCountValues];
+
+  // 現在のスポーンレートが0%なら、表示上のスポーン数も強制的に0
+  const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
+  const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
+
+  const handleRateChange = (newSelection: number) => {
+    TEMP_updateExROptionSelection(uniqueRateId, newSelection);
+
+    // スポーンレートが0%なら、スポーン数も0としてリセット
+    if (rateValues[newSelection] === 0) {
+      TEMP_updateExROptionSelection(uniqueCountId, 0);
+    }
+  };
+
+  const handleRateInputChange = (val: number) => {
+    handleRateChange(findClosestIndex(rateValues, val));
+  };
+
+  const handleCountUIChange = (newUISelection: number) => {
+    if (newUISelection === 0) {
+      // 数を0にすると、レートも0%にする
+      TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 0));
+      TEMP_updateExROptionSelection(uniqueCountId, 0);
+    } else {
+      // 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
+      if (isSpawnRateZero) {
+        TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 10));
+      }
+      TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
+    }
+  };
+
+  const handleCountUIInputChange = (val: number) => {
+    handleCountUIChange(findClosestIndex(virtualCountValues, val));
+  };
+
+  return (
+    <div className="flex items-center gap-4">
+      <CompactSlider
+        label="レート"
+        values={rateValues}
+        currentSelection={spawnRateSelection}
+        onSelectionChange={handleRateChange}
+        onInputChange={handleRateInputChange}
+        testId="spawn-rate-control"
+      />
+      <CompactSlider
+        label="数"
+        values={virtualCountValues}
+        currentSelection={currentCountUISelection}
+        onSelectionChange={handleCountUIChange}
+        onInputChange={handleCountUIInputChange}
+        testId="spawn-count-control"
+      />
+    </div>
+  );
+}

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -1,96 +1,108 @@
-import { useStore } from '../useStore';
-import { getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
-import { CompactSlider } from '../components/parts/CompactSlider';
-import type { ExROptionDto } from '../type';
+import { CompactSlider } from "../components/parts/CompactSlider";
+import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
+import type { ExROptionDto } from "../type";
+import { useStore } from "../useStore";
 
 interface ExRRoleSpawnControlsProps {
-  categoryId: number;
-  spawnRateOption: ExROptionDto;
-  spawnCountOption: ExROptionDto;
+	categoryId: number;
+	spawnRateOption: ExROptionDto;
+	spawnCountOption: ExROptionDto;
 }
 
 /**
  * 役職のスポーンレートとスポーン数をセットで管理し、同期させるためのコンポーネント
  */
 export function ExRRoleSpawnControls({
-  categoryId,
-  spawnRateOption,
-  spawnCountOption,
+	categoryId,
+	spawnRateOption,
+	spawnCountOption,
 }: ExRRoleSpawnControlsProps) {
-  const uniqueRateId = getUniqueOptionId(categoryId, 50);
-  const uniqueCountId = getUniqueOptionId(categoryId, 51);
+	const uniqueRateId = getUniqueOptionId(categoryId, 50);
+	const uniqueCountId = getUniqueOptionId(categoryId, 51);
 
-  const spawnRateSelection = useStore((state) => {
-    return state.effectiveSelections[uniqueRateId] ?? spawnRateOption.Selection ?? 0;
-  });
+	const spawnRateSelection = useStore((state) => {
+		return (
+			state.effectiveSelections[uniqueRateId] ?? spawnRateOption.Selection ?? 0
+		);
+	});
 
-  const spawnCountSelection = useStore((state) => {
-    return state.effectiveSelections[uniqueCountId] ?? spawnCountOption.Selection ?? 0;
-  });
+	const spawnCountSelection = useStore((state) => {
+		return (
+			state.effectiveSelections[uniqueCountId] ??
+			spawnCountOption.Selection ??
+			0
+		);
+	});
 
-  const TEMP_updateExROptionSelection = useStore((state) => {
-    return state.TEMP_updateExROptionSelection;
-  });
+	const TEMP_updateExROptionSelection = useStore((state) => {
+		return state.TEMP_updateExROptionSelection;
+	});
 
-  const rateValues = spawnRateOption.RangeMeta.Values as number[];
-  const originalCountValues = spawnCountOption.RangeMeta.Values as number[];
+	const rateValues = spawnRateOption.RangeMeta.Values as number[];
+	const originalCountValues = spawnCountOption.RangeMeta.Values as number[];
 
-  // スポーン数が0をサポートするための仮想的な値リスト
-  const virtualCountValues = [0, ...originalCountValues];
+	// スポーン数が0をサポートするための仮想的な値リスト
+	const virtualCountValues = [0, ...originalCountValues];
 
-  // 現在のスポーンレートが0%なら、表示上のスポーン数も強制的に0
-  const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
-  const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
+	// 現在のスポーンレートが0%なら、表示上のスポーン数も強制的に0
+	const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
+	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
-  const handleRateChange = (newSelection: number) => {
-    TEMP_updateExROptionSelection(uniqueRateId, newSelection);
+	const handleRateChange = (newSelection: number) => {
+		TEMP_updateExROptionSelection(uniqueRateId, newSelection);
 
-    // スポーンレートが0%なら、スポーン数も0としてリセット
-    if (rateValues[newSelection] === 0) {
-      TEMP_updateExROptionSelection(uniqueCountId, 0);
-    }
-  };
+		// スポーンレートが0%なら、スポーン数も0としてリセット
+		if (rateValues[newSelection] === 0) {
+			TEMP_updateExROptionSelection(uniqueCountId, 0);
+		}
+	};
 
-  const handleRateInputChange = (val: number) => {
-    handleRateChange(findClosestIndex(rateValues, val));
-  };
+	const handleRateInputChange = (val: number) => {
+		handleRateChange(findClosestIndex(rateValues, val));
+	};
 
-  const handleCountUIChange = (newUISelection: number) => {
-    if (newUISelection === 0) {
-      // 数を0にすると、レートも0%にする
-      TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 0));
-      TEMP_updateExROptionSelection(uniqueCountId, 0);
-    } else {
-      // 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
-      if (isSpawnRateZero) {
-        TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 10));
-      }
-      TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
-    }
-  };
+	const handleCountUIChange = (newUISelection: number) => {
+		if (newUISelection === 0) {
+			// 数を0にすると、レートも0%にする
+			TEMP_updateExROptionSelection(
+				uniqueRateId,
+				findClosestIndex(rateValues, 0),
+			);
+			TEMP_updateExROptionSelection(uniqueCountId, 0);
+		} else {
+			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
+			if (isSpawnRateZero) {
+				TEMP_updateExROptionSelection(
+					uniqueRateId,
+					findClosestIndex(rateValues, 10),
+				);
+			}
+			TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
+		}
+	};
 
-  const handleCountUIInputChange = (val: number) => {
-    handleCountUIChange(findClosestIndex(virtualCountValues, val));
-  };
+	const handleCountUIInputChange = (val: number) => {
+		handleCountUIChange(findClosestIndex(virtualCountValues, val));
+	};
 
-  return (
-    <div className="flex items-center gap-4">
-      <CompactSlider
-        label="レート"
-        values={rateValues}
-        currentSelection={spawnRateSelection}
-        onSelectionChange={handleRateChange}
-        onInputChange={handleRateInputChange}
-        testId="spawn-rate-control"
-      />
-      <CompactSlider
-        label="数"
-        values={virtualCountValues}
-        currentSelection={currentCountUISelection}
-        onSelectionChange={handleCountUIChange}
-        onInputChange={handleCountUIInputChange}
-        testId="spawn-count-control"
-      />
-    </div>
-  );
+	return (
+		<div className="flex items-center gap-4">
+			<CompactSlider
+				label="レート"
+				values={rateValues}
+				currentSelection={spawnRateSelection}
+				onSelectionChange={handleRateChange}
+				onInputChange={handleRateInputChange}
+				testId="spawn-rate-control"
+			/>
+			<CompactSlider
+				label="数"
+				values={virtualCountValues}
+				currentSelection={currentCountUISelection}
+				onSelectionChange={handleCountUIChange}
+				onInputChange={handleCountUIInputChange}
+				testId="spawn-count-control"
+			/>
+		</div>
+	);
 }

--- a/src/feature/ExRStandardCategoryItem.tsx
+++ b/src/feature/ExRStandardCategoryItem.tsx
@@ -1,43 +1,9 @@
 import { useStore } from '../useStore';
 import { Accordion } from '../components/parts/Accordion';
 import { ColoredText } from '../components/parts/ColoredText';
-import { ExROptionItem } from './ExROptionItem';
-import { ExRPairedOptionRow } from './ExRPairedOptionRow';
-import { isPresetOption, groupOptionPairs } from '../logics/optionUtils';
-import type { ExRCategoryDto, ExROptionDto } from '../type';
-
-const GROUPED_CATEGORY_IDS = [5, 6];
-
-interface ExRCategoryOptionListProps {
-  categoryId: number;
-  options: ExROptionDto[];
-}
-
-function ExRCategoryOptionList({ categoryId, options }: ExRCategoryOptionListProps) {
-  const shouldGroup = GROUPED_CATEGORY_IDS.includes(categoryId);
-  const groupedItems = shouldGroup ? groupOptionPairs(options) : options;
-
-  return (
-    <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-      {groupedItems.map((item, idx) => {
-        if ('type' in item && item.type === 'pair') {
-          return (
-            <ExRPairedOptionRow
-              key={`pair-${idx}`}
-              categoryId={categoryId}
-              baseName={item.baseName}
-              min={item.min}
-              max={item.max}
-              minLabel={item.minLabel}
-              maxLabel={item.maxLabel}
-            />
-          );
-        }
-        return <ExROptionItem key={item.Id} categoryId={categoryId} option={item} />;
-      })}
-    </div>
-  );
-}
+import { ExRCategoryOptionList } from './ExRCategoryOptionList';
+import { isPresetOption } from '../logics/optionUtils';
+import type { ExRCategoryDto } from '../type';
 
 interface ExRStandardCategoryItemProps {
   category: ExRCategoryDto;

--- a/src/feature/ExRStandardCategoryItem.tsx
+++ b/src/feature/ExRStandardCategoryItem.tsx
@@ -1,0 +1,76 @@
+import { useStore } from '../useStore';
+import { Accordion } from '../components/parts/Accordion';
+import { ColoredText } from '../components/parts/ColoredText';
+import { ExROptionItem } from './ExROptionItem';
+import { ExRPairedOptionRow } from './ExRPairedOptionRow';
+import { isPresetOption, groupOptionPairs } from '../logics/optionUtils';
+import type { ExRCategoryDto, ExROptionDto } from '../type';
+
+const GROUPED_CATEGORY_IDS = [5, 6];
+
+interface ExRCategoryOptionListProps {
+  categoryId: number;
+  options: ExROptionDto[];
+}
+
+function ExRCategoryOptionList({ categoryId, options }: ExRCategoryOptionListProps) {
+  const shouldGroup = GROUPED_CATEGORY_IDS.includes(categoryId);
+  const groupedItems = shouldGroup ? groupOptionPairs(options) : options;
+
+  return (
+    <div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
+      {groupedItems.map((item, idx) => {
+        if ('type' in item && item.type === 'pair') {
+          return (
+            <ExRPairedOptionRow
+              key={`pair-${idx}`}
+              categoryId={categoryId}
+              baseName={item.baseName}
+              min={item.min}
+              max={item.max}
+              minLabel={item.minLabel}
+              maxLabel={item.maxLabel}
+            />
+          );
+        }
+        return <ExROptionItem key={item.Id} categoryId={categoryId} option={item} />;
+      })}
+    </div>
+  );
+}
+
+interface ExRStandardCategoryItemProps {
+  category: ExRCategoryDto;
+}
+
+/**
+ * 全般タブなどで使用される標準的なカテゴリ表示コンポーネント
+ */
+export function ExRStandardCategoryItem({ category }: ExRStandardCategoryItemProps) {
+  const isOpen = useStore((state) => {
+    return state.openedExRCategoryIds[category.Id] ?? false;
+  });
+  const toggleExRCategory = useStore((state) => {
+    return state.toggleExRCategory;
+  });
+
+  const filteredOptions = category.Options.filter((option) => {
+    return !isPresetOption(category.Id, option.Id);
+  });
+
+  if (filteredOptions.length === 0) {
+    return null;
+  }
+
+  return (
+    <Accordion
+      title={<ColoredText text={category.Name} />}
+      isOpen={isOpen}
+      onToggle={() => {
+        toggleExRCategory(category.Id);
+      }}
+    >
+      <ExRCategoryOptionList categoryId={category.Id} options={filteredOptions} />
+    </Accordion>
+  );
+}

--- a/src/feature/ExRStandardCategoryItem.tsx
+++ b/src/feature/ExRStandardCategoryItem.tsx
@@ -29,14 +29,16 @@ export function ExRStandardCategoryItem({ category }: ExRStandardCategoryItemPro
   }
 
   return (
-    <Accordion
-      title={<ColoredText text={category.Name} />}
-      isOpen={isOpen}
-      onToggle={() => {
-        toggleExRCategory(category.Id);
-      }}
-    >
-      <ExRCategoryOptionList categoryId={category.Id} options={filteredOptions} />
-    </Accordion>
+    <div data-testid={`exr-category-${category.Id}`}>
+      <Accordion
+        title={<ColoredText text={category.Name} />}
+        isOpen={isOpen}
+        onToggle={() => {
+          toggleExRCategory(category.Id);
+        }}
+      >
+        <ExRCategoryOptionList categoryId={category.Id} options={filteredOptions} />
+      </Accordion>
+    </div>
   );
 }

--- a/src/feature/ExRStandardCategoryItem.tsx
+++ b/src/feature/ExRStandardCategoryItem.tsx
@@ -1,44 +1,49 @@
-import { useStore } from '../useStore';
-import { Accordion } from '../components/parts/Accordion';
-import { ColoredText } from '../components/parts/ColoredText';
-import { ExRCategoryOptionList } from './ExRCategoryOptionList';
-import { isPresetOption } from '../logics/optionUtils';
-import type { ExRCategoryDto } from '../type';
+import { Accordion } from "../components/parts/Accordion";
+import { ColoredText } from "../components/parts/ColoredText";
+import { isPresetOption } from "../logics/optionUtils";
+import type { ExRCategoryDto } from "../type";
+import { useStore } from "../useStore";
+import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
 
 interface ExRStandardCategoryItemProps {
-  category: ExRCategoryDto;
+	category: ExRCategoryDto;
 }
 
 /**
  * 全般タブなどで使用される標準的なカテゴリ表示コンポーネント
  */
-export function ExRStandardCategoryItem({ category }: ExRStandardCategoryItemProps) {
-  const isOpen = useStore((state) => {
-    return state.openedExRCategoryIds[category.Id] ?? false;
-  });
-  const toggleExRCategory = useStore((state) => {
-    return state.toggleExRCategory;
-  });
+export function ExRStandardCategoryItem({
+	category,
+}: ExRStandardCategoryItemProps) {
+	const isOpen = useStore((state) => {
+		return state.openedExRCategoryIds[category.Id] ?? false;
+	});
+	const toggleExRCategory = useStore((state) => {
+		return state.toggleExRCategory;
+	});
 
-  const filteredOptions = category.Options.filter((option) => {
-    return !isPresetOption(category.Id, option.Id);
-  });
+	const filteredOptions = category.Options.filter((option) => {
+		return !isPresetOption(category.Id, option.Id);
+	});
 
-  if (filteredOptions.length === 0) {
-    return null;
-  }
+	if (filteredOptions.length === 0) {
+		return null;
+	}
 
-  return (
-    <div data-testid={`exr-category-${category.Id}`}>
-      <Accordion
-        title={<ColoredText text={category.Name} />}
-        isOpen={isOpen}
-        onToggle={() => {
-          toggleExRCategory(category.Id);
-        }}
-      >
-        <ExRCategoryOptionList categoryId={category.Id} options={filteredOptions} />
-      </Accordion>
-    </div>
-  );
+	return (
+		<div data-testid={`exr-category-${category.Id}`}>
+			<Accordion
+				title={<ColoredText text={category.Name} />}
+				isOpen={isOpen}
+				onToggle={() => {
+					toggleExRCategory(category.Id);
+				}}
+			>
+				<ExRCategoryOptionList
+					categoryId={category.Id}
+					options={filteredOptions}
+				/>
+			</Accordion>
+		</div>
+	);
 }

--- a/tests/CompactSlider.test.tsx
+++ b/tests/CompactSlider.test.tsx
@@ -44,9 +44,14 @@ describe("CompactSlider", () => {
 	it("stops event propagation on click", () => {
 		const parentClick = vi.fn();
 		render(
-			<div onClick={parentClick}>
+			<button
+				type="button"
+				onClick={parentClick}
+				onKeyDown={parentClick}
+				aria-label="parent"
+			>
 				<CompactSlider {...defaultProps} />
-			</div>,
+			</button>,
 		);
 
 		fireEvent.click(screen.getByText("Test Label"));
@@ -56,9 +61,9 @@ describe("CompactSlider", () => {
 	it("stops event propagation on slider change", () => {
 		const parentChange = vi.fn();
 		render(
-			<div onChange={parentChange}>
+			<form onChange={parentChange}>
 				<CompactSlider {...defaultProps} />
-			</div>,
+			</form>,
 		);
 
 		fireEvent.change(screen.getByRole("slider"), { target: { value: "0" } });

--- a/tests/CompactSlider.test.tsx
+++ b/tests/CompactSlider.test.tsx
@@ -1,65 +1,67 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { CompactSlider } from '../src/components/parts/CompactSlider';
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CompactSlider } from "../src/components/parts/CompactSlider";
 
-describe('CompactSlider', () => {
-  const defaultProps = {
-    label: 'Test Label',
-    values: [0, 10, 20],
-    currentSelection: 1,
-    onSelectionChange: vi.fn(),
-    onInputChange: vi.fn(),
-  };
+describe("CompactSlider", () => {
+	const defaultProps = {
+		label: "Test Label",
+		values: [0, 10, 20],
+		currentSelection: 1,
+		onSelectionChange: vi.fn(),
+		onInputChange: vi.fn(),
+	};
 
-  it('renders label and current value correctly', () => {
-    render(<CompactSlider {...defaultProps} />);
+	it("renders label and current value correctly", () => {
+		render(<CompactSlider {...defaultProps} />);
 
-    expect(screen.getByText('Test Label')).toBeInTheDocument();
-    expect(screen.getByRole('slider')).toHaveValue('1');
-    expect(screen.getByDisplayValue('10')).toBeInTheDocument();
-  });
+		expect(screen.getByText("Test Label")).toBeInTheDocument();
+		expect(screen.getByRole("slider")).toHaveValue("1");
+		expect(screen.getByDisplayValue("10")).toBeInTheDocument();
+	});
 
-  it('calls onSelectionChange when slider is moved', () => {
-    const onSelectionChange = vi.fn();
-    render(<CompactSlider {...defaultProps} onSelectionChange={onSelectionChange} />);
+	it("calls onSelectionChange when slider is moved", () => {
+		const onSelectionChange = vi.fn();
+		render(
+			<CompactSlider {...defaultProps} onSelectionChange={onSelectionChange} />,
+		);
 
-    const slider = screen.getByRole('slider');
-    fireEvent.change(slider, { target: { value: '2' } });
+		const slider = screen.getByRole("slider");
+		fireEvent.change(slider, { target: { value: "2" } });
 
-    expect(onSelectionChange).toHaveBeenCalledWith(2);
-  });
+		expect(onSelectionChange).toHaveBeenCalledWith(2);
+	});
 
-  it('calls onInputChange when text input is changed', () => {
-    const onInputChange = vi.fn();
-    render(<CompactSlider {...defaultProps} onInputChange={onInputChange} />);
+	it("calls onInputChange when text input is changed", () => {
+		const onInputChange = vi.fn();
+		render(<CompactSlider {...defaultProps} onInputChange={onInputChange} />);
 
-    const input = screen.getByDisplayValue('10');
-    fireEvent.change(input, { target: { value: '20' } });
+		const input = screen.getByDisplayValue("10");
+		fireEvent.change(input, { target: { value: "20" } });
 
-    expect(onInputChange).toHaveBeenCalledWith(20);
-  });
+		expect(onInputChange).toHaveBeenCalledWith(20);
+	});
 
-  it('stops event propagation on click', () => {
-    const parentClick = vi.fn();
-    render(
-      <div onClick={parentClick}>
-        <CompactSlider {...defaultProps} />
-      </div>
-    );
+	it("stops event propagation on click", () => {
+		const parentClick = vi.fn();
+		render(
+			<div onClick={parentClick}>
+				<CompactSlider {...defaultProps} />
+			</div>,
+		);
 
-    fireEvent.click(screen.getByText('Test Label'));
-    expect(parentClick).not.toHaveBeenCalled();
-  });
+		fireEvent.click(screen.getByText("Test Label"));
+		expect(parentClick).not.toHaveBeenCalled();
+	});
 
-  it('stops event propagation on slider change', () => {
-    const parentChange = vi.fn();
-    render(
-      <div onChange={parentChange}>
-        <CompactSlider {...defaultProps} />
-      </div>
-    );
+	it("stops event propagation on slider change", () => {
+		const parentChange = vi.fn();
+		render(
+			<div onChange={parentChange}>
+				<CompactSlider {...defaultProps} />
+			</div>,
+		);
 
-    fireEvent.change(screen.getByRole('slider'), { target: { value: '0' } });
-    expect(parentChange).not.toHaveBeenCalled();
-  });
+		fireEvent.change(screen.getByRole("slider"), { target: { value: "0" } });
+		expect(parentChange).not.toHaveBeenCalled();
+	});
 });

--- a/tests/CompactSlider.test.tsx
+++ b/tests/CompactSlider.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CompactSlider } from '../src/components/parts/CompactSlider';
+
+describe('CompactSlider', () => {
+  const defaultProps = {
+    label: 'Test Label',
+    values: [0, 10, 20],
+    currentSelection: 1,
+    onSelectionChange: vi.fn(),
+    onInputChange: vi.fn(),
+  };
+
+  it('renders label and current value correctly', () => {
+    render(<CompactSlider {...defaultProps} />);
+
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByRole('slider')).toHaveValue('1');
+    expect(screen.getByDisplayValue('10')).toBeInTheDocument();
+  });
+
+  it('calls onSelectionChange when slider is moved', () => {
+    const onSelectionChange = vi.fn();
+    render(<CompactSlider {...defaultProps} onSelectionChange={onSelectionChange} />);
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '2' } });
+
+    expect(onSelectionChange).toHaveBeenCalledWith(2);
+  });
+
+  it('calls onInputChange when text input is changed', () => {
+    const onInputChange = vi.fn();
+    render(<CompactSlider {...defaultProps} onInputChange={onInputChange} />);
+
+    const input = screen.getByDisplayValue('10');
+    fireEvent.change(input, { target: { value: '20' } });
+
+    expect(onInputChange).toHaveBeenCalledWith(20);
+  });
+
+  it('stops event propagation on click', () => {
+    const parentClick = vi.fn();
+    render(
+      <div onClick={parentClick}>
+        <CompactSlider {...defaultProps} />
+      </div>
+    );
+
+    fireEvent.click(screen.getByText('Test Label'));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('stops event propagation on slider change', () => {
+    const parentChange = vi.fn();
+    render(
+      <div onChange={parentChange}>
+        <CompactSlider {...defaultProps} />
+      </div>
+    );
+
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '0' } });
+    expect(parentChange).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExRCategoryList } from '../src/feature/ExRCategoryList';
+import { OptionTab, type ExRTabDto } from '../src/type';
+import { useStore } from '../src/useStore';
+
+describe('ExRCategoryList Component Selection', () => {
+  const mockTabs: ExRTabDto[] = [
+    {
+      Id: OptionTab.GeneralTab, // Tab 0
+      Name: 'General',
+      Categories: [
+        {
+          Id: 1,
+          Name: 'General Category',
+          Options: [
+            {
+              Id: 101,
+              IsActive: true,
+              TranslatedName: 'General Option',
+              Selection: 0,
+              Format: '{0}',
+              RangeMeta: { Type: 'Int32', Values: [0, 1] },
+              Childs: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      Id: OptionTab.CrewmateTab, // Tab 1
+      Name: 'Crewmate',
+      Categories: [
+        {
+          Id: 2,
+          Name: 'Sheriff',
+          Options: [
+            {
+              Id: 50,
+              IsActive: true,
+              TranslatedName: 'Spawn Rate',
+              Selection: 0,
+              Format: '{0}',
+              RangeMeta: { Type: 'Int32', Values: [0, 100] },
+              Childs: [],
+            },
+            {
+              Id: 51,
+              IsActive: true,
+              TranslatedName: 'Spawn Count',
+              Selection: 0,
+              Format: '{0}',
+              RangeMeta: { Type: 'Int32', Values: [0, 1] },
+              Childs: [],
+            },
+            {
+              Id: 201,
+              IsActive: true,
+              TranslatedName: 'Kill CD',
+              Selection: 0,
+              Format: '{0}',
+              RangeMeta: { Type: 'Int32', Values: [10, 20] },
+              Childs: [],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    useStore.getState().resetViewer();
+  });
+
+  it('renders ExRStandardCategoryItem for General Tab', () => {
+    useStore.getState().setSelectedExRTabId(OptionTab.GeneralTab);
+    render(<ExRCategoryList tabs={mockTabs} />);
+
+    // General Tab: Should render standard category
+    expect(screen.getByText('General Category')).toBeInTheDocument();
+
+    // Header should NOT have spawn controls
+    expect(screen.queryByText('レート')).not.toBeInTheDocument();
+  });
+
+  it('renders ExRRoleCategoryItem for Role Tab', () => {
+    useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
+    render(<ExRCategoryList tabs={mockTabs} />);
+
+    // Role Tab: Should render specialized category item
+    expect(screen.getByText('Sheriff')).toBeInTheDocument();
+
+    // Header should have spawn rate control (レート)
+    expect(screen.getByText('レート')).toBeInTheDocument();
+  });
+
+  it('filters out 50 and 51 from role category body', () => {
+    useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
+    render(<ExRCategoryList tabs={mockTabs} />);
+
+    // Open accordion - RoleCategoryItem uses a custom layout,
+    // we find the toggle button by role.
+    const toggleButton = screen.getByRole('button', { name: /Sheriff/i });
+    fireEvent.click(toggleButton);
+
+    // Body content should be visible after click
+    // ExRRoleCategoryItem renders options list when isOpen is true
+    expect(screen.getByText('Kill CD')).toBeInTheDocument();
+
+    // 50 and 51 should be filtered out from the body
+    expect(screen.queryByText('Spawn Rate')).not.toBeInTheDocument();
+    expect(screen.queryByText('Spawn Count')).not.toBeInTheDocument();
+  });
+});

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -1,114 +1,114 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { ExRCategoryList } from '../src/feature/ExRCategoryList';
-import { OptionTab, type ExRTabDto } from '../src/type';
-import { useStore } from '../src/useStore';
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ExRCategoryList } from "../src/feature/ExRCategoryList";
+import { type ExRTabDto, OptionTab } from "../src/type";
+import { useStore } from "../src/useStore";
 
-describe('ExRCategoryList Component Selection', () => {
-  const mockTabs: ExRTabDto[] = [
-    {
-      Id: OptionTab.GeneralTab, // Tab 0
-      Name: 'General',
-      Categories: [
-        {
-          Id: 1,
-          Name: 'General Category',
-          Options: [
-            {
-              Id: 101,
-              IsActive: true,
-              TranslatedName: 'General Option',
-              Selection: 0,
-              Format: '{0}',
-              RangeMeta: { Type: 'Int32', Values: [0, 1] },
-              Childs: [],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      Id: OptionTab.CrewmateTab, // Tab 1
-      Name: 'Crewmate',
-      Categories: [
-        {
-          Id: 2,
-          Name: 'Sheriff',
-          Options: [
-            {
-              Id: 50,
-              IsActive: true,
-              TranslatedName: 'Spawn Rate',
-              Selection: 0,
-              Format: '{0}',
-              RangeMeta: { Type: 'Int32', Values: [0, 100] },
-              Childs: [],
-            },
-            {
-              Id: 51,
-              IsActive: true,
-              TranslatedName: 'Spawn Count',
-              Selection: 0,
-              Format: '{0}',
-              RangeMeta: { Type: 'Int32', Values: [0, 1] },
-              Childs: [],
-            },
-            {
-              Id: 201,
-              IsActive: true,
-              TranslatedName: 'Kill CD',
-              Selection: 0,
-              Format: '{0}',
-              RangeMeta: { Type: 'Int32', Values: [10, 20] },
-              Childs: [],
-            },
-          ],
-        },
-      ],
-    },
-  ];
+describe("ExRCategoryList Component Selection", () => {
+	const mockTabs: ExRTabDto[] = [
+		{
+			Id: OptionTab.GeneralTab, // Tab 0
+			Name: "General",
+			Categories: [
+				{
+					Id: 1,
+					Name: "General Category",
+					Options: [
+						{
+							Id: 101,
+							IsActive: true,
+							TranslatedName: "General Option",
+							Selection: 0,
+							Format: "{0}",
+							RangeMeta: { Type: "Int32", Values: [0, 1] },
+							Childs: [],
+						},
+					],
+				},
+			],
+		},
+		{
+			Id: OptionTab.CrewmateTab, // Tab 1
+			Name: "Crewmate",
+			Categories: [
+				{
+					Id: 2,
+					Name: "Sheriff",
+					Options: [
+						{
+							Id: 50,
+							IsActive: true,
+							TranslatedName: "Spawn Rate",
+							Selection: 0,
+							Format: "{0}",
+							RangeMeta: { Type: "Int32", Values: [0, 100] },
+							Childs: [],
+						},
+						{
+							Id: 51,
+							IsActive: true,
+							TranslatedName: "Spawn Count",
+							Selection: 0,
+							Format: "{0}",
+							RangeMeta: { Type: "Int32", Values: [0, 1] },
+							Childs: [],
+						},
+						{
+							Id: 201,
+							IsActive: true,
+							TranslatedName: "Kill CD",
+							Selection: 0,
+							Format: "{0}",
+							RangeMeta: { Type: "Int32", Values: [10, 20] },
+							Childs: [],
+						},
+					],
+				},
+			],
+		},
+	];
 
-  beforeEach(() => {
-    useStore.getState().resetViewer();
-  });
+	beforeEach(() => {
+		useStore.getState().resetViewer();
+	});
 
-  it('renders ExRStandardCategoryItem for General Tab', () => {
-    useStore.getState().setSelectedExRTabId(OptionTab.GeneralTab);
-    render(<ExRCategoryList tabs={mockTabs} />);
+	it("renders ExRStandardCategoryItem for General Tab", () => {
+		useStore.getState().setSelectedExRTabId(OptionTab.GeneralTab);
+		render(<ExRCategoryList tabs={mockTabs} />);
 
-    // General Tab: Should render standard category
-    expect(screen.getByText('General Category')).toBeInTheDocument();
+		// General Tab: Should render standard category
+		expect(screen.getByText("General Category")).toBeInTheDocument();
 
-    // Header should NOT have spawn controls
-    expect(screen.queryByText('レート')).not.toBeInTheDocument();
-  });
+		// Header should NOT have spawn controls
+		expect(screen.queryByText("レート")).not.toBeInTheDocument();
+	});
 
-  it('renders ExRRoleCategoryItem for Role Tab', () => {
-    useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
-    render(<ExRCategoryList tabs={mockTabs} />);
+	it("renders ExRRoleCategoryItem for Role Tab", () => {
+		useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
+		render(<ExRCategoryList tabs={mockTabs} />);
 
-    // Role Tab: Should render specialized category item
-    expect(screen.getByText('Sheriff')).toBeInTheDocument();
+		// Role Tab: Should render specialized category item
+		expect(screen.getByText("Sheriff")).toBeInTheDocument();
 
-    // Header should have spawn rate control (レート)
-    expect(screen.getByText('レート')).toBeInTheDocument();
-  });
+		// Header should have spawn rate control (レート)
+		expect(screen.getByText("レート")).toBeInTheDocument();
+	});
 
-  it('filters out 50 and 51 from role category body', () => {
-    useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
-    render(<ExRCategoryList tabs={mockTabs} />);
+	it("filters out 50 and 51 from role category body", () => {
+		useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
+		render(<ExRCategoryList tabs={mockTabs} />);
 
-    // Open accordion - RoleCategoryItem uses a custom layout,
-    // we find the toggle button by role.
-    const toggleButton = screen.getByRole('button', { name: /Sheriff/i });
-    fireEvent.click(toggleButton);
+		// Open accordion - RoleCategoryItem uses a custom layout,
+		// we find the toggle button by role.
+		const toggleButton = screen.getByRole("button", { name: /Sheriff/i });
+		fireEvent.click(toggleButton);
 
-    // Body content should be visible after click
-    // ExRRoleCategoryItem renders options list when isOpen is true
-    expect(screen.getByText('Kill CD')).toBeInTheDocument();
+		// Body content should be visible after click
+		// ExRRoleCategoryItem renders options list when isOpen is true
+		expect(screen.getByText("Kill CD")).toBeInTheDocument();
 
-    // 50 and 51 should be filtered out from the body
-    expect(screen.queryByText('Spawn Rate')).not.toBeInTheDocument();
-    expect(screen.queryByText('Spawn Count')).not.toBeInTheDocument();
-  });
+		// 50 and 51 should be filtered out from the body
+		expect(screen.queryByText("Spawn Rate")).not.toBeInTheDocument();
+		expect(screen.queryByText("Spawn Count")).not.toBeInTheDocument();
+	});
 });

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExRHeaderOptionControl } from '../src/feature/ExRHeaderOptionControl';
+import { useStore } from '../src/useStore';
+import type { ExROptionDto } from '../src/type';
+
+describe('ExRHeaderOptionControl', () => {
+  const mockOption: ExROptionDto = {
+    Id: 50,
+    IsActive: true,
+    TranslatedName: 'レート',
+    Selection: 0,
+    Format: '{0}%',
+    RangeMeta: { Type: 'Int32', Values: [0, 50, 100] },
+    Childs: [],
+  };
+
+  beforeEach(() => {
+    useStore.getState().resetViewer();
+  });
+
+  it('renders correctly with given label and value', () => {
+    render(
+      <ExRHeaderOptionControl
+        categoryId={1}
+        option={mockOption}
+        label="Rate"
+      />
+    );
+
+    expect(screen.getByText('Rate')).toBeInTheDocument();
+    expect(screen.getByRole('slider')).toHaveValue('0');
+
+    const inputs = screen.getAllByDisplayValue('0');
+    const textInput = inputs.find(i => (i as HTMLInputElement).type === 'text');
+    expect(textInput).toBeInTheDocument();
+  });
+
+  it('updates selection when slider is moved', () => {
+    render(
+      <ExRHeaderOptionControl
+        categoryId={1}
+        option={mockOption}
+        label="Rate"
+      />
+    );
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '1' } });
+
+    // Check if store was updated
+    const state = useStore.getState();
+    expect(state.effectiveSelections['1-50']).toBe(1);
+  });
+
+  it('updates selection when input is changed', () => {
+    render(
+      <ExRHeaderOptionControl
+        categoryId={1}
+        option={mockOption}
+        label="Rate"
+      />
+    );
+
+    const inputs = screen.getAllByDisplayValue('0');
+    const textInput = inputs.find(i => (i as HTMLInputElement).type === 'text')!;
+
+    fireEvent.change(textInput, { target: { value: '100' } });
+
+    const state = useStore.getState();
+    expect(state.effectiveSelections['1-50']).toBe(2); // 100 is at index 2
+  });
+
+  it('prevents click propagation to parent', () => {
+    const parentClick = vi.fn();
+    render(
+      <div onClick={parentClick}>
+        <ExRHeaderOptionControl
+          categoryId={1}
+          option={mockOption}
+          label="Rate"
+        />
+      </div>
+    );
+
+    const label = screen.getByText('Rate');
+    fireEvent.click(label);
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -1,91 +1,95 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { ExRHeaderOptionControl } from '../src/feature/ExRHeaderOptionControl';
-import { useStore } from '../src/useStore';
-import type { ExROptionDto } from '../src/type';
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
+import type { ExROptionDto } from "../src/type";
+import { useStore } from "../src/useStore";
 
-describe('ExRHeaderOptionControl', () => {
-  const mockOption: ExROptionDto = {
-    Id: 50,
-    IsActive: true,
-    TranslatedName: 'レート',
-    Selection: 0,
-    Format: '{0}%',
-    RangeMeta: { Type: 'Int32', Values: [0, 50, 100] },
-    Childs: [],
-  };
+describe("ExRHeaderOptionControl", () => {
+	const mockOption: ExROptionDto = {
+		Id: 50,
+		IsActive: true,
+		TranslatedName: "レート",
+		Selection: 0,
+		Format: "{0}%",
+		RangeMeta: { Type: "Int32", Values: [0, 50, 100] },
+		Childs: [],
+	};
 
-  beforeEach(() => {
-    useStore.getState().resetViewer();
-  });
+	beforeEach(() => {
+		useStore.getState().resetViewer();
+	});
 
-  it('renders correctly with given label and value', () => {
-    render(
-      <ExRHeaderOptionControl
-        categoryId={1}
-        option={mockOption}
-        label="Rate"
-      />
-    );
+	it("renders correctly with given label and value", () => {
+		render(
+			<ExRHeaderOptionControl
+				categoryId={1}
+				option={mockOption}
+				label="Rate"
+			/>,
+		);
 
-    expect(screen.getByText('Rate')).toBeInTheDocument();
-    expect(screen.getByRole('slider')).toHaveValue('0');
+		expect(screen.getByText("Rate")).toBeInTheDocument();
+		expect(screen.getByRole("slider")).toHaveValue("0");
 
-    const inputs = screen.getAllByDisplayValue('0');
-    const textInput = inputs.find(i => (i as HTMLInputElement).type === 'text');
-    expect(textInput).toBeInTheDocument();
-  });
+		const inputs = screen.getAllByDisplayValue("0");
+		const textInput = inputs.find(
+			(i) => (i as HTMLInputElement).type === "text",
+		);
+		expect(textInput).toBeInTheDocument();
+	});
 
-  it('updates selection when slider is moved', () => {
-    render(
-      <ExRHeaderOptionControl
-        categoryId={1}
-        option={mockOption}
-        label="Rate"
-      />
-    );
+	it("updates selection when slider is moved", () => {
+		render(
+			<ExRHeaderOptionControl
+				categoryId={1}
+				option={mockOption}
+				label="Rate"
+			/>,
+		);
 
-    const slider = screen.getByRole('slider');
-    fireEvent.change(slider, { target: { value: '1' } });
+		const slider = screen.getByRole("slider");
+		fireEvent.change(slider, { target: { value: "1" } });
 
-    // Check if store was updated
-    const state = useStore.getState();
-    expect(state.effectiveSelections['1-50']).toBe(1);
-  });
+		// Check if store was updated
+		const state = useStore.getState();
+		expect(state.effectiveSelections["1-50"]).toBe(1);
+	});
 
-  it('updates selection when input is changed', () => {
-    render(
-      <ExRHeaderOptionControl
-        categoryId={1}
-        option={mockOption}
-        label="Rate"
-      />
-    );
+	it("updates selection when input is changed", () => {
+		render(
+			<ExRHeaderOptionControl
+				categoryId={1}
+				option={mockOption}
+				label="Rate"
+			/>,
+		);
 
-    const inputs = screen.getAllByDisplayValue('0');
-    const textInput = inputs.find(i => (i as HTMLInputElement).type === 'text')!;
+		const inputs = screen.getAllByDisplayValue("0");
+		const textInput = inputs.find(
+			(i) => (i as HTMLInputElement).type === "text",
+		)!;
 
-    fireEvent.change(textInput, { target: { value: '100' } });
+		fireEvent.change(textInput, { target: { value: "100" } });
 
-    const state = useStore.getState();
-    expect(state.effectiveSelections['1-50']).toBe(2); // 100 is at index 2
-  });
+		const state = useStore.getState();
+		expect(state.effectiveSelections["1-50"]).toBe(2); // 100 is at index 2
+	});
 
-  it('prevents click propagation to parent', () => {
-    const parentClick = vi.fn();
-    render(
-      <div onClick={parentClick}>
-        <ExRHeaderOptionControl
-          categoryId={1}
-          option={mockOption}
-          label="Rate"
-        />
-      </div>
-    );
+	it("prevents click propagation to parent", () => {
+		const parentClick = vi.fn();
+		render(
+			<div onClick={parentClick}>
+				<ExRHeaderOptionControl
+					categoryId={1}
+					option={mockOption}
+					label="Rate"
+				/>
+			</div>,
+		);
 
-    const label = screen.getByText('Rate');
-    fireEvent.click(label);
+		const label = screen.getByText("Rate");
+		fireEvent.click(label);
 
-    expect(parentClick).not.toHaveBeenCalled();
-  });
+		expect(parentClick).not.toHaveBeenCalled();
+	});
 });

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -67,7 +67,10 @@ describe("ExRHeaderOptionControl", () => {
 		const inputs = screen.getAllByDisplayValue("0");
 		const textInput = inputs.find(
 			(i) => (i as HTMLInputElement).type === "text",
-		)!;
+		);
+		if (!textInput) {
+			throw new Error("Text input not found");
+		}
 
 		fireEvent.change(textInput, { target: { value: "100" } });
 
@@ -78,13 +81,18 @@ describe("ExRHeaderOptionControl", () => {
 	it("prevents click propagation to parent", () => {
 		const parentClick = vi.fn();
 		render(
-			<div onClick={parentClick}>
+			<button
+				type="button"
+				onClick={parentClick}
+				onKeyDown={parentClick}
+				aria-label="parent"
+			>
 				<ExRHeaderOptionControl
 					categoryId={1}
 					option={mockOption}
 					label="Rate"
 				/>
-			</div>,
+			</button>,
 		);
 
 		const label = screen.getByText("Rate");

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,125 +1,135 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { ExRRoleSpawnControls } from '../src/feature/ExRRoleSpawnControls';
-import { useStore } from '../src/useStore';
-import type { ExROptionDto } from '../src/type';
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
+import type { ExROptionDto } from "../src/type";
+import { useStore } from "../src/useStore";
 
-describe('ExRRoleSpawnControls', () => {
-  const spawnRateOption: ExROptionDto = {
-    Id: 50,
-    IsActive: true,
-    TranslatedName: 'レート',
-    Selection: 0,
-    Format: '{0}%',
-    RangeMeta: { Type: 'Int32', Values: [0, 10, 20, 30] },
-    Childs: [],
-  };
+describe("ExRRoleSpawnControls", () => {
+	const spawnRateOption: ExROptionDto = {
+		Id: 50,
+		IsActive: true,
+		TranslatedName: "レート",
+		Selection: 0,
+		Format: "{0}%",
+		RangeMeta: { Type: "Int32", Values: [0, 10, 20, 30] },
+		Childs: [],
+	};
 
-  const spawnCountOption: ExROptionDto = {
-    Id: 51,
-    IsActive: true,
-    TranslatedName: '数',
-    Selection: 0,
-    Format: '',
-    RangeMeta: { Type: 'Int32', Values: [1, 2, 3] },
-    Childs: [],
-  };
+	const spawnCountOption: ExROptionDto = {
+		Id: 51,
+		IsActive: true,
+		TranslatedName: "数",
+		Selection: 0,
+		Format: "",
+		RangeMeta: { Type: "Int32", Values: [1, 2, 3] },
+		Childs: [],
+	};
 
-  beforeEach(() => {
-    useStore.getState().resetViewer();
-  });
+	beforeEach(() => {
+		useStore.getState().resetViewer();
+	});
 
-  it('renders both controls', () => {
-    render(
-      <ExRRoleSpawnControls
-        categoryId={1}
-        spawnRateOption={spawnRateOption}
-        spawnCountOption={spawnCountOption}
-      />
-    );
+	it("renders both controls", () => {
+		render(
+			<ExRRoleSpawnControls
+				categoryId={1}
+				spawnRateOption={spawnRateOption}
+				spawnCountOption={spawnCountOption}
+			/>,
+		);
 
-    expect(screen.getByTestId('spawn-rate-control')).toBeInTheDocument();
-    expect(screen.getByTestId('spawn-count-control')).toBeInTheDocument();
-  });
+		expect(screen.getByTestId("spawn-rate-control")).toBeInTheDocument();
+		expect(screen.getByTestId("spawn-count-control")).toBeInTheDocument();
+	});
 
-  it('handles virtual 0 for spawn count', () => {
-    render(
-      <ExRRoleSpawnControls
-        categoryId={1}
-        spawnRateOption={spawnRateOption}
-        spawnCountOption={spawnCountOption}
-      />
-    );
+	it("handles virtual 0 for spawn count", () => {
+		render(
+			<ExRRoleSpawnControls
+				categoryId={1}
+				spawnRateOption={spawnRateOption}
+				spawnCountOption={spawnCountOption}
+			/>,
+		);
 
-    const countControl = screen.getByTestId('spawn-count-control');
-    const slider = countControl.querySelector('input[type="range"]') as HTMLInputElement;
+		const countControl = screen.getByTestId("spawn-count-control");
+		const slider = countControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
 
-    // Max should be 3 (virtual values: [0, 1, 2, 3] from backend [1, 2, 3])
-    expect(slider.max).toBe('3');
-  });
+		// Max should be 3 (virtual values: [0, 1, 2, 3] from backend [1, 2, 3])
+		expect(slider.max).toBe("3");
+	});
 
-  it('syncs rate to 0 when count is set to 0', () => {
-    // Set initial rate to 10%
-    useStore.getState().TEMP_updateExROptionSelection('1-50', 1);
+	it("syncs rate to 0 when count is set to 0", () => {
+		// Set initial rate to 10%
+		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
 
-    render(
-      <ExRRoleSpawnControls
-        categoryId={1}
-        spawnRateOption={spawnRateOption}
-        spawnCountOption={spawnCountOption}
-      />
-    );
+		render(
+			<ExRRoleSpawnControls
+				categoryId={1}
+				spawnRateOption={spawnRateOption}
+				spawnCountOption={spawnCountOption}
+			/>,
+		);
 
-    const countControl = screen.getByTestId('spawn-count-control');
-    const slider = countControl.querySelector('input[type="range"]') as HTMLInputElement;
+		const countControl = screen.getByTestId("spawn-count-control");
+		const slider = countControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
 
-    fireEvent.change(slider, { target: { value: '0' } });
+		fireEvent.change(slider, { target: { value: "0" } });
 
-    const state = useStore.getState();
-    expect(state.effectiveSelections['1-50']).toBe(0); // Rate 0%
-  });
+		const state = useStore.getState();
+		expect(state.effectiveSelections["1-50"]).toBe(0); // Rate 0%
+	});
 
-  it('syncs rate to 10% when count is set to non-zero from zero rate', () => {
-    render(
-      <ExRRoleSpawnControls
-        categoryId={1}
-        spawnRateOption={spawnRateOption}
-        spawnCountOption={spawnCountOption}
-      />
-    );
+	it("syncs rate to 10% when count is set to non-zero from zero rate", () => {
+		render(
+			<ExRRoleSpawnControls
+				categoryId={1}
+				spawnRateOption={spawnRateOption}
+				spawnCountOption={spawnCountOption}
+			/>,
+		);
 
-    const countControl = screen.getByTestId('spawn-count-control');
-    const slider = countControl.querySelector('input[type="range"]') as HTMLInputElement;
+		const countControl = screen.getByTestId("spawn-count-control");
+		const slider = countControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
 
-    fireEvent.change(slider, { target: { value: '1' } }); // Select '1'
+		fireEvent.change(slider, { target: { value: "1" } }); // Select '1'
 
-    const state = useStore.getState();
-    expect(state.effectiveSelections['1-50']).toBe(1); // Rate index 1 is 10%
-  });
+		const state = useStore.getState();
+		expect(state.effectiveSelections["1-50"]).toBe(1); // Rate index 1 is 10%
+	});
 
-  it('syncs count to 0 when rate is set to 0%', () => {
-    // Set initial rate to 10% and count to 2
-    useStore.getState().TEMP_updateExROptionSelection('1-50', 1);
-    useStore.getState().TEMP_updateExROptionSelection('1-51', 1); // backend index 1 is value 2
+	it("syncs count to 0 when rate is set to 0%", () => {
+		// Set initial rate to 10% and count to 2
+		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
+		useStore.getState().TEMP_updateExROptionSelection("1-51", 1); // backend index 1 is value 2
 
-    render(
-      <ExRRoleSpawnControls
-        categoryId={1}
-        spawnRateOption={spawnRateOption}
-        spawnCountOption={spawnCountOption}
-      />
-    );
+		render(
+			<ExRRoleSpawnControls
+				categoryId={1}
+				spawnRateOption={spawnRateOption}
+				spawnCountOption={spawnCountOption}
+			/>,
+		);
 
-    const rateControl = screen.getByTestId('spawn-rate-control');
-    const slider = rateControl.querySelector('input[type="range"]') as HTMLInputElement;
+		const rateControl = screen.getByTestId("spawn-rate-control");
+		const slider = rateControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
 
-    fireEvent.change(slider, { target: { value: '0' } });
+		fireEvent.change(slider, { target: { value: "0" } });
 
-    const state = useStore.getState();
-    expect(state.effectiveSelections['1-51']).toBe(0); // Count reset to index 0
+		const state = useStore.getState();
+		expect(state.effectiveSelections["1-51"]).toBe(0); // Count reset to index 0
 
-    // UI should show 0
-    const countDisplay = screen.getByTestId('spawn-count-control').querySelector('input[type="text"]');
-    expect(countDisplay).toHaveValue('0');
-  });
+		// UI should show 0
+		const countDisplay = screen
+			.getByTestId("spawn-count-control")
+			.querySelector('input[type="text"]');
+		expect(countDisplay).toHaveValue("0");
+	});
 });

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExRRoleSpawnControls } from '../src/feature/ExRRoleSpawnControls';
+import { useStore } from '../src/useStore';
+import type { ExROptionDto } from '../src/type';
+
+describe('ExRRoleSpawnControls', () => {
+  const spawnRateOption: ExROptionDto = {
+    Id: 50,
+    IsActive: true,
+    TranslatedName: 'レート',
+    Selection: 0,
+    Format: '{0}%',
+    RangeMeta: { Type: 'Int32', Values: [0, 10, 20, 30] },
+    Childs: [],
+  };
+
+  const spawnCountOption: ExROptionDto = {
+    Id: 51,
+    IsActive: true,
+    TranslatedName: '数',
+    Selection: 0,
+    Format: '',
+    RangeMeta: { Type: 'Int32', Values: [1, 2, 3] },
+    Childs: [],
+  };
+
+  beforeEach(() => {
+    useStore.getState().resetViewer();
+  });
+
+  it('renders both controls', () => {
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    expect(screen.getByTestId('spawn-rate-control')).toBeInTheDocument();
+    expect(screen.getByTestId('spawn-count-control')).toBeInTheDocument();
+  });
+
+  it('handles virtual 0 for spawn count', () => {
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    const countControl = screen.getByTestId('spawn-count-control');
+    const slider = countControl.querySelector('input[type="range"]') as HTMLInputElement;
+
+    // Max should be 3 (virtual values: [0, 1, 2, 3] from backend [1, 2, 3])
+    expect(slider.max).toBe('3');
+  });
+
+  it('syncs rate to 0 when count is set to 0', () => {
+    // Set initial rate to 10%
+    useStore.getState().TEMP_updateExROptionSelection('1-50', 1);
+
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    const countControl = screen.getByTestId('spawn-count-control');
+    const slider = countControl.querySelector('input[type="range"]') as HTMLInputElement;
+
+    fireEvent.change(slider, { target: { value: '0' } });
+
+    const state = useStore.getState();
+    expect(state.effectiveSelections['1-50']).toBe(0); // Rate 0%
+  });
+
+  it('syncs rate to 10% when count is set to non-zero from zero rate', () => {
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    const countControl = screen.getByTestId('spawn-count-control');
+    const slider = countControl.querySelector('input[type="range"]') as HTMLInputElement;
+
+    fireEvent.change(slider, { target: { value: '1' } }); // Select '1'
+
+    const state = useStore.getState();
+    expect(state.effectiveSelections['1-50']).toBe(1); // Rate index 1 is 10%
+  });
+
+  it('syncs count to 0 when rate is set to 0%', () => {
+    // Set initial rate to 10% and count to 2
+    useStore.getState().TEMP_updateExROptionSelection('1-50', 1);
+    useStore.getState().TEMP_updateExROptionSelection('1-51', 1); // backend index 1 is value 2
+
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    const rateControl = screen.getByTestId('spawn-rate-control');
+    const slider = rateControl.querySelector('input[type="range"]') as HTMLInputElement;
+
+    fireEvent.change(slider, { target: { value: '0' } });
+
+    const state = useStore.getState();
+    expect(state.effectiveSelections['1-51']).toBe(0); // Count reset to index 0
+
+    // UI should show 0
+    const countDisplay = screen.getByTestId('spawn-count-control').querySelector('input[type="text"]');
+    expect(countDisplay).toHaveValue('0');
+  });
+});


### PR DESCRIPTION
This change moves the "Spawn Rate" (OptionId: 50) and "Spawn Count" (OptionId: 51) controls from the regular option list into the category headers for all role-related ExR tabs (everything except General Tab). 

Key changes:
- `src/components/parts/Accordion.tsx`: Added `headerExtra` prop and refactored the header layout to allow interactive elements in the header that don't trigger the accordion toggle.
- `src/feature/ExRHeaderOptionControl.tsx`: A new compact component for rendering sliders and inputs in the header.
- `src/feature/ExRCategoryList.tsx`: Added logic to identify role tabs, extract options 50 and 51, and manage their conditional display (Spawn Count only shows if Spawn Rate > 0).

Visual verification was performed using Playwright, confirming that the controls appear in the header, are interactive, and do not trigger the accordion when clicked. Existing unit tests passed.

---
*PR created automatically by Jules for task [1520609924127994617](https://jules.google.com/task/1520609924127994617) started by @yukieiji*