### PR TITLE
Putオプションの戻り値のAPI仕様変更に対応

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -84,7 +84,12 @@ export const handlers = [
     // それ以外はUpdatedOptionsを返す
     const mockUpdatedOptions: UpdatedOptions = {
       UpdatedCategory: validatedExRMockData[0].Categories[0],
-      ChainUpdatedOption: [validatedExRMockData[0].Categories[0].Options[0]],
+      ChainUpdatedOption: [
+        {
+          Id: validatedExRMockData[0].Categories[0].Id,
+          Options: [validatedExRMockData[0].Categories[0].Options[0]],
+        },
+      ],
     };
 
     // レスポンスデータのバリデーション

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Suspense, use } from "react";
+import { LoadingView } from "./components/parts/LoadingView";
 import { AuOptionEditor } from "./feature/AuOptionEditor";
 import { ExROptionEditor } from "./feature/ExROptionEditor";
-import { LoadingView } from "./feature/LoadingView";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { PresetSelector } from "./feature/PresetSelector";
 import { getAuOptions, getExrOptions } from "./logics/api";

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -37,7 +37,11 @@ export function ExRCategoryOptionList({
 					);
 				}
 				return (
-					<ExROptionItem key={item.Id} categoryId={categoryId} option={item} />
+					<ExROptionItem
+						key={(item as ExROptionDto).Id}
+						categoryId={categoryId}
+						option={item as ExROptionDto}
+					/>
 				);
 			})}
 		</div>

--- a/src/type.ts
+++ b/src/type.ts
@@ -200,16 +200,29 @@ export const VanillaOptionPutRequestSchema = z.object({
 });
 
 /**
+ * カテゴリごとのオプションリスト
+ */
+export interface CategoryOptionDto {
+	Id: number;
+	Options: ExROptionDto[];
+}
+
+export const CategoryOptionDtoSchema = z.object({
+	Id: z.number().int(),
+	Options: z.array(ExROptionDtoSchema),
+});
+
+/**
  * 更新されたオプション情報
  */
 export interface UpdatedOptions {
 	UpdatedCategory: ExRCategoryDto | null;
-	ChainUpdatedOption: ExROptionDto[];
+	ChainUpdatedOption: CategoryOptionDto[];
 }
 
 export const UpdatedOptionsSchema = z.object({
 	UpdatedCategory: ExRCategoryDtoSchema.nullable(),
-	ChainUpdatedOption: z.array(ExROptionDtoSchema),
+	ChainUpdatedOption: z.array(CategoryOptionDtoSchema),
 });
 
 /**

--- a/tests/api-validation.test.ts
+++ b/tests/api-validation.test.ts
@@ -52,16 +52,21 @@ describe("ExROptionPutRequest and UpdatedOptions Validation", () => {
 			},
 			ChainUpdatedOption: [
 				{
-					Id: 101,
-					IsActive: true,
-					TranslatedName: "Test Option",
-					Selection: 1,
-					Format: "Test Format",
-					RangeMeta: {
-						Type: "Int32",
-						Values: [1, 2, 3],
-					},
-					Childs: [],
+					Id: 2,
+					Options: [
+						{
+							Id: 101,
+							IsActive: true,
+							TranslatedName: "Test Option",
+							Selection: 1,
+							Format: "Test Format",
+							RangeMeta: {
+								Type: "Int32",
+								Values: [1, 2, 3],
+							},
+							Childs: [],
+						},
+					],
 				},
 			],
 		};
@@ -135,16 +140,21 @@ describe("UpdatedOptions Validation", () => {
 			UpdatedCategory: null,
 			ChainUpdatedOption: [
 				{
-					Id: 201,
-					IsActive: true,
-					TranslatedName: "Option",
-					Selection: 1,
-					Format: "{0}",
-					RangeMeta: {
-						Type: "Int32",
-						Values: [1, 2, 3],
-					},
-					Childs: [],
+					Id: 5,
+					Options: [
+						{
+							Id: 201,
+							IsActive: true,
+							TranslatedName: "Option",
+							Selection: 1,
+							Format: "{0}",
+							RangeMeta: {
+								Type: "Int32",
+								Values: [1, 2, 3],
+							},
+							Childs: [],
+						},
+					],
 				},
 			],
 		};


### PR DESCRIPTION
Putオプションの戻り値である UpdatedOptions の構造を、新しいバックエンドの仕様に合わせて修正しました。ChainUpdatedOption が CategoryOptionDto の配列を受け取るように変更しています。

---
*PR created automatically by Jules for task [18212425797881906299](https://jules.google.com/task/18212425797881906299) started by @yukieiji*