### PR TITLE
Improve UX for role spawn rate and count synchronization

### DIFF
--- a/e2e/exr_role_spawn_options.spec.ts
+++ b/e2e/exr_role_spawn_options.spec.ts
@@ -18,33 +18,53 @@ test.beforeEach(async ({ page }) => {
 test.describe('ExR Role Spawn Options in Header', () => {
   const SHERIFF_ID = '270';
 
-  test('should display spawn rate in category header of role tabs', async ({ page }) => {
+  test('should display both spawn rate and count in category header of role tabs', async ({ page }) => {
     // 役職タブ（クルーメイト）に切り替え
     await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
 
-    // カテゴリ（シェリフ）のヘッダーに「レート」が表示されていることを確認
+    // カテゴリ（シェリフ）のヘッダーに「レート」と「数」が表示されていることを確認
     const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
     await expect(sheriffCategory.getByTestId('spawn-rate-control')).toBeVisible();
+    await expect(sheriffCategory.getByTestId('spawn-count-control')).toBeVisible();
   });
 
-  test('should show spawn count only when spawn rate is 1 or more', async ({ page }) => {
+  test('should synchronize spawn rate and count', async ({ page }) => {
     await page.getByRole('button', { name: 'クルーメイト役職設定', exact: true }).click();
 
     const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+    const rateControl = sheriffCategory.getByTestId('spawn-rate-control');
+    const countControl = sheriffCategory.getByTestId('spawn-count-control');
 
-    // 初期状態（レート 0）では「数」は表示されていないはず
-    await expect(sheriffCategory.getByTestId('spawn-count-control')).not.toBeVisible();
+    const rateInput = rateControl.locator('input[type="text"]');
+    const countInput = countControl.locator('input[type="text"]');
+    const rateSlider = rateControl.locator('input[type="range"]');
+    const countSlider = countControl.locator('input[type="range"]');
 
-    // レートのスライダーを操作して 1 以上にする
-    const rateSlider = sheriffCategory.getByTestId('spawn-rate-control').locator('input[type="range"]');
-    await rateSlider.fill('10');
-
-    // 「数」が表示されることを確認
-    await expect(sheriffCategory.getByTestId('spawn-count-control')).toBeVisible();
-
-    // レートを 0 に戻すと「数」が消えることを確認
+    // 初期状態が 0, 0 であることを確認（モックデータ依存だが、このテストスイートではそう仮定）
+    // もしモックが違うなら、まず 0 にする
     await rateSlider.fill('0');
-    await expect(sheriffCategory.getByTestId('spawn-count-control')).not.toBeVisible();
+    await expect(rateInput).toHaveValue('0');
+    await expect(countInput).toHaveValue('0');
+
+    // 1. スポーン数を変更するとスポーンレートを10％へ
+    await countSlider.fill('1'); // インデックス1 = 値1 (0番目は0)
+    await expect(countInput).toHaveValue('1');
+    await expect(rateInput).toHaveValue('10');
+
+    // 2. スポーンレートを0％にするとスポーン数を0
+    await rateSlider.fill('0');
+    await expect(rateInput).toHaveValue('0');
+    await expect(countInput).toHaveValue('0');
+
+    // 3. スポーン数を0へ変更するとスポーンレートが0％へ
+    // まず 10%, 1 に戻す
+    await countSlider.fill('1');
+    await expect(rateInput).toHaveValue('10');
+    await expect(countInput).toHaveValue('1');
+    // 0へ変更
+    await countSlider.fill('0');
+    await expect(countInput).toHaveValue('0');
+    await expect(rateInput).toHaveValue('0');
   });
 
   test('interacting with header controls should not toggle accordion', async ({ page }) => {
@@ -63,7 +83,7 @@ test.describe('ExR Role Spawn Options in Header', () => {
     // まだ閉じているはず（stopPropagationが効いている）
     await expect(content).not.toBeVisible();
 
-    // 数が表示されたのでそちらも操作してみる
+    // 数も操作してみる
     const countSlider = sheriffCategory.getByTestId('spawn-count-control').locator('input[type="range"]');
     await countSlider.fill('2');
 

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -12,6 +12,7 @@ interface CompactSliderProps {
 /**
  * カテゴリアコーディオンのヘッダーなどで使用する、コンパクトなスライダーとテキスト入力のセット
  * (純粋なUIコンポーネント)
+ * 入力欄はスライダーの上に表示されるようにレイアウト
  */
 export function CompactSlider({
   label,
@@ -43,11 +44,19 @@ export function CompactSlider({
 
   return (
     <div
-      className="flex items-center gap-2 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
+      className="flex flex-col gap-1 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
       onClick={handleClick}
       data-testid={testId}
     >
-      <span className="text-xs font-medium text-gray-400 whitespace-nowrap">{label}</span>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] font-medium text-gray-400 whitespace-nowrap leading-none">{label}</span>
+        <input
+          type="text"
+          value={currentValue}
+          onChange={handleInputChange}
+          className="w-8 px-0.5 py-0 text-right text-[10px] bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500 leading-none"
+        />
+      </div>
       <input
         type="range"
         min={0}
@@ -55,13 +64,7 @@ export function CompactSlider({
         step={1}
         value={currentSelection}
         onChange={handleSliderChange}
-        className="w-20 h-1.5 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-      />
-      <input
-        type="text"
-        value={currentValue}
-        onChange={handleInputChange}
-        className="w-10 px-1 py-0.5 text-right text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
+        className="w-20 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
       />
     </div>
   );

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+interface CompactSliderProps {
+  label: string;
+  values: number[];
+  currentSelection: number;
+  onSelectionChange: (selection: number) => void;
+  onInputChange: (value: number) => void;
+  testId?: string;
+}
+
+/**
+ * カテゴリアコーディオンのヘッダーなどで使用する、コンパクトなスライダーとテキスト入力のセット
+ * (純粋なUIコンポーネント)
+ */
+export function CompactSlider({
+  label,
+  values,
+  currentSelection,
+  onSelectionChange,
+  onInputChange,
+  testId,
+}: CompactSliderProps) {
+  const currentValue = values[currentSelection] ?? values[0] ?? 0;
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    onSelectionChange(parseInt(e.target.value, 10));
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    const val = parseFloat(e.target.value);
+    if (!isNaN(val)) {
+      onInputChange(val);
+    }
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    // アコーディオンの開閉を防ぐ
+    e.stopPropagation();
+  };
+
+  return (
+    <div
+      className="flex items-center gap-2 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
+      onClick={handleClick}
+      data-testid={testId}
+    >
+      <span className="text-xs font-medium text-gray-400 whitespace-nowrap">{label}</span>
+      <input
+        type="range"
+        min={0}
+        max={values.length - 1}
+        step={1}
+        value={currentSelection}
+        onChange={handleSliderChange}
+        className="w-20 h-1.5 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
+      />
+      <input
+        type="text"
+        value={currentValue}
+        onChange={handleInputChange}
+        className="w-10 px-1 py-0.5 text-right text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
+      />
+    </div>
+  );
+}

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -6,6 +6,9 @@ interface ExRHeaderOptionControlProps {
   categoryId: number;
   option: ExROptionDto;
   label: string;
+  customValues?: number[];
+  customSelection?: number;
+  onSelectionChange?: (selection: number) => void;
 }
 
 /**
@@ -15,23 +18,33 @@ export function ExRHeaderOptionControl({
   categoryId,
   option,
   label,
+  customValues,
+  customSelection,
+  onSelectionChange,
 }: ExRHeaderOptionControlProps) {
   const uniqueId = getUniqueOptionId(categoryId, option.Id);
   const effectiveSelection = useStore((state) => {
     return state.effectiveSelections[uniqueId];
   });
-  const currentSelection = effectiveSelection ?? option.Selection;
   const TEMP_updateExROptionSelection = useStore((state) => {
     return state.TEMP_updateExROptionSelection;
   });
 
-  const { Values } = option.RangeMeta;
-  const values = Values as number[];
+  const values = customValues ?? (option.RangeMeta.Values as number[]);
+  const currentSelection = customSelection ?? effectiveSelection ?? option.Selection;
   const currentValue = values[currentSelection] ?? values[0] ?? 0;
+
+  const handleSelectionUpdate = (newSelection: number) => {
+    if (onSelectionChange) {
+      onSelectionChange(newSelection);
+    } else {
+      TEMP_updateExROptionSelection(uniqueId, newSelection);
+    }
+  };
 
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
-    TEMP_updateExROptionSelection(uniqueId, parseInt(e.target.value, 10));
+    handleSelectionUpdate(parseInt(e.target.value, 10));
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,7 +53,7 @@ export function ExRHeaderOptionControl({
     if (isNaN(val)) {
       return;
     }
-    TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+    handleSelectionUpdate(findClosestIndex(values, val));
   };
 
   const handleClick = (e: React.MouseEvent) => {

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -1,84 +1,49 @@
 import { useStore } from '../useStore';
 import { getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
+import { CompactSlider } from '../components/parts/CompactSlider';
 import type { ExROptionDto } from '../type';
 
 interface ExRHeaderOptionControlProps {
   categoryId: number;
   option: ExROptionDto;
   label: string;
-  customValues?: number[];
-  customSelection?: number;
-  onSelectionChange?: (selection: number) => void;
 }
 
 /**
  * カテゴリアコーディオンのヘッダーに表示するためのコンパクトなスライダーコントロール
+ * (ストア接続済みラッパー)
  */
 export function ExRHeaderOptionControl({
   categoryId,
   option,
   label,
-  customValues,
-  customSelection,
-  onSelectionChange,
 }: ExRHeaderOptionControlProps) {
   const uniqueId = getUniqueOptionId(categoryId, option.Id);
   const effectiveSelection = useStore((state) => {
     return state.effectiveSelections[uniqueId];
   });
+  const currentSelection = effectiveSelection ?? option.Selection;
   const TEMP_updateExROptionSelection = useStore((state) => {
     return state.TEMP_updateExROptionSelection;
   });
 
-  const values = customValues ?? (option.RangeMeta.Values as number[]);
-  const currentSelection = customSelection ?? effectiveSelection ?? option.Selection;
-  const currentValue = values[currentSelection] ?? values[0] ?? 0;
+  const values = option.RangeMeta.Values as number[];
 
-  const handleSelectionUpdate = (newSelection: number) => {
-    if (onSelectionChange) {
-      onSelectionChange(newSelection);
-    } else {
-      TEMP_updateExROptionSelection(uniqueId, newSelection);
-    }
+  const handleSelectionChange = (newSelection: number) => {
+    TEMP_updateExROptionSelection(uniqueId, newSelection);
   };
 
-  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-    handleSelectionUpdate(parseInt(e.target.value, 10));
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-    const val = parseFloat(e.target.value);
-    if (isNaN(val)) {
-      return;
-    }
-    handleSelectionUpdate(findClosestIndex(values, val));
-  };
-
-  const handleClick = (e: React.MouseEvent) => {
-    // アコーディオンの開閉を防ぐ
-    e.stopPropagation();
+  const handleInputChange = (val: number) => {
+    TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
   };
 
   return (
-    <div className="flex items-center gap-2 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50" onClick={handleClick}>
-      <span className="text-xs font-medium text-gray-400 whitespace-nowrap">{label}</span>
-      <input
-        type="range"
-        min={0}
-        max={values.length - 1}
-        step={1}
-        value={currentSelection}
-        onChange={handleSliderChange}
-        className="w-20 h-1.5 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
-      />
-      <input
-        type="text"
-        value={currentValue}
-        onChange={handleInputChange}
-        className="w-10 px-1 py-0.5 text-right text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
-      />
-    </div>
+    <CompactSlider
+      label={label}
+      values={values}
+      currentSelection={currentSelection}
+      onSelectionChange={handleSelectionChange}
+      onInputChange={handleInputChange}
+    />
   );
 }

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,8 +1,8 @@
 import { useStore } from '../useStore';
 import { ColoredText } from '../components/parts/ColoredText';
 import { ExRCategoryOptionList } from './ExRCategoryOptionList';
-import { ExRHeaderOptionControl } from './ExRHeaderOptionControl';
-import { isPresetOption, getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
+import { ExRRoleSpawnControls } from './ExRRoleSpawnControls';
+import { isPresetOption } from '../logics/optionUtils';
 import type { ExRCategoryDto } from '../type';
 
 interface ExRRoleCategoryItemProps {
@@ -19,9 +19,6 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
   const toggleExRCategory = useStore((state) => {
     return state.toggleExRCategory;
   });
-  const TEMP_updateExROptionSelection = useStore((state) => {
-    return state.TEMP_updateExROptionSelection;
-  });
 
   const spawnRateOption = category.Options.find((opt) => {
     return opt.Id === 50;
@@ -29,62 +26,6 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
   const spawnCountOption = category.Options.find((opt) => {
     return opt.Id === 51;
   });
-
-  const spawnRateSelection = useStore((state) => {
-    const uniqueId = getUniqueOptionId(category.Id, 50);
-    return state.effectiveSelections[uniqueId] ?? spawnRateOption?.Selection ?? 0;
-  });
-
-  const spawnCountSelection = useStore((state) => {
-    const uniqueId = getUniqueOptionId(category.Id, 51);
-    return state.effectiveSelections[uniqueId] ?? spawnCountOption?.Selection ?? 0;
-  });
-
-  // スポーンレートが0のときはスポーン数も0として扱うための仮想的な値リスト
-  const originalSpawnCountValues = (spawnCountOption?.RangeMeta.Values as number[]) ?? [];
-  const virtualSpawnCountValues = [0, ...originalSpawnCountValues];
-
-  // 現在のスポーンレートが0%なら、表示上のスポーン数も0にする
-  const spawnRateValues = (spawnRateOption?.RangeMeta.Values as number[]) ?? [0];
-  const isSpawnRateZero = spawnRateValues[spawnRateSelection] === 0;
-
-  const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
-
-  const handleRateChange = (newSelection: number) => {
-    if (!spawnRateOption) {
-      return;
-    }
-    const uniqueRateId = getUniqueOptionId(category.Id, 50);
-    TEMP_updateExROptionSelection(uniqueRateId, newSelection);
-
-    // スポーンレートを0%にするとスポーン数を0に（内部的にはレートが0なら数も0と見なす）
-    const newRateValue = spawnRateValues[newSelection] ?? 0;
-    if (newRateValue === 0 && spawnCountOption) {
-      const uniqueCountId = getUniqueOptionId(category.Id, 51);
-      // スポーン数を0にする（レート0のときは表示上0になるので、内部値は適当でも良いが、一応最小値にしておく）
-      TEMP_updateExROptionSelection(uniqueCountId, 0);
-    }
-  };
-
-  const handleCountUIChange = (newUISelection: number) => {
-    if (!spawnCountOption || !spawnRateOption) {
-      return;
-    }
-    const uniqueCountId = getUniqueOptionId(category.Id, 51);
-    const uniqueRateId = getUniqueOptionId(category.Id, 50);
-
-    if (newUISelection === 0) {
-      // スポーン数を0へ変更するとスポーンレートが0%へ
-      TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(spawnRateValues, 0));
-      TEMP_updateExROptionSelection(uniqueCountId, 0);
-    } else {
-      // スポーン数を変更（0以外）するとスポーンレートを10％へ（元が0%の場合のみ）
-      if (isSpawnRateZero) {
-        TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(spawnRateValues, 10));
-      }
-      TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
-    }
-  };
 
   const filteredOptions = category.Options.filter((option) => {
     if (isPresetOption(category.Id, option.Id)) {
@@ -132,29 +73,13 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
           </span>
         </button>
 
-        <div className="flex items-center px-4 gap-4">
-          {spawnRateOption && (
-            <div data-testid="spawn-rate-control">
-              <ExRHeaderOptionControl
-                categoryId={category.Id}
-                option={spawnRateOption}
-                label="レート"
-                customSelection={spawnRateSelection}
-                onSelectionChange={handleRateChange}
-              />
-            </div>
-          )}
-          {spawnCountOption && (
-            <div data-testid="spawn-count-control">
-              <ExRHeaderOptionControl
-                categoryId={category.Id}
-                option={spawnCountOption}
-                label="数"
-                customValues={virtualSpawnCountValues}
-                customSelection={currentCountUISelection}
-                onSelectionChange={handleCountUIChange}
-              />
-            </div>
+        <div className="flex items-center px-4">
+          {spawnRateOption && spawnCountOption && (
+            <ExRRoleSpawnControls
+              categoryId={category.Id}
+              spawnRateOption={spawnRateOption}
+              spawnCountOption={spawnCountOption}
+            />
           )}
         </div>
       </div>

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -2,7 +2,7 @@ import { useStore } from '../useStore';
 import { ColoredText } from '../components/parts/ColoredText';
 import { ExRCategoryOptionList } from './ExRCategoryOptionList';
 import { ExRHeaderOptionControl } from './ExRHeaderOptionControl';
-import { isPresetOption, getUniqueOptionId } from '../logics/optionUtils';
+import { isPresetOption, getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
 import type { ExRCategoryDto } from '../type';
 
 interface ExRRoleCategoryItemProps {
@@ -19,6 +19,9 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
   const toggleExRCategory = useStore((state) => {
     return state.toggleExRCategory;
   });
+  const TEMP_updateExROptionSelection = useStore((state) => {
+    return state.TEMP_updateExROptionSelection;
+  });
 
   const spawnRateOption = category.Options.find((opt) => {
     return opt.Id === 50;
@@ -31,6 +34,57 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
     const uniqueId = getUniqueOptionId(category.Id, 50);
     return state.effectiveSelections[uniqueId] ?? spawnRateOption?.Selection ?? 0;
   });
+
+  const spawnCountSelection = useStore((state) => {
+    const uniqueId = getUniqueOptionId(category.Id, 51);
+    return state.effectiveSelections[uniqueId] ?? spawnCountOption?.Selection ?? 0;
+  });
+
+  // スポーンレートが0のときはスポーン数も0として扱うための仮想的な値リスト
+  const originalSpawnCountValues = (spawnCountOption?.RangeMeta.Values as number[]) ?? [];
+  const virtualSpawnCountValues = [0, ...originalSpawnCountValues];
+
+  // 現在のスポーンレートが0%なら、表示上のスポーン数も0にする
+  const spawnRateValues = (spawnRateOption?.RangeMeta.Values as number[]) ?? [0];
+  const isSpawnRateZero = spawnRateValues[spawnRateSelection] === 0;
+
+  const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
+
+  const handleRateChange = (newSelection: number) => {
+    if (!spawnRateOption) {
+      return;
+    }
+    const uniqueRateId = getUniqueOptionId(category.Id, 50);
+    TEMP_updateExROptionSelection(uniqueRateId, newSelection);
+
+    // スポーンレートを0%にするとスポーン数を0に（内部的にはレートが0なら数も0と見なす）
+    const newRateValue = spawnRateValues[newSelection] ?? 0;
+    if (newRateValue === 0 && spawnCountOption) {
+      const uniqueCountId = getUniqueOptionId(category.Id, 51);
+      // スポーン数を0にする（レート0のときは表示上0になるので、内部値は適当でも良いが、一応最小値にしておく）
+      TEMP_updateExROptionSelection(uniqueCountId, 0);
+    }
+  };
+
+  const handleCountUIChange = (newUISelection: number) => {
+    if (!spawnCountOption || !spawnRateOption) {
+      return;
+    }
+    const uniqueCountId = getUniqueOptionId(category.Id, 51);
+    const uniqueRateId = getUniqueOptionId(category.Id, 50);
+
+    if (newUISelection === 0) {
+      // スポーン数を0へ変更するとスポーンレートが0%へ
+      TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(spawnRateValues, 0));
+      TEMP_updateExROptionSelection(uniqueCountId, 0);
+    } else {
+      // スポーン数を変更（0以外）するとスポーンレートを10％へ（元が0%の場合のみ）
+      if (isSpawnRateZero) {
+        TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(spawnRateValues, 10));
+      }
+      TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
+    }
+  };
 
   const filteredOptions = category.Options.filter((option) => {
     if (isPresetOption(category.Id, option.Id)) {
@@ -85,15 +139,20 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
                 categoryId={category.Id}
                 option={spawnRateOption}
                 label="レート"
+                customSelection={spawnRateSelection}
+                onSelectionChange={handleRateChange}
               />
             </div>
           )}
-          {spawnRateSelection >= 1 && spawnCountOption && (
+          {spawnCountOption && (
             <div data-testid="spawn-count-control">
               <ExRHeaderOptionControl
                 categoryId={category.Id}
                 option={spawnCountOption}
                 label="数"
+                customValues={virtualSpawnCountValues}
+                customSelection={currentCountUISelection}
+                onSelectionChange={handleCountUIChange}
               />
             </div>
           )}

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -1,0 +1,96 @@
+import { useStore } from '../useStore';
+import { getUniqueOptionId, findClosestIndex } from '../logics/optionUtils';
+import { CompactSlider } from '../components/parts/CompactSlider';
+import type { ExROptionDto } from '../type';
+
+interface ExRRoleSpawnControlsProps {
+  categoryId: number;
+  spawnRateOption: ExROptionDto;
+  spawnCountOption: ExROptionDto;
+}
+
+/**
+ * 役職のスポーンレートとスポーン数をセットで管理し、同期させるためのコンポーネント
+ */
+export function ExRRoleSpawnControls({
+  categoryId,
+  spawnRateOption,
+  spawnCountOption,
+}: ExRRoleSpawnControlsProps) {
+  const uniqueRateId = getUniqueOptionId(categoryId, 50);
+  const uniqueCountId = getUniqueOptionId(categoryId, 51);
+
+  const spawnRateSelection = useStore((state) => {
+    return state.effectiveSelections[uniqueRateId] ?? spawnRateOption.Selection ?? 0;
+  });
+
+  const spawnCountSelection = useStore((state) => {
+    return state.effectiveSelections[uniqueCountId] ?? spawnCountOption.Selection ?? 0;
+  });
+
+  const TEMP_updateExROptionSelection = useStore((state) => {
+    return state.TEMP_updateExROptionSelection;
+  });
+
+  const rateValues = spawnRateOption.RangeMeta.Values as number[];
+  const originalCountValues = spawnCountOption.RangeMeta.Values as number[];
+
+  // スポーン数が0をサポートするための仮想的な値リスト
+  const virtualCountValues = [0, ...originalCountValues];
+
+  // 現在のスポーンレートが0%なら、表示上のスポーン数も強制的に0
+  const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
+  const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
+
+  const handleRateChange = (newSelection: number) => {
+    TEMP_updateExROptionSelection(uniqueRateId, newSelection);
+
+    // スポーンレートが0%なら、スポーン数も0としてリセット
+    if (rateValues[newSelection] === 0) {
+      TEMP_updateExROptionSelection(uniqueCountId, 0);
+    }
+  };
+
+  const handleRateInputChange = (val: number) => {
+    handleRateChange(findClosestIndex(rateValues, val));
+  };
+
+  const handleCountUIChange = (newUISelection: number) => {
+    if (newUISelection === 0) {
+      // 数を0にすると、レートも0%にする
+      TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 0));
+      TEMP_updateExROptionSelection(uniqueCountId, 0);
+    } else {
+      // 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
+      if (isSpawnRateZero) {
+        TEMP_updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 10));
+      }
+      TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
+    }
+  };
+
+  const handleCountUIInputChange = (val: number) => {
+    handleCountUIChange(findClosestIndex(virtualCountValues, val));
+  };
+
+  return (
+    <div className="flex items-center gap-4">
+      <CompactSlider
+        label="レート"
+        values={rateValues}
+        currentSelection={spawnRateSelection}
+        onSelectionChange={handleRateChange}
+        onInputChange={handleRateInputChange}
+        testId="spawn-rate-control"
+      />
+      <CompactSlider
+        label="数"
+        values={virtualCountValues}
+        currentSelection={currentCountUISelection}
+        onSelectionChange={handleCountUIChange}
+        onInputChange={handleCountUIInputChange}
+        testId="spawn-count-control"
+      />
+    </div>
+  );
+}

--- a/tests/CompactSlider.test.tsx
+++ b/tests/CompactSlider.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CompactSlider } from '../src/components/parts/CompactSlider';
+
+describe('CompactSlider', () => {
+  const defaultProps = {
+    label: 'Test Label',
+    values: [0, 10, 20],
+    currentSelection: 1,
+    onSelectionChange: vi.fn(),
+    onInputChange: vi.fn(),
+  };
+
+  it('renders label and current value correctly', () => {
+    render(<CompactSlider {...defaultProps} />);
+
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByRole('slider')).toHaveValue('1');
+    expect(screen.getByDisplayValue('10')).toBeInTheDocument();
+  });
+
+  it('calls onSelectionChange when slider is moved', () => {
+    const onSelectionChange = vi.fn();
+    render(<CompactSlider {...defaultProps} onSelectionChange={onSelectionChange} />);
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '2' } });
+
+    expect(onSelectionChange).toHaveBeenCalledWith(2);
+  });
+
+  it('calls onInputChange when text input is changed', () => {
+    const onInputChange = vi.fn();
+    render(<CompactSlider {...defaultProps} onInputChange={onInputChange} />);
+
+    const input = screen.getByDisplayValue('10');
+    fireEvent.change(input, { target: { value: '20' } });
+
+    expect(onInputChange).toHaveBeenCalledWith(20);
+  });
+
+  it('stops event propagation on click', () => {
+    const parentClick = vi.fn();
+    render(
+      <div onClick={parentClick}>
+        <CompactSlider {...defaultProps} />
+      </div>
+    );
+
+    fireEvent.click(screen.getByText('Test Label'));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('stops event propagation on slider change', () => {
+    const parentChange = vi.fn();
+    render(
+      <div onChange={parentChange}>
+        <CompactSlider {...defaultProps} />
+      </div>
+    );
+
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '0' } });
+    expect(parentChange).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExRRoleSpawnControls } from '../src/feature/ExRRoleSpawnControls';
+import { useStore } from '../src/useStore';
+import type { ExROptionDto } from '../src/type';
+
+describe('ExRRoleSpawnControls', () => {
+  const spawnRateOption: ExROptionDto = {
+    Id: 50,
+    IsActive: true,
+    TranslatedName: 'レート',
+    Selection: 0,
+    Format: '{0}%',
+    RangeMeta: { Type: 'Int32', Values: [0, 10, 20, 30] },
+    Childs: [],
+  };
+
+  const spawnCountOption: ExROptionDto = {
+    Id: 51,
+    IsActive: true,
+    TranslatedName: '数',
+    Selection: 0,
+    Format: '',
+    RangeMeta: { Type: 'Int32', Values: [1, 2, 3] },
+    Childs: [],
+  };
+
+  beforeEach(() => {
+    useStore.getState().resetViewer();
+  });
+
+  it('renders both controls', () => {
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    expect(screen.getByTestId('spawn-rate-control')).toBeInTheDocument();
+    expect(screen.getByTestId('spawn-count-control')).toBeInTheDocument();
+  });
+
+  it('handles virtual 0 for spawn count', () => {
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    const countControl = screen.getByTestId('spawn-count-control');
+    const slider = countControl.querySelector('input[type="range"]') as HTMLInputElement;
+
+    // Max should be 3 (virtual values: [0, 1, 2, 3] from backend [1, 2, 3])
+    expect(slider.max).toBe('3');
+  });
+
+  it('syncs rate to 0 when count is set to 0', () => {
+    // Set initial rate to 10%
+    useStore.getState().TEMP_updateExROptionSelection('1-50', 1);
+
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    const countControl = screen.getByTestId('spawn-count-control');
+    const slider = countControl.querySelector('input[type="range"]') as HTMLInputElement;
+
+    fireEvent.change(slider, { target: { value: '0' } });
+
+    const state = useStore.getState();
+    expect(state.effectiveSelections['1-50']).toBe(0); // Rate 0%
+  });
+
+  it('syncs rate to 10% when count is set to non-zero from zero rate', () => {
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    const countControl = screen.getByTestId('spawn-count-control');
+    const slider = countControl.querySelector('input[type="range"]') as HTMLInputElement;
+
+    fireEvent.change(slider, { target: { value: '1' } }); // Select '1'
+
+    const state = useStore.getState();
+    expect(state.effectiveSelections['1-50']).toBe(1); // Rate index 1 is 10%
+  });
+
+  it('syncs count to 0 when rate is set to 0%', () => {
+    // Set initial rate to 10% and count to 2
+    useStore.getState().TEMP_updateExROptionSelection('1-50', 1);
+    useStore.getState().TEMP_updateExROptionSelection('1-51', 1); // backend index 1 is value 2
+
+    render(
+      <ExRRoleSpawnControls
+        categoryId={1}
+        spawnRateOption={spawnRateOption}
+        spawnCountOption={spawnCountOption}
+      />
+    );
+
+    const rateControl = screen.getByTestId('spawn-rate-control');
+    const slider = rateControl.querySelector('input[type="range"]') as HTMLInputElement;
+
+    fireEvent.change(slider, { target: { value: '0' } });
+
+    const state = useStore.getState();
+    expect(state.effectiveSelections['1-51']).toBe(0); // Count reset to index 0
+
+    // UI should show 0
+    const countDisplay = screen.getByTestId('spawn-count-control').querySelector('input[type="text"]');
+    expect(countDisplay).toHaveValue('0');
+  });
+});


### PR DESCRIPTION
Improved the user experience for role category settings by ensuring "Spawn Rate" and "Spawn Count" are always visible and synchronized.

Key changes:
- Refactored `ExRHeaderOptionControl` to allow parent components to override selection and value lists.
- Modified `ExRRoleCategoryItem` to implement complex synchronization logic:
  - If Spawn Count is set to 0, Spawn Rate is set to 0%.
  - If Spawn Rate is set to 0%, Spawn Count is displayed as 0.
  - If Spawn Count is increased from 0, Spawn Rate is automatically bumped to 10% (if it was 0%).
- Added a virtual "0" value for the Spawn Count UI to ensure it can always be set to zero by the user, regardless of the backend range.
- Updated E2E tests to cover these new interaction rules and ensure regressions are prevented.

---
*PR created automatically by Jules for task [16165599176376963282](https://jules.google.com/task/16165599176376963282) started by @yukieiji*