### PR TITLE
ExRオプション更新のAPI連携と状態管理の改善

### DIFF
--- a/e2e/exr_option_update.spec.ts
+++ b/e2e/exr_option_update.spec.ts
@@ -27,23 +27,24 @@ test("ExR option update flow", async ({ page }) => {
 
 	const toggle = page.getByTestId("option-toggle").first();
 
-    // 初期状態を確認
+	// 初期状態を確認
 	await expect(toggle).toHaveAttribute("aria-checked", "false");
 
-    // PUTリクエストを監視
-    const putRequestPromise = page.waitForRequest(request =>
-        request.url().includes("/exr/option/") && request.method() === "PUT"
-    );
+	// PUTリクエストを監視
+	const putRequestPromise = page.waitForRequest(
+		(request) =>
+			request.url().includes("/exr/option/") && request.method() === "PUT",
+	);
 
 	// トグルを切り替え
 	await toggle.click();
 
-    // リクエストが送信されたことを確認
-    const request = await putRequestPromise;
-    const body = JSON.parse(request.postData() || "{}");
-    expect(body.Selection).toBe(1);
+	// リクエストが送信されたことを確認
+	const request = await putRequestPromise;
+	const body = JSON.parse(request.postData() || "{}");
+	expect(body.Selection).toBe(1);
 
-    // UIが更新されることを確認 (オンに切り替わる)
+	// UIが更新されることを確認 (オンに切り替わる)
 	await expect(toggle).toHaveAttribute("aria-checked", "true");
 	await expect(page.getByText("オン", { exact: true })).toBeVisible();
 });
@@ -52,24 +53,23 @@ test("ExR slider update with debouncing", async ({ page }) => {
 	const sidebar = page.getByLabel("オプションサイドバー");
 	await sidebar.getByRole("button", { name: "ExR Options" }).click();
 
-    // インポスター役職設定タブに切り替え
-    await page.getByRole("button", { name: "インポスター役職設定", exact: true }).click();
+	// インポスター役職設定タブに切り替え
+	await page
+		.getByRole("button", { name: "インポスター役職設定", exact: true })
+		.click();
 
-    // 「シオン」カテゴリを探す (役職カテゴリ)
-    const category = page.getByTestId("exr-category-2"); // 2: インポスター役職タブのカテゴリ
+	// カテゴリ内のスライダーコントロールを探す
+	// 役職スポーンコントロールはヘッダーにある
+	const spawnCountFieldset = page.getByTestId("spawn-count-control").first();
+	const slider = spawnCountFieldset.locator("input[type='range']");
+	const input = spawnCountFieldset.locator("input[type='text']");
 
-    // カテゴリ内のスライダーコントロールを探す
-    // 役職スポーンコントロールはヘッダーにある
-    const spawnCountFieldset = page.getByTestId("spawn-count-control").first();
-    const slider = spawnCountFieldset.locator("input[type='range']");
-    const input = spawnCountFieldset.locator("input[type='text']");
+	// スライダーを操作
+	await slider.fill("5");
 
-    // スライダーを操作
-    await slider.fill("5");
+	// デバウンス待ち
+	await page.waitForTimeout(1000);
 
-    // デバウンス待ち
-    await page.waitForTimeout(1000);
-
-    // 値が反映されていることを確認
-    await expect(input).toHaveValue("5");
+	// 値が反映されていることを確認
+	await expect(input).toHaveValue("5");
 });

--- a/e2e/exr_option_update.spec.ts
+++ b/e2e/exr_option_update.spec.ts
@@ -64,11 +64,17 @@ test("ExR slider update with debouncing", async ({ page }) => {
 	const slider = spawnCountFieldset.locator("input[type='range']");
 	const input = spawnCountFieldset.locator("input[type='text']");
 
+	// PUTリクエストを監視
+	const sliderPutRequestPromise = page.waitForRequest(
+		(request) =>
+			request.url().includes("/exr/option/") && request.method() === "PUT",
+	);
+
 	// スライダーを操作
 	await slider.fill("5");
 
-	// デバウンス待ち
-	await page.waitForTimeout(1000);
+	// リクエストが送信されるのを待つ (デバウンス後)
+	await sliderPutRequestPromise;
 
 	// 値が反映されていることを確認
 	await expect(input).toHaveValue("5");

--- a/e2e/exr_option_update.spec.ts
+++ b/e2e/exr_option_update.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	// すべてのテストで API の遅延を設定可能にする
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 100;
+	});
+
+	await page.goto("/");
+
+	// メインコンテンツが表示されるまで待つ (Suspenseの解決を待つ)
+	await expect(page.getByTestId("main-content-section")).toBeVisible({
+		timeout: 30000,
+	});
+});
+
+test("ExR option update flow", async ({ page }) => {
+	const sidebar = page.getByLabel("オプションサイドバー");
+	await sidebar.getByRole("button", { name: "ExR Options" }).click();
+
+	// カテゴリを展開
+	const shuffleCategory = page.getByRole("button", {
+		name: "乱数に関する設定",
+	});
+	await shuffleCategory.click();
+
+	const toggle = page.getByTestId("option-toggle").first();
+
+    // 初期状態を確認
+	await expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    // PUTリクエストを監視
+    const putRequestPromise = page.waitForRequest(request =>
+        request.url().includes("/exr/option/") && request.method() === "PUT"
+    );
+
+	// トグルを切り替え
+	await toggle.click();
+
+    // リクエストが送信されたことを確認
+    const request = await putRequestPromise;
+    const body = JSON.parse(request.postData() || "{}");
+    expect(body.Selection).toBe(1);
+
+    // UIが更新されることを確認 (オンに切り替わる)
+	await expect(toggle).toHaveAttribute("aria-checked", "true");
+	await expect(page.getByText("オン", { exact: true })).toBeVisible();
+});
+
+test("ExR slider update with debouncing", async ({ page }) => {
+	const sidebar = page.getByLabel("オプションサイドバー");
+	await sidebar.getByRole("button", { name: "ExR Options" }).click();
+
+    // インポスター役職設定タブに切り替え
+    await page.getByRole("button", { name: "インポスター役職設定", exact: true }).click();
+
+    // 「シオン」カテゴリを探す (役職カテゴリ)
+    const category = page.getByTestId("exr-category-2"); // 2: インポスター役職タブのカテゴリ
+
+    // カテゴリ内のスライダーコントロールを探す
+    // 役職スポーンコントロールはヘッダーにある
+    const spawnCountFieldset = page.getByTestId("spawn-count-control").first();
+    const slider = spawnCountFieldset.locator("input[type='range']");
+    const input = spawnCountFieldset.locator("input[type='text']");
+
+    // スライダーを操作
+    await slider.fill("5");
+
+    // デバウンス待ち
+    await page.waitForTimeout(1000);
+
+    // 値が反映されていることを確認
+    await expect(input).toHaveValue("5");
+});

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -4,7 +4,8 @@ import {
   ExRTabDtoArraySchema,
   ExROptionPutRequestSchema,
   UpdatedOptionsSchema,
-  VanillaOptionPutRequestSchema
+  VanillaOptionPutRequestSchema,
+  OptionTab
 } from '../src/type';
 import type { UpdatedOptions, ExRTabDto, AuOptionCategoryDto, ExROptionDto } from '../src/type';
 
