### PR TITLE
Fix lint and accessibility errors

### DIFF
--- a/src/components/parts/Accordion.tsx
+++ b/src/components/parts/Accordion.tsx
@@ -30,6 +30,7 @@ export function Accordion({
 					viewBox="0 0 24 24"
 					stroke="currentColor"
 				>
+					<title>{isOpen ? "Collapse" : "Expand"}</title>
 					<path
 						strokeLinecap="round"
 						strokeLinejoin="round"

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -32,20 +32,22 @@ export function CompactSlider({
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		e.stopPropagation();
 		const val = parseFloat(e.target.value);
-		if (!isNaN(val)) {
+		if (!Number.isNaN(val)) {
 			onInputChange(val);
 		}
 	};
 
-	const handleClick = (e: React.MouseEvent) => {
+	const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
 		// アコーディオンの開閉を防ぐ
 		e.stopPropagation();
 	};
 
 	return (
-		<div
-			className="flex flex-col gap-1 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50"
+		<fieldset
+			className="flex flex-col gap-1 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50 text-left cursor-default"
 			onClick={handleClick}
+			onKeyDown={handleClick}
+			aria-label={label}
 			data-testid={testId}
 		>
 			<div className="flex items-center justify-between gap-2">
@@ -68,6 +70,6 @@ export function CompactSlider({
 				onChange={handleSliderChange}
 				className="w-20 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
 			/>
-		</div>
+		</fieldset>
 	);
 }

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -22,11 +22,11 @@ export function ExRCategoryOptionList({
 
 	return (
 		<div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
-			{groupedItems.map((item, idx) => {
+			{groupedItems.map((item) => {
 				if ("type" in item && item.type === "pair") {
 					return (
 						<ExRPairedOptionRow
-							key={`pair-${idx}`}
+							key={`pair-${item.baseName}`}
 							categoryId={categoryId}
 							baseName={item.baseName}
 							min={item.min}

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -61,6 +61,7 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 						viewBox="0 0 24 24"
 						stroke="currentColor"
 					>
+						<title>{isOpen ? "Collapse" : "Expand"}</title>
 						<path
 							strokeLinecap="round"
 							strokeLinejoin="round"

--- a/tests/CompactSlider.test.tsx
+++ b/tests/CompactSlider.test.tsx
@@ -44,9 +44,14 @@ describe("CompactSlider", () => {
 	it("stops event propagation on click", () => {
 		const parentClick = vi.fn();
 		render(
-			<div onClick={parentClick}>
+			<button
+				type="button"
+				onClick={parentClick}
+				onKeyDown={parentClick}
+				aria-label="parent"
+			>
 				<CompactSlider {...defaultProps} />
-			</div>,
+			</button>,
 		);
 
 		fireEvent.click(screen.getByText("Test Label"));
@@ -56,9 +61,9 @@ describe("CompactSlider", () => {
 	it("stops event propagation on slider change", () => {
 		const parentChange = vi.fn();
 		render(
-			<div onChange={parentChange}>
+			<form onChange={parentChange}>
 				<CompactSlider {...defaultProps} />
-			</div>,
+			</form>,
 		);
 
 		fireEvent.change(screen.getByRole("slider"), { target: { value: "0" } });

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -67,7 +67,10 @@ describe("ExRHeaderOptionControl", () => {
 		const inputs = screen.getAllByDisplayValue("0");
 		const textInput = inputs.find(
 			(i) => (i as HTMLInputElement).type === "text",
-		)!;
+		);
+		if (!textInput) {
+			throw new Error("Text input not found");
+		}
 
 		fireEvent.change(textInput, { target: { value: "100" } });
 
@@ -78,13 +81,18 @@ describe("ExRHeaderOptionControl", () => {
 	it("prevents click propagation to parent", () => {
 		const parentClick = vi.fn();
 		render(
-			<div onClick={parentClick}>
+			<button
+				type="button"
+				onClick={parentClick}
+				onKeyDown={parentClick}
+				aria-label="parent"
+			>
 				<ExRHeaderOptionControl
 					categoryId={1}
 					option={mockOption}
 					label="Rate"
 				/>
-			</div>,
+			</button>,
 		);
 
 		const label = screen.getByText("Rate");


### PR DESCRIPTION
Fixed multiple lint errors identified by Biome, focusing on accessibility (a11y), suspicious code patterns, and style violations. Specifically:
- `CompactSlider.tsx`: Switched to `Number.isNaN` and converted the container to a `<fieldset>` with an `aria-label` to allow nested inputs while satisfying interaction rules.
- `Accordion.tsx` & `ExRRoleCategoryItem.tsx`: Added descriptive `<title>` tags to SVGs for screen readers.
- `ExRCategoryOptionList.tsx`: Replaced array index keys with `baseName`-based keys for improved React reconciliation.
- Test files: Removed non-null assertions and replaced illegal `div` interaction wrappers with semantic elements like `<button type="button">` and `<form>`, ensuring event propagation tests remain valid.
Verified all changes pass `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [5095984797751286332](https://jules.google.com/task/5095984797751286332) started by @yukieiji*