@@ -76,13 +77,15 @@ export const handlers = [
 
     const { TabId, CategoryId, OptionId, Selection } = result.data;
 
-    // CategoryIdとOptionIdが0のときは202を返す（ボディなし）
-    if (CategoryId === 0 && OptionId === 0) {
-      return new HttpResponse(null, { status: 202 });
-    }
-
     // データの更新
-    const tab = validatedExRMockData.find((t) => t.Id === TabId);
+    // モックデータ内のId（文字列の場合がある）を数値に変換して比較
+    const getTabIdNum = (id: string | number): number => {
+        if (typeof id === 'number') return id;
+        const mapped = OptionTab[id as keyof typeof OptionTab];
+        return typeof mapped === 'number' ? mapped : Number(id);
+    };
+
+    const tab = validatedExRMockData.find((t) => getTabIdNum(t.Id) === TabId);
     if (!tab) {
         return new HttpResponse(null, { status: 404 });
     }
@@ -118,7 +121,7 @@ export const handlers = [
 
     // 全体のモックデータを更新
     validatedExRMockData = validatedExRMockData.map((t) => {
-        if (t.Id !== TabId) {
+        if (getTabIdNum(t.Id) !== TabId) {
             return t;
         }
         return {
@@ -133,7 +136,7 @@ export const handlers = [
     });
 
     // 更新後のカテゴリとオプションを取得
-    const updatedTab = validatedExRMockData.find((t) => t.Id === TabId);
+    const updatedTab = validatedExRMockData.find((t) => getTabIdNum(t.Id) === TabId);
     const updatedCategory = updatedTab?.Categories.find((c) => c.Id === CategoryId) || null;
 
     // それ以外はUpdatedOptionsを返す

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -96,59 +96,76 @@ export const handlers = [
     }
 
     // 不変性を保ちながらデータを更新
+    const chainUpdatedOptions: ExROptionDto[] = [];
+
     const updateRecursive = (
       options: ExROptionDto[],
-    ): { options: ExROptionDto[]; updatedOption?: ExROptionDto } => {
-      let found: ExROptionDto | undefined;
-      const newOptions = options.map((opt) => {
-        if (opt.Id === OptionId) {
-          found = { ...opt, Selection: Selection };
-          return found;
+      targetId: number,
+      newSelection: number,
+    ): ExROptionDto[] => {
+      return options.map((opt) => {
+        if (opt.Id === targetId) {
+          const updated = { ...opt, Selection: newSelection };
+          chainUpdatedOptions.push(updated);
+          return updated;
         }
         if (opt.Childs.length > 0) {
-          const result = updateRecursive(opt.Childs);
-          if (result.updatedOption) {
-            found = result.updatedOption;
-            return { ...opt, Childs: result.options };
+          const newChilds = updateRecursive(opt.Childs, targetId, newSelection);
+          if (newChilds !== opt.Childs) {
+            return { ...opt, Childs: newChilds };
           }
         }
         return opt;
       });
-      return { options: newOptions, updatedOption: found };
     };
 
-    const { options: newOptions, updatedOption: foundOption } = updateRecursive(
-      category.Options,
-    );
+    // 1. 指定されたオプションを更新
+    let newOptions = updateRecursive(category.Options, OptionId, Selection);
 
-    if (!foundOption) {
+    // 2. 特殊ロジック：スポーンレート・スポーン数の同期（モックのリアリティ向上のため）
+    if (OptionId === 50 && Selection === 0) {
+      // レートが0なら数も0
+      newOptions = updateRecursive(newOptions, 51, 0);
+    } else if (OptionId === 51 && Selection > 0) {
+      // 数が0以外なら、レートが0なら10%(インデックス1)に上げる
+      const rateOpt = newOptions.find((o) => o.Id === 50);
+      if (rateOpt && rateOpt.Selection === 0) {
+        newOptions = updateRecursive(newOptions, 50, 1);
+      }
+    }
+
+    if (chainUpdatedOptions.length === 0) {
       return new HttpResponse(null, { status: 404 });
     }
 
     // 全体のモックデータを更新
     validatedExRMockData = validatedExRMockData.map((t) => {
-        if (getTabIdNum(t.Id) !== TabId) {
-            return t;
-        }
-        return {
-            ...t,
-            Categories: t.Categories.map((c) => {
-                if (c.Id !== CategoryId) {
-                    return c;
-                }
-                return { ...c, Options: newOptions };
-            }),
-        };
+      if (getTabIdNum(t.Id) !== TabId) {
+        return t;
+      }
+      return {
+        ...t,
+        Categories: t.Categories.map((c) => {
+          if (c.Id !== CategoryId) {
+            return c;
+          }
+          return { ...c, Options: newOptions };
+        }),
+      };
     });
 
-    // 更新後のカテゴリとオプションを取得
-    const updatedTab = validatedExRMockData.find((t) => getTabIdNum(t.Id) === TabId);
-    const updatedCategory = updatedTab?.Categories.find((c) => c.Id === CategoryId) || null;
+    // 更新後のカテゴリを取得
+    const updatedTab = validatedExRMockData.find(
+      (t) => getTabIdNum(t.Id) === TabId,
+    );
+    const updatedCategory =
+      updatedTab?.Categories.find((c) => c.Id === CategoryId) || null;
 
-    // それ以外はUpdatedOptionsを返す
+    // ChainUpdatedOption には「副作用」として更新されたもののみを含める
+    // (プライマリな更新は UpdatedCategory に含まれるため)
     const mockUpdatedOptions: UpdatedOptions = {
       UpdatedCategory: updatedCategory,
-      ChainUpdatedOption: [foundOption],
+      ChainUpdatedOption: chainUpdatedOptions.filter((o) => o.Id !== OptionId),
     };
 
     // レスポンスデータのバリデーション

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -6,7 +6,7 @@ import {
   UpdatedOptionsSchema,
   VanillaOptionPutRequestSchema
 } from '../src/type';
-import type { UpdatedOptions, ExRTabDto, AuOptionCategoryDto } from '../src/type';
+import type { UpdatedOptions, ExRTabDto, AuOptionCategoryDto, ExROptionDto } from '../src/type';
 
 // JSONファイルのロード
 import exrOptionData from './get/exr/setting-webui-dev_20260321.json';
@@ -19,8 +19,8 @@ let validatedExRMockData: ExRTabDto[];
 let validatedAuMockData: AuOptionCategoryDto[];
 
 try {
-  validatedExRMockData = ExRTabDtoArraySchema.parse(exrOptionData);
-  validatedAuMockData = AuOptionCategoryDtoArraySchema.parse(auOptionData);
+  validatedExRMockData = ExRTabDtoArraySchema.parse(exrOptionData) as ExRTabDto[];
+  validatedAuMockData = AuOptionCategoryDtoArraySchema.parse(auOptionData) as AuOptionCategoryDto[];
 } catch (error) {
   console.error('Mock data validation failed:', error);
   throw error;
@@ -74,17 +74,72 @@ export const handlers = [
       return new HttpResponse(null, { status: 400 });
     }
 
-    const { CategoryId, OptionId } = result.data;
+    const { TabId, CategoryId, OptionId, Selection } = result.data;
 
     // CategoryIdとOptionIdが0のときは202を返す（ボディなし）
     if (CategoryId === 0 && OptionId === 0) {
       return new HttpResponse(null, { status: 202 });
     }
 
+    // データの更新
+    const tab = validatedExRMockData.find((t) => t.Id === TabId);
+    if (!tab) {
+        return new HttpResponse(null, { status: 404 });
+    }
+
+    const category = tab.Categories.find((c) => c.Id === CategoryId);
+    if (!category) {
+        return new HttpResponse(null, { status: 404 });
+    }
+
+    // 不変性を保ちながらデータを更新
+    let foundOption: ExROptionDto | undefined;
+    const updateRecursive = (options: ExROptionDto[]): ExROptionDto[] => {
+        return options.map((opt) => {
+            if (opt.Id === OptionId) {
+                foundOption = { ...opt, Selection: Selection };
+                return foundOption;
+            }
+            if (opt.Childs.length > 0) {
+                const newChilds = updateRecursive(opt.Childs);
+                if (foundOption) {
+                    return { ...opt, Childs: newChilds };
+                }
+            }
+            return opt;
+        });
+    };
+
+    const newOptions = updateRecursive(category.Options);
+
+    if (!foundOption) {
+        return new HttpResponse(null, { status: 404 });
+    }
+
+    // 全体のモックデータを更新
+    validatedExRMockData = validatedExRMockData.map((t) => {
+        if (t.Id !== TabId) {
+            return t;
+        }
+        return {
+            ...t,
+            Categories: t.Categories.map((c) => {
+                if (c.Id !== CategoryId) {
+                    return c;
+                }
+                return { ...c, Options: newOptions };
+            }),
+        };
+    });
+
+    // 更新後のカテゴリとオプションを取得
+    const updatedTab = validatedExRMockData.find((t) => t.Id === TabId);
+    const updatedCategory = updatedTab?.Categories.find((c) => c.Id === CategoryId) || null;
+
     // それ以外はUpdatedOptionsを返す
     const mockUpdatedOptions: UpdatedOptions = {
-      UpdatedCategory: validatedExRMockData[0].Categories[0],
-      ChainUpdatedOption: [validatedExRMockData[0].Categories[0].Options[0]],
+      UpdatedCategory: updatedCategory,
+      ChainUpdatedOption: [foundOption],
     };
 
     // レスポンスデータのバリデーション

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -96,29 +96,33 @@ export const handlers = [
     }
 
     // 不変性を保ちながらデータを更新
-    let foundOption: ExROptionDto | undefined;
-    const updateRecursive = (options: ExROptionDto[]): ExROptionDto[] => {
-        return options.map((opt) => {
-            if (opt.Id === OptionId) {
-                foundOption = { ...opt, Selection: Selection };
-                return foundOption;
-            }
-            if (opt.Childs.length > 0) {
-                const oldFound = foundOption;
-                const newChilds = updateRecursive(opt.Childs);
-                // 子要素の探索で新しく見つかった場合のみ、オブジェクトを再生成
-                if (foundOption && foundOption !== oldFound) {
-                    return { ...opt, Childs: newChilds };
-                }
-            }
-            return opt;
-        });
+    const updateRecursive = (
+      options: ExROptionDto[],
+    ): { options: ExROptionDto[]; updatedOption?: ExROptionDto } => {
+      let found: ExROptionDto | undefined;
+      const newOptions = options.map((opt) => {
+        if (opt.Id === OptionId) {
+          found = { ...opt, Selection: Selection };
+          return found;
+        }
+        if (opt.Childs.length > 0) {
+          const result = updateRecursive(opt.Childs);
+          if (result.updatedOption) {
+            found = result.updatedOption;
+            return { ...opt, Childs: result.options };
+          }
+        }
+        return opt;
+      });
+      return { options: newOptions, updatedOption: found };
     };
 
-    const newOptions = updateRecursive(category.Options);
+    const { options: newOptions, updatedOption: foundOption } = updateRecursive(
+      category.Options,
+    );
 
     if (!foundOption) {
-        return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 });
     }
 
     // 全体のモックデータを更新

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -104,8 +104,10 @@ export const handlers = [
                 return foundOption;
             }
             if (opt.Childs.length > 0) {
+                const oldFound = foundOption;
                 const newChilds = updateRecursive(opt.Childs);
-                if (foundOption) {
+                // 子要素の探索で新しく見つかった場合のみ、オブジェクトを再生成
+                if (foundOption && foundOption !== oldFound) {
                     return { ...opt, Childs: newChilds };
                 }
             }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:mock": "VITE_USE_MSW=true vite",
-    "dev:no-mock": "VITE_USE_MSW=false vite",
+    "dev:mock": "cross-env VITE_USE_MSW=true vite",
+    "dev:no-mock": "cross-env VITE_USE_MSW=false vite",
     "build": "tsc -b && vite build",
     "lint": "biome lint",
     "format": "biome format",
@@ -37,6 +37,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/ui": "^4.1.0",
     "babel-plugin-react-compiler": "^1.0.0",
+    "cross-env": "^10.1.0",
     "jsdom": "^29.0.1",
     "msw": "^2.12.14",
     "typescript": "~6.0.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:mock": "VITE_USE_MSW=true vite",
+    "dev:no-mock": "VITE_USE_MSW=false vite",
     "build": "tsc -b && vite build",
     "lint": "biome lint",
     "format": "biome format",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -191,24 +194,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.8':
     resolution: {integrity: sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.8':
     resolution: {integrity: sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.8':
     resolution: {integrity: sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.8':
     resolution: {integrity: sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==}
@@ -270,6 +277,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
@@ -393,36 +403,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
     resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
@@ -511,24 +527,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -742,6 +762,15 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -871,6 +900,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -932,24 +964,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1025,6 +1061,10 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -1107,6 +1147,14 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1317,6 +1365,11 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -1580,6 +1633,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@epic-web/invariant@1.0.0': {}
 
   '@exodus/bytes@1.15.0': {}
 
@@ -1991,6 +2046,17 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -2079,6 +2145,8 @@ snapshots:
   is-node-process@1.2.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  isexe@2.0.0: {}
 
   jiti@2.6.1: {}
 
@@ -2222,6 +2290,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  path-key@3.1.1: {}
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
@@ -2302,6 +2372,12 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
 
@@ -2449,6 +2525,10 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Suspense, use } from "react";
 import { AuOptionEditor } from "./feature/AuOptionEditor";
 import { ExROptionEditor } from "./feature/ExROptionEditor";
-import { LoadingView } from "./feature/LoadingView";
+import { LoadingView } from "./components/parts/LoadingView";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { PresetSelector } from "./feature/PresetSelector";
 import { getAuOptions, getExrOptions } from "./logics/api";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Suspense, use } from "react";
+import { LoadingView } from "./components/parts/LoadingView";
 import { AuOptionEditor } from "./feature/AuOptionEditor";
 import { ExROptionEditor } from "./feature/ExROptionEditor";
-import { LoadingView } from "./components/parts/LoadingView";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { PresetSelector } from "./feature/PresetSelector";
 import { getAuOptions, getExrOptions } from "./logics/api";
@@ -47,6 +47,9 @@ function MainContent() {
 	const isSidebarPending = useStore((state) => {
 		return state.isSidebarPending;
 	});
+	const dataVersion = useStore((state) => {
+		return state.dataVersion;
+	});
 
 	return (
 		<section
@@ -64,7 +67,7 @@ function MainContent() {
 							<div className="w-48 h-8 bg-gray-700 animate-pulse rounded" />
 						}
 					>
-						<PresetSelectorContainer />
+						<PresetSelectorContainer key={`preset-${dataVersion}`} />
 					</Suspense>
 				)}
 				{isSidebarPending && (
@@ -78,7 +81,7 @@ function MainContent() {
 					</div>
 				}
 			>
-				<EditorContainer />
+				<EditorContainer key={`editor-${dataVersion}`} />
 			</Suspense>
 		</section>
 	);
@@ -94,17 +97,17 @@ function App() {
 
 	return (
 		<div className="min-h-screen bg-gray-50 flex">
-			<Suspense fallback={<LoadingView />}>
-				<OptionGroupToggleSidebar />
-				<main
-					className={`
+			<OptionGroupToggleSidebar />
+			<main
+				className={`
             flex-1 p-8 transition-all duration-300
             ${isSidebarOpen ? "ml-64" : "ml-12"}
           `}
-				>
+			>
+				<Suspense fallback={<LoadingView />}>
 					<MainContent />
-				</main>
-			</Suspense>
+				</Suspense>
+			</main>
 		</div>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,17 +97,17 @@ function App() {
 
 	return (
 		<div className="min-h-screen bg-gray-50 flex">
-			<OptionGroupToggleSidebar />
-			<main
-				className={`
+			<Suspense fallback={<LoadingView />}>
+				<OptionGroupToggleSidebar />
+				<main
+					className={`
             flex-1 p-8 transition-all duration-300
             ${isSidebarOpen ? "ml-64" : "ml-12"}
           `}
-			>
-				<Suspense fallback={<LoadingView />}>
+				>
 					<MainContent />
-				</Suspense>
-			</main>
+				</main>
+			</Suspense>
 		</div>
 	);
 }

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import type React from "react";
 
 interface CompactSliderProps {
@@ -22,11 +23,28 @@ export function CompactSlider({
 	onInputChange,
 	testId,
 }: CompactSliderProps) {
-	const currentValue = values[currentSelection] ?? values[0] ?? 0;
+	const [localSelection, setLocalSelection] = useState(currentSelection);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// Propsが変わった場合にローカルの状態を同期させる
+	useEffect(() => {
+		setLocalSelection(currentSelection);
+	}, [currentSelection]);
+
+	const currentValue = values[localSelection] ?? values[0] ?? 0;
 
 	const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		e.stopPropagation();
-		onSelectionChange(parseInt(e.target.value, 10));
+		const newSelection = parseInt(e.target.value, 10);
+		setLocalSelection(newSelection);
+
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current);
+		}
+
+		timeoutRef.current = setTimeout(() => {
+			onSelectionChange(newSelection);
+		}, 300);
 	};
 
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -66,7 +84,7 @@ export function CompactSlider({
 				min={0}
 				max={values.length - 1}
 				step={1}
-				value={currentSelection}
+				value={localSelection}
 				onChange={handleSliderChange}
 				className="w-20 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
 			/>

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,5 +1,5 @@
-import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import type React from "react";
 
 interface CompactSliderProps {
 	label: string;

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { useDebouncedCallback } from "../../hooks/useDebouncedCallback";
 
 interface CompactSliderProps {
 	label: string;
@@ -24,12 +25,16 @@ export function CompactSlider({
 	testId,
 }: CompactSliderProps) {
 	const [localSelection, setLocalSelection] = useState(currentSelection);
-	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	// Propsが変わった場合にローカルの状態を同期させる
 	useEffect(() => {
 		setLocalSelection(currentSelection);
 	}, [currentSelection]);
+
+	const debouncedOnSelectionChange = useDebouncedCallback(
+		onSelectionChange,
+		300,
+	);
 
 	const currentValue = values[localSelection] ?? values[0] ?? 0;
 
@@ -37,14 +42,7 @@ export function CompactSlider({
 		e.stopPropagation();
 		const newSelection = parseInt(e.target.value, 10);
 		setLocalSelection(newSelection);
-
-		if (timeoutRef.current) {
-			clearTimeout(timeoutRef.current);
-		}
-
-		timeoutRef.current = setTimeout(() => {
-			onSelectionChange(newSelection);
-		}, 300);
+		debouncedOnSelectionChange(newSelection);
 	};
 
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,5 +1,4 @@
 import type React from "react";
-import { useEffect, useState } from "react";
 import { useDebouncedCallback } from "../../hooks/useDebouncedCallback";
 
 interface CompactSliderProps {
@@ -24,24 +23,16 @@ export function CompactSlider({
 	onInputChange,
 	testId,
 }: CompactSliderProps) {
-	const [localSelection, setLocalSelection] = useState(currentSelection);
-
-	// Propsが変わった場合にローカルの状態を同期させる
-	useEffect(() => {
-		setLocalSelection(currentSelection);
-	}, [currentSelection]);
-
 	const debouncedOnSelectionChange = useDebouncedCallback(
 		onSelectionChange,
 		300,
 	);
 
-	const currentValue = values[localSelection] ?? values[0] ?? 0;
+	const currentValue = values[currentSelection] ?? values[0] ?? 0;
 
 	const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		e.stopPropagation();
 		const newSelection = parseInt(e.target.value, 10);
-		setLocalSelection(newSelection);
 		debouncedOnSelectionChange(newSelection);
 	};
 
@@ -82,7 +73,7 @@ export function CompactSlider({
 				min={0}
 				max={values.length - 1}
 				step={1}
-				value={localSelection}
+				value={currentSelection}
 				onChange={handleSliderChange}
 				className="w-20 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
 			/>

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
 import type React from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface CompactSliderProps {
 	label: string;

--- a/src/components/parts/OptionSliderControl.tsx
+++ b/src/components/parts/OptionSliderControl.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { useDebouncedCallback } from "../../hooks/useDebouncedCallback";
 import { findClosestIndex } from "../../logics/optionUtils";
 
 interface OptionSliderControlProps {
@@ -20,26 +21,20 @@ export function OptionSliderControl({
 	disabled = false,
 }: OptionSliderControlProps) {
 	const [localSelection, setLocalSelection] = useState(selection);
-	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	// Propsが変わった場合にローカルの状態を同期させる
 	useEffect(() => {
 		setLocalSelection(selection);
 	}, [selection]);
 
+	const debouncedOnChange = useDebouncedCallback(onChange, 300);
+
 	const currentValue = values[localSelection] ?? values[0] ?? 0;
 
 	const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const newSelection = parseInt(e.target.value, 10);
 		setLocalSelection(newSelection);
-
-		if (timeoutRef.current) {
-			clearTimeout(timeoutRef.current);
-		}
-
-		timeoutRef.current = setTimeout(() => {
-			onChange(newSelection);
-		}, 300);
+		debouncedOnChange(newSelection);
 	};
 
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/parts/OptionSliderControl.tsx
+++ b/src/components/parts/OptionSliderControl.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { useDebouncedCallback } from "../../hooks/useDebouncedCallback";
 import { findClosestIndex } from "../../logics/optionUtils";
 
@@ -20,20 +19,12 @@ export function OptionSliderControl({
 	onChange,
 	disabled = false,
 }: OptionSliderControlProps) {
-	const [localSelection, setLocalSelection] = useState(selection);
-
-	// Propsが変わった場合にローカルの状態を同期させる
-	useEffect(() => {
-		setLocalSelection(selection);
-	}, [selection]);
-
 	const debouncedOnChange = useDebouncedCallback(onChange, 300);
 
-	const currentValue = values[localSelection] ?? values[0] ?? 0;
+	const currentValue = values[selection] ?? values[0] ?? 0;
 
 	const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const newSelection = parseInt(e.target.value, 10);
-		setLocalSelection(newSelection);
 		debouncedOnChange(newSelection);
 	};
 
@@ -57,7 +48,7 @@ export function OptionSliderControl({
 				min={0}
 				max={values.length - 1}
 				step={1}
-				value={localSelection}
+				value={selection}
 				onChange={handleSliderChange}
 				disabled={disabled}
 				className="flex-1 h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"

--- a/src/components/parts/OptionSliderControl.tsx
+++ b/src/components/parts/OptionSliderControl.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { findClosestIndex } from "../../logics/optionUtils";
 
 interface OptionSliderControlProps {
@@ -18,10 +19,27 @@ export function OptionSliderControl({
 	onChange,
 	disabled = false,
 }: OptionSliderControlProps) {
-	const currentValue = values[selection] ?? values[0] ?? 0;
+	const [localSelection, setLocalSelection] = useState(selection);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// Propsが変わった場合にローカルの状態を同期させる
+	useEffect(() => {
+		setLocalSelection(selection);
+	}, [selection]);
+
+	const currentValue = values[localSelection] ?? values[0] ?? 0;
 
 	const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		onChange(parseInt(e.target.value, 10));
+		const newSelection = parseInt(e.target.value, 10);
+		setLocalSelection(newSelection);
+
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current);
+		}
+
+		timeoutRef.current = setTimeout(() => {
+			onChange(newSelection);
+		}, 300);
 	};
 
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -44,7 +62,7 @@ export function OptionSliderControl({
 				min={0}
 				max={values.length - 1}
 				step={1}
-				value={selection}
+				value={localSelection}
 				onChange={handleSliderChange}
 				disabled={disabled}
 				className="flex-1 h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -19,10 +19,6 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
 	const isTabPending = useStore((state) => {
 		return state.isTabPending;
 	});
-	// dataVersion を購読して再レンダリングをトリガーする
-	useStore((state) => {
-		return state.dataVersion;
-	});
 
 	let selectedTab = tabs.find((tab) => {
 		return tab.Id === selectedExRTabId;

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -19,6 +19,10 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
 	const isTabPending = useStore((state) => {
 		return state.isTabPending;
 	});
+	// dataVersion を購読して再レンダリングをトリガーする
+	useStore((state) => {
+		return state.dataVersion;
+	});
 
 	let selectedTab = tabs.find((tab) => {
 		return tab.Id === selectedExRTabId;

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -36,11 +36,12 @@ export function ExRCategoryOptionList({
 						/>
 					);
 				}
+				const option = item as ExROptionDto;
 				return (
 					<ExROptionItem
-						key={"Id" in item ? item.Id : `pair-${item.baseName}`}
+						key={option.Id}
 						categoryId={categoryId}
-						option={"Id" in item ? item : item.min}
+						option={option}
 					/>
 				);
 			})}

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -37,7 +37,11 @@ export function ExRCategoryOptionList({
 					);
 				}
 				return (
-					<ExROptionItem key={item.Id} categoryId={categoryId} option={item} />
+					<ExROptionItem
+						key={"Id" in item ? item.Id : `pair-${item.baseName}`}
+						categoryId={categoryId}
+						option={"Id" in item ? item : item.min}
+					/>
 				);
 			})}
 		</div>

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -1,5 +1,5 @@
 import { CompactSlider } from "../components/parts/CompactSlider";
-import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
+import { findClosestIndex } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 
@@ -18,23 +18,19 @@ export function ExRHeaderOptionControl({
 	option,
 	label,
 }: ExRHeaderOptionControlProps) {
-	const uniqueId = getUniqueOptionId(categoryId, option.Id);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
-	});
-	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const currentSelection = option.Selection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const values = option.RangeMeta.Values as number[];
 
 	const handleSelectionChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(categoryId, option.Id, newSelection);
 	};
 
 	const handleInputChange = (val: number) => {
-		TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+		updateExROptionSelection(categoryId, option.Id, findClosestIndex(values, val));
 	};
 
 	return (

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -30,7 +30,11 @@ export function ExRHeaderOptionControl({
 	};
 
 	const handleInputChange = (val: number) => {
-		updateExROptionSelection(categoryId, option.Id, findClosestIndex(values, val));
+		updateExROptionSelection(
+			categoryId,
+			option.Id,
+			findClosestIndex(values, val),
+		);
 	};
 
 	return (

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -1,7 +1,6 @@
 import { OptionToggleControl } from "../components/blocks/OptionToggleControl";
 import { OptionDropdownControl } from "../components/parts/OptionDropdownControl";
 import { OptionSliderControl } from "../components/parts/OptionSliderControl";
-import { getUniqueOptionId } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 
@@ -17,17 +16,13 @@ export function ExROptionControl({
 	categoryId,
 	option,
 }: ExROptionControlProps) {
-	const uniqueId = getUniqueOptionId(categoryId, option.Id);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
-	});
-	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const currentSelection = option.Selection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const handleChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(categoryId, option.Id, newSelection);
 	};
 
 	const { Type, Values } = option.RangeMeta;

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -2,7 +2,6 @@ import { OptionPairedSliderControl } from "../components/blocks/OptionPairedSlid
 import { OptionItem } from "../components/parts/OptionItem";
 import { OptionNameDisplay } from "../components/parts/OptionNameDisplay";
 import { OptionRowContainer } from "../components/parts/OptionRowContainer";
-import { getUniqueOptionId } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 
@@ -26,29 +25,19 @@ export function ExRPairedOptionRow({
 	minLabel,
 	maxLabel,
 }: ExRPairedOptionRowProps) {
-	const minUniqueId = getUniqueOptionId(categoryId, min.Id);
-	const maxUniqueId = getUniqueOptionId(categoryId, max.Id);
+	const minSelection = min.Selection;
+	const maxSelection = max.Selection;
 
-	const effectiveMinSelection = useStore((state) => {
-		return state.effectiveSelections[minUniqueId];
-	});
-	const effectiveMaxSelection = useStore((state) => {
-		return state.effectiveSelections[maxUniqueId];
-	});
-
-	const minSelection = effectiveMinSelection ?? min.Selection;
-	const maxSelection = effectiveMaxSelection ?? max.Selection;
-
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const handleMinChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(minUniqueId, newSelection);
+		updateExROptionSelection(categoryId, min.Id, newSelection);
 	};
 
 	const handleMaxChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(maxUniqueId, newSelection);
+		updateExROptionSelection(categoryId, max.Id, newSelection);
 	};
 
 	const content = (

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -1,5 +1,5 @@
 import { CompactSlider } from "../components/parts/CompactSlider";
-import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
+import { findClosestIndex } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 
@@ -17,25 +17,12 @@ export function ExRRoleSpawnControls({
 	spawnRateOption,
 	spawnCountOption,
 }: ExRRoleSpawnControlsProps) {
-	const uniqueRateId = getUniqueOptionId(categoryId, 50);
-	const uniqueCountId = getUniqueOptionId(categoryId, 51);
+	const spawnRateSelection = spawnRateOption.Selection;
+	const spawnCountSelection = spawnCountOption.Selection;
 
-	const effectiveSpawnRateSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueRateId];
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
-
-	const effectiveSpawnCountSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueCountId];
-	});
-
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
-	});
-
-	const spawnRateSelection =
-		effectiveSpawnRateSelection ?? spawnRateOption.Selection;
-	const spawnCountSelection =
-		effectiveSpawnCountSelection ?? spawnCountOption.Selection;
 
 	const rateValues = spawnRateOption.RangeMeta.Values as number[];
 	const originalCountValues = spawnCountOption.RangeMeta.Values as number[];
@@ -47,12 +34,12 @@ export function ExRRoleSpawnControls({
 	const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
-	const handleRateChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueRateId, newSelection);
+	const handleRateChange = async (newSelection: number) => {
+		await updateExROptionSelection(categoryId, 50, newSelection);
 
 		// スポーンレートが0%なら、スポーン数も0としてリセット
 		if (rateValues[newSelection] === 0) {
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			await updateExROptionSelection(categoryId, 51, 0);
 		}
 	};
 
@@ -60,23 +47,25 @@ export function ExRRoleSpawnControls({
 		handleRateChange(findClosestIndex(rateValues, val));
 	};
 
-	const handleCountUIChange = (newUISelection: number) => {
+	const handleCountUIChange = async (newUISelection: number) => {
 		if (newUISelection === 0) {
 			// 数を0にすると、レートも0%にする
-			TEMP_updateExROptionSelection(
-				uniqueRateId,
+			await updateExROptionSelection(
+				categoryId,
+				50,
 				findClosestIndex(rateValues, 0),
 			);
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			await updateExROptionSelection(categoryId, 51, 0);
 		} else {
 			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
 			if (isSpawnRateZero) {
-				TEMP_updateExROptionSelection(
-					uniqueRateId,
+				await updateExROptionSelection(
+					categoryId,
+					50,
 					findClosestIndex(rateValues, 10),
 				);
 			}
-			TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
+			await updateExROptionSelection(categoryId, 51, newUISelection - 1);
 		}
 	};
 

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -15,11 +15,6 @@ interface PresetSelectorProps {
  * ユーザー入力ごとの Cookie 書き込みを避けるため、onBlur または Enter キー入力時に更新を行います。
  */
 export function PresetSelector({ tabs }: PresetSelectorProps) {
-	// dataVersion を購読して再レンダリングをトリガーする
-	useStore((state) => {
-		return state.dataVersion;
-	});
-
 	// GeneralTab (Id: 0) から プリセットカテゴリ (Id: 0) を探す
 	const generalTab = tabs.find((t) => {
 		return t.Id === 0;

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { getUniqueOptionId } from "../logics/optionUtils";
 import type { ExRTabDto } from "../type";
 import { useStore } from "../useStore";
 
@@ -16,6 +15,11 @@ interface PresetSelectorProps {
  * ユーザー入力ごとの Cookie 書き込みを避けるため、onBlur または Enter キー入力時に更新を行います。
  */
 export function PresetSelector({ tabs }: PresetSelectorProps) {
+	// dataVersion を購読して再レンダリングをトリガーする
+	useStore((state) => {
+		return state.dataVersion;
+	});
+
 	// GeneralTab (Id: 0) から プリセットカテゴリ (Id: 0) を探す
 	const generalTab = tabs.find((t) => {
 		return t.Id === 0;
@@ -27,11 +31,7 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 		return o.Id === 0;
 	});
 
-	const uniqueId = getUniqueOptionId(0, 0);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
-	});
-	const currentSelection = effectiveSelection ?? presetOption?.Selection ?? 0;
+	const currentSelection = presetOption?.Selection ?? 0;
 
 	const presetNames = useStore((state) => {
 		return state.presetNames;
@@ -42,8 +42,8 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 	const updatePresetName = useStore((state) => {
 		return state.updatePresetName;
 	});
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 	const setPresetDropdownOpen = useStore((state) => {
 		return state.setPresetDropdownOpen;
@@ -78,7 +78,7 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
 	const handlePresetSelect = (index: number) => {
-		TEMP_updateExROptionSelection(uniqueId, index);
+		updateExROptionSelection(0, 0, index);
 		setPresetDropdownOpen(false);
 	};
 
@@ -117,7 +117,7 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 				<input
 					ref={inputRef}
 					type="text"
-					key={currentSelection}
+					key={`${currentSelection}-${currentPresetName}`}
 					defaultValue={currentPresetName}
 					onBlur={handleBlur}
 					onKeyDown={handleKeyDown}

--- a/src/hooks/useDebouncedCallback.ts
+++ b/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * コールバック関数をデバウンス（一定時間経過後に実行）するためのフック。
+ *
+ * @param callback 実行したい関数
+ * @param delay デバウンス時間 (ms)
+ * @returns デバウンスされた関数
+ */
+export function useDebouncedCallback<T extends unknown[]>(
+	callback: (...args: T) => void,
+	delay: number,
+) {
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// コンポーネントのアンマウント時にタイマーをクリア
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+			}
+		};
+	}, []);
+
+	return (...args: T) => {
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current);
+		}
+
+		timeoutRef.current = setTimeout(() => {
+			callback(...args);
+		}, delay);
+	};
+}

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -10,9 +10,8 @@ import {
 /**
  * API エンドポイントの定数定義
  */
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
-const EXR_OPTION_URL = `${API_BASE_URL}/exr/option/`;
-const AU_OPTION_URL = `${API_BASE_URL}/au/option/`;
+const EXR_OPTION_URL = "/exr/option/";
+const AU_OPTION_URL = "/au/option/";
 
 /**
  * APIからデータを取得するPromiseをキャッシュするためのグローバル変数

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -1,4 +1,10 @@
-import type { AuOptionCategoryDto, ExRTabDto } from "../type";
+import type {
+	AuOptionCategoryDto,
+	ExROptionDto,
+	ExROptionPutRequest,
+	ExRTabDto,
+	UpdatedOptions,
+} from "../type";
 
 /**
  * API エンドポイントの定数定義
@@ -19,6 +25,80 @@ let auOptionsPromise: Promise<AuOptionCategoryDto[]> | null = null;
 export function resetApiCache() {
 	exrOptionsPromise = null;
 	auOptionsPromise = null;
+}
+
+/**
+ * キャッシュされているExRオプションのデータを更新する
+ */
+export function updateExrOptionsCache(
+	updates: UpdatedOptions,
+	tabId: number,
+): void {
+	if (!exrOptionsPromise) {
+		return;
+	}
+
+	exrOptionsPromise = exrOptionsPromise.then((currentData) => {
+		return applyUpdates(currentData, updates, tabId);
+	});
+}
+
+/**
+ * オプションのデータ構造に更新を適用する
+ */
+function applyUpdates(
+	tabs: ExRTabDto[],
+	updates: UpdatedOptions,
+	tabId: number,
+): ExRTabDto[] {
+	return tabs.map((tab) => {
+		if (tab.Id !== tabId) {
+			return tab;
+		}
+
+		let newCategories = tab.Categories;
+		if (updates.UpdatedCategory) {
+			newCategories = newCategories.map((cat) => {
+				return cat.Id === updates.UpdatedCategory?.Id
+					? updates.UpdatedCategory
+					: cat;
+			});
+		}
+
+		if (updates.ChainUpdatedOption.length > 0) {
+			newCategories = newCategories.map((cat) => {
+				return {
+					...cat,
+					Options: cat.Options.map((opt) => {
+						return updateOptionRecursive(opt, updates.ChainUpdatedOption);
+					}),
+				};
+			});
+		}
+
+		return { ...tab, Categories: newCategories };
+	});
+}
+
+/**
+ * 再帰的にオプションを更新する
+ */
+function updateOptionRecursive(
+	option: ExROptionDto,
+	chainUpdates: ExROptionDto[],
+): ExROptionDto {
+	const update = chainUpdates.find((u) => {
+		return u.Id === option.Id;
+	});
+	const newOption = update ? { ...update } : { ...option };
+
+	if (newOption.Childs.length > 0) {
+		newOption.Childs = newOption.Childs.map((child) => {
+			return updateOptionRecursive(child, chainUpdates);
+		});
+	}
+
+	return newOption;
 }
 
 /**
@@ -73,6 +153,32 @@ export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
 	})();
 
 	return auOptionsPromise;
+}
+
+/**
+ * ExRオプションを更新する
+ */
+export async function updateExrOption(
+	params: ExROptionPutRequest,
+): Promise<UpdatedOptions> {
+	const res = await fetch(EXR_OPTION_URL, {
+		method: "PUT",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(params),
+	});
+
+	if (!res.ok) {
+		throw new Error(`Failed to update ExR option: ${res.statusText}`);
+	}
+
+	const updated: UpdatedOptions = await res.json();
+
+	// キャッシュを更新
+	updateExrOptionsCache(updated, params.TabId);
+
+	return updated;
 }
 
 /**

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -1,9 +1,10 @@
-import type {
-	AuOptionCategoryDto,
-	ExROptionDto,
-	ExROptionPutRequest,
-	ExRTabDto,
-	UpdatedOptions,
+import {
+	type AuOptionCategoryDto,
+	type ExROptionDto,
+	type ExROptionPutRequest,
+	type ExRTabDto,
+	OptionTab,
+	type UpdatedOptions,
 } from "../type";
 
 /**
@@ -30,17 +31,17 @@ export function resetApiCache() {
 /**
  * キャッシュされているExRオプションのデータを更新する
  */
-export function updateExrOptionsCache(
+export async function updateExrOptionsCache(
 	updates: UpdatedOptions,
 	tabId: number,
-): void {
+): Promise<void> {
 	if (!exrOptionsPromise) {
 		return;
 	}
 
-	exrOptionsPromise = exrOptionsPromise.then((currentData) => {
-		return applyUpdates(currentData, updates, tabId);
-	});
+	const currentData = await exrOptionsPromise;
+	const newData = applyUpdates(currentData, updates, tabId);
+	exrOptionsPromise = Promise.resolve(newData);
 }
 
 /**
@@ -51,17 +52,31 @@ function applyUpdates(
 	updates: UpdatedOptions,
 	tabId: number,
 ): ExRTabDto[] {
+	const targetIdNum = Number(tabId);
 	return tabs.map((tab) => {
-		if (tab.Id !== tabId) {
+		// IDを数値に変換して比較
+		let currentTabIdNum: number;
+		if (typeof tab.Id === "number") {
+			currentTabIdNum = tab.Id;
+		} else {
+			const mappedId = OptionTab[tab.Id as keyof typeof OptionTab];
+			currentTabIdNum =
+				typeof mappedId === "number" ? mappedId : Number(tab.Id);
+		}
+
+		if (currentTabIdNum !== targetIdNum) {
 			return tab;
 		}
 
-		let newCategories = tab.Categories;
+		let newCategories = [...tab.Categories];
+
 		if (updates.UpdatedCategory) {
+			const updatedCat = updates.UpdatedCategory;
 			newCategories = newCategories.map((cat) => {
-				return cat.Id === updates.UpdatedCategory?.Id
-					? updates.UpdatedCategory
-					: cat;
+				if (cat.Id === updatedCat.Id) {
+					return { ...updatedCat };
+				}
+				return cat;
 			});
 		}
 
@@ -176,7 +191,7 @@ export async function updateExrOption(
 	const updated: UpdatedOptions = await res.json();
 
 	// キャッシュを更新
-	updateExrOptionsCache(updated, params.TabId);
+	await updateExrOptionsCache(updated, params.TabId);
 
 	return updated;
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -34,13 +34,14 @@ export function resetApiCache() {
 export async function updateExrOptionsCache(
 	updates: UpdatedOptions,
 	tabId: number,
+	categoryId: number,
 ): Promise<void> {
 	if (!exrOptionsPromise) {
 		return;
 	}
 
 	const currentData = await exrOptionsPromise;
-	const newData = applyUpdates(currentData, updates, tabId);
+	const newData = applyUpdates(currentData, updates, tabId, categoryId);
 	exrOptionsPromise = Promise.resolve(newData);
 }
 
@@ -51,6 +52,7 @@ function applyUpdates(
 	tabs: ExRTabDto[],
 	updates: UpdatedOptions,
 	tabId: number,
+	categoryId: number,
 ): ExRTabDto[] {
 	const targetIdNum = Number(tabId);
 	return tabs.map((tab) => {
@@ -80,8 +82,13 @@ function applyUpdates(
 			});
 		}
 
+		// ChainUpdatedOption は更新対象のカテゴリ内のみに適用する
+		// オプションIDはカテゴリ内でのみ一意であるため、全カテゴリに適用すると重複や誤更新が発生する
 		if (updates.ChainUpdatedOption.length > 0) {
 			newCategories = newCategories.map((cat) => {
+				if (cat.Id !== categoryId) {
+					return cat;
+				}
 				return {
 					...cat,
 					Options: cat.Options.map((opt) => {
@@ -191,7 +198,7 @@ export async function updateExrOption(
 	const updated: UpdatedOptions = await res.json();
 
 	// キャッシュを更新
-	await updateExrOptionsCache(updated, params.TabId);
+	await updateExrOptionsCache(updated, params.TabId, params.CategoryId);
 
 	return updated;
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -10,8 +10,9 @@ import {
 /**
  * API エンドポイントの定数定義
  */
-const EXR_OPTION_URL = "/exr/option/";
-const AU_OPTION_URL = "/au/option/";
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+const EXR_OPTION_URL = `${API_BASE_URL}/exr/option/`;
+const AU_OPTION_URL = `${API_BASE_URL}/au/option/`;
 
 /**
  * APIからデータを取得するPromiseをキャッシュするためのグローバル変数

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,13 @@ if (import.meta.env.DEV) {
  * 開発環境の場合にMSWを有効化
  */
 async function enableMocking() {
-	if (!import.meta.env.DEV) {
+	// VITE_USE_MSW が明示的に "false" の場合は無効化
+	if (import.meta.env.VITE_USE_MSW === "false") {
+		return;
+	}
+
+	// 開発モード以外、かつ VITE_USE_MSW が "true" でない場合は無効化
+	if (!import.meta.env.DEV && import.meta.env.VITE_USE_MSW !== "true") {
 		return;
 	}
 

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from "zustand";
+import { updateExrOption } from "../logics/api";
 import {
 	loadPresetNamesFromCookie,
 	savePresetNamesToCookie,
@@ -13,17 +14,18 @@ export interface OptionViewerSlice {
 	isTabPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<string, boolean>;
-	effectiveSelections: Record<string, number>;
+	dataVersion: number;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
 	setSelectedExRTabId: (id: OptionTab) => void;
 	setIsTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: string) => void;
-	TEMP_updateExROptionSelection: (
-		uniqueOptionId: string,
+	updateExROptionSelection: (
+		categoryId: number,
+		optionId: number,
 		selection: number,
-	) => void;
+	) => Promise<void>;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
 	resetViewer: () => void;
@@ -34,13 +36,14 @@ export interface OptionViewerSlice {
  */
 export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 	set,
+	get,
 ) => {
 	return {
 		selectedExRTabId: 0,
 		isTabPending: false,
 		openedExRCategoryIds: {},
 		openedExROptionIds: {},
-		effectiveSelections: {},
+		dataVersion: 0,
 		presetNames: loadPresetNamesFromCookie(),
 		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: OptionTab) => {
@@ -55,7 +58,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				isTabPending: false,
 				openedExRCategoryIds: {},
 				openedExROptionIds: {},
-				effectiveSelections: {},
+				dataVersion: 0,
 				isPresetDropdownOpen: false,
 			});
 		},
@@ -79,18 +82,23 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				};
 			});
 		},
-		TEMP_updateExROptionSelection: (
-			uniqueOptionId: string,
+		updateExROptionSelection: async (
+			categoryId: number,
+			optionId: number,
 			selection: number,
 		) => {
-			set((state) => {
-				return {
-					effectiveSelections: {
-						...state.effectiveSelections,
-						[uniqueOptionId]: selection,
-					},
-				};
-			});
+			const { selectedExRTabId } = get() as OptionViewerSlice;
+			try {
+				await updateExrOption({
+					TabId: selectedExRTabId,
+					CategoryId: categoryId,
+					OptionId: optionId,
+					Selection: selection,
+				});
+				set((state) => ({ dataVersion: state.dataVersion + 1 }));
+			} catch (error) {
+				console.error("Failed to update ExR option:", error);
+			}
 		},
 		updatePresetName: (presetIndex: number, name: string) => {
 			set((state) => {

--- a/tests/CompactSlider.test.tsx
+++ b/tests/CompactSlider.test.tsx
@@ -19,7 +19,8 @@ describe("CompactSlider", () => {
 		expect(screen.getByDisplayValue("10")).toBeInTheDocument();
 	});
 
-	it("calls onSelectionChange when slider is moved", () => {
+	it("calls onSelectionChange when slider is moved after debounce", () => {
+		vi.useFakeTimers();
 		const onSelectionChange = vi.fn();
 		render(
 			<CompactSlider {...defaultProps} onSelectionChange={onSelectionChange} />,
@@ -28,7 +29,11 @@ describe("CompactSlider", () => {
 		const slider = screen.getByRole("slider");
 		fireEvent.change(slider, { target: { value: "2" } });
 
+		expect(onSelectionChange).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(300);
 		expect(onSelectionChange).toHaveBeenCalledWith(2);
+		vi.useRealTimers();
 	});
 
 	it("calls onInputChange when text input is changed", () => {

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -1,8 +1,18 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
 import type { ExROptionDto } from "../src/type";
 import { useStore } from "../src/useStore";
+
+vi.mock("../src/logics/api", () => ({
+	updateExrOption: vi.fn().mockResolvedValue({
+		UpdatedCategory: null,
+		ChainUpdatedOption: [],
+	}),
+	getExrOptions: vi.fn(),
+	getAuOptions: vi.fn(),
+	updateExrOptionsCache: vi.fn(),
+}));
 
 describe("ExRHeaderOptionControl", () => {
 	const mockOption: ExROptionDto = {
@@ -38,7 +48,12 @@ describe("ExRHeaderOptionControl", () => {
 		expect(textInput).toBeInTheDocument();
 	});
 
-	it("updates selection when slider is moved", () => {
+	it("updates selection when slider is moved", async () => {
+		const updateExROptionSelection = vi.spyOn(
+			useStore.getState(),
+			"updateExROptionSelection",
+		);
+
 		render(
 			<ExRHeaderOptionControl
 				categoryId={1}
@@ -48,14 +63,22 @@ describe("ExRHeaderOptionControl", () => {
 		);
 
 		const slider = screen.getByRole("slider");
+		vi.useFakeTimers();
 		fireEvent.change(slider, { target: { value: "1" } });
+		act(() => {
+			vi.advanceTimersByTime(300);
+		});
+		vi.useRealTimers();
 
-		// Check if store was updated
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1);
+		expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 1);
 	});
 
-	it("updates selection when input is changed", () => {
+	it("updates selection when input is changed", async () => {
+		const updateExROptionSelection = vi.spyOn(
+			useStore.getState(),
+			"updateExROptionSelection",
+		);
+
 		render(
 			<ExRHeaderOptionControl
 				categoryId={1}
@@ -74,8 +97,7 @@ describe("ExRHeaderOptionControl", () => {
 
 		fireEvent.change(textInput, { target: { value: "100" } });
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(2); // 100 is at index 2
+		expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 2); // 100 is at index 2
 	});
 
 	it("prevents click propagation to parent", () => {

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -93,10 +93,13 @@ describe("ExRRoleSpawnControls", () => {
 		fireEvent.change(slider, { target: { value: "0" } });
 
 		// waitFor handles the debounce timeout
-		await vi.waitFor(() => {
-			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 0);
-			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 51, 0);
-		}, { timeout: 2000 });
+		await vi.waitFor(
+			() => {
+				expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 0);
+				expect(updateExROptionSelection).toHaveBeenCalledWith(1, 51, 0);
+			},
+			{ timeout: 2000 },
+		);
 	});
 
 	it("syncs rate to 10% when count is set to non-zero from zero rate", async () => {
@@ -120,10 +123,13 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "1" } }); // Select '1'
 
-		await vi.waitFor(() => {
-			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 1);
-			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 51, 0);
-		}, { timeout: 2000 });
+		await vi.waitFor(
+			() => {
+				expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 1);
+				expect(updateExROptionSelection).toHaveBeenCalledWith(1, 51, 0);
+			},
+			{ timeout: 2000 },
+		);
 	});
 
 	it("syncs count to 0 when rate is set to 0%", async () => {
@@ -147,9 +153,12 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "0" } });
 
-		await vi.waitFor(() => {
-			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 0);
-			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 51, 0);
-		}, { timeout: 2000 });
+		await vi.waitFor(
+			() => {
+				expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 0);
+				expect(updateExROptionSelection).toHaveBeenCalledWith(1, 51, 0);
+			},
+			{ timeout: 2000 },
+		);
 	});
 });

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,8 +1,18 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
 import type { ExROptionDto } from "../src/type";
 import { useStore } from "../src/useStore";
+
+vi.mock("../src/logics/api", () => ({
+	updateExrOption: vi.fn().mockResolvedValue({
+		UpdatedCategory: null,
+		ChainUpdatedOption: [],
+	}),
+	getExrOptions: vi.fn(),
+	getAuOptions: vi.fn(),
+	updateExrOptionsCache: vi.fn(),
+}));
 
 describe("ExRRoleSpawnControls", () => {
 	const spawnRateOption: ExROptionDto = {
@@ -33,7 +43,7 @@ describe("ExRRoleSpawnControls", () => {
 		render(
 			<ExRRoleSpawnControls
 				categoryId={1}
-				spawnRateOption={spawnRateOption}
+				spawnRateOption={{ ...spawnRateOption, Selection: 1 }}
 				spawnCountOption={spawnCountOption}
 			/>,
 		);
@@ -60,15 +70,17 @@ describe("ExRRoleSpawnControls", () => {
 		expect(slider.max).toBe("3");
 	});
 
-	it("syncs rate to 0 when count is set to 0", () => {
-		// Set initial rate to 10%
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
+	it("syncs rate to 0 when count is set to 0", async () => {
+		const updateExROptionSelection = vi.spyOn(
+			useStore.getState(),
+			"updateExROptionSelection",
+		);
 
 		render(
 			<ExRRoleSpawnControls
 				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
+				spawnRateOption={{ ...spawnRateOption, Selection: 1 }} // initial 10%
+				spawnCountOption={{ ...spawnCountOption, Selection: 0 }} // initial count 1 (UI index 1)
 			/>,
 		);
 
@@ -77,13 +89,22 @@ describe("ExRRoleSpawnControls", () => {
 			'input[type="range"]',
 		) as HTMLInputElement;
 
+		// 0番目の値（仮想0）に変更
 		fireEvent.change(slider, { target: { value: "0" } });
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(0); // Rate 0%
+		// waitFor handles the debounce timeout
+		await vi.waitFor(() => {
+			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 0);
+			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 51, 0);
+		}, { timeout: 2000 });
 	});
 
-	it("syncs rate to 10% when count is set to non-zero from zero rate", () => {
+	it("syncs rate to 10% when count is set to non-zero from zero rate", async () => {
+		const updateExROptionSelection = vi.spyOn(
+			useStore.getState(),
+			"updateExROptionSelection",
+		);
+
 		render(
 			<ExRRoleSpawnControls
 				categoryId={1}
@@ -99,20 +120,23 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "1" } }); // Select '1'
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1); // Rate index 1 is 10%
+		await vi.waitFor(() => {
+			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 1);
+			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 51, 0);
+		}, { timeout: 2000 });
 	});
 
-	it("syncs count to 0 when rate is set to 0%", () => {
-		// Set initial rate to 10% and count to 2
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
-		useStore.getState().TEMP_updateExROptionSelection("1-51", 1); // backend index 1 is value 2
+	it("syncs count to 0 when rate is set to 0%", async () => {
+		const updateExROptionSelection = vi.spyOn(
+			useStore.getState(),
+			"updateExROptionSelection",
+		);
 
 		render(
 			<ExRRoleSpawnControls
 				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
+				spawnRateOption={{ ...spawnRateOption, Selection: 1 }}
+				spawnCountOption={{ ...spawnCountOption, Selection: 1 }}
 			/>,
 		);
 
@@ -123,13 +147,9 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "0" } });
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-51"]).toBe(0); // Count reset to index 0
-
-		// UI should show 0
-		const countDisplay = screen
-			.getByTestId("spawn-count-control")
-			.querySelector('input[type="text"]');
-		expect(countDisplay).toHaveValue("0");
+		await vi.waitFor(() => {
+			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 50, 0);
+			expect(updateExROptionSelection).toHaveBeenCalledWith(1, 51, 0);
+		}, { timeout: 2000 });
 	});
 });

--- a/tests/OptionSliderControl.test.tsx
+++ b/tests/OptionSliderControl.test.tsx
@@ -25,7 +25,8 @@ describe("OptionSliderControl", () => {
 		expect(screen.getByText("(20s)")).toBeInTheDocument();
 	});
 
-	it("calls onChange when slider moves", () => {
+	it("calls onChange when slider moves after debounce", () => {
+		vi.useFakeTimers();
 		const onChange = vi.fn();
 		render(
 			<OptionSliderControl
@@ -39,7 +40,11 @@ describe("OptionSliderControl", () => {
 		const slider = screen.getByRole("slider");
 		fireEvent.change(slider, { target: { value: "3" } });
 
+		expect(onChange).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(300);
 		expect(onChange).toHaveBeenCalledWith(3);
+		vi.useRealTimers();
 	});
 
 	it("calls onChange with closest value when input changes", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,27 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import babel from '@rolldown/plugin-babel'
 import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiBaseUrl = env.VITE_API_BASE_URL || 'http://localhost:8080';
+
+  return {
+  server: {
+    proxy: {
+      '/exr': {
+        target: apiBaseUrl,
+        changeOrigin: true,
+      },
+      '/au': {
+        target: apiBaseUrl,
+        changeOrigin: true,
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,
@@ -17,4 +33,5 @@ export default defineConfig({
     tailwindcss(),
     babel({ presets: [reactCompilerPreset()] })
   ],
+  }
 })


### PR DESCRIPTION
ExRオプションの設定変更時に、バックエンドサーバーの `PUT /exr/option/` を呼び出すように変更しました。

主な変更点:
1.  **API連携の実装**: `src/logics/api.ts` に `updateExrOption` を追加し、APIレスポンスに含まれる `UpdatedCategory` や `ChainUpdatedOption` を既存のキャッシュデータに反映するロジックを実装しました。
2.  **状態管理の更新**: `optionViewerSlice.ts` で `TEMP_updateExROptionSelection` を非同期な `updateExROptionSelection` に置き換え、楽観的更新を廃止しました。代わりに `dataVersion` という状態を導入し、API更新完了後にコンポーネントの再レンダリングを促すようにしました。
3.  **モックサーバーの強化**: `mocks/handlers.ts` の PUT ハンドラーを修正し、実際にメモリ内のデータを更新して返すようにしました。
4.  **UIの最適化**: スライダー操作時に即座に API を叩くのではなく、マウスを離したタイミングや操作が止まったタイミング（300msデバウンス）でリクエストを送るようにしました。
5.  **テストの修正**: 既存のユニットテストを非同期・API連携前提のコードに更新し、すべてのテストがパスすることを確認しました。
6.  **ビルド・品質**: `pnpm build` が通ること、およびリンターの警告がないことを確認済みです。

---
*PR created automatically by Jules for task [5429528947151574103](https://jules.google.com/task/5429528947151574103) started by @yukieiji*