### PR TITLE
Implement ExR Option PUT Integration and Mock-free Dev Command

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -82,18 +82,27 @@ export const handlers = [
     }
 
     // それ以外はUpdatedOptionsを返す
-    const mockUpdatedOptions: UpdatedOptions = {
-      UpdatedCategory: validatedExRMockData[0].Categories[0],
-      ChainUpdatedOption: [
-        {
-          Id: validatedExRMockData[0].Categories[0].Id,
-          Options: [validatedExRMockData[0].Categories[0].Options[0]],
-        },
-      ],
+    // 実際にデータを更新して、E2Eテストが正常に動作するようにします。
+    const { TabId, Selection } = result.data;
+    const tab = validatedExRMockData.find(t => t.Id === TabId);
+    if (!tab) return new HttpResponse(null, { status: 404 });
+
+    const category = tab.Categories.find(c => c.Id === CategoryId);
+    if (!category) return new HttpResponse(null, { status: 404 });
+
+    const option = category.Options.find(o => o.Id === OptionId);
+    if (!option) return new HttpResponse(null, { status: 404 });
+
+    // データの更新 (メモ上でのみ)
+    option.Selection = Selection;
+
+    const responseData: UpdatedOptions = {
+      UpdatedCategory: category,
+      ChainUpdatedOption: [],
     };
 
     // レスポンスデータのバリデーション
-    const validatedResponse = UpdatedOptionsSchema.parse(mockUpdatedOptions);
+    const validatedResponse = UpdatedOptionsSchema.parse(responseData);
 
     return HttpResponse.json(validatedResponse);
   }),

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/ui": "^4.1.0",
     "babel-plugin-react-compiler": "^1.0.0",
-    "cross-env": "^10.1.0",
+    "cross-env": "^7.0.3",
     "jsdom": "^29.0.1",
     "msw": "^2.12.14",
     "typescript": "~6.0.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:no-mock": "cross-env VITE_USE_MOCK=false vite",
     "build": "tsc -b && vite build",
     "lint": "biome lint",
     "format": "biome format",
@@ -35,6 +36,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/ui": "^4.1.0",
     "babel-plugin-react-compiler": "^1.0.0",
+    "cross-env": "^10.1.0",
     "jsdom": "^29.0.1",
     "msw": "^2.12.14",
     "typescript": "~6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       cross-env:
-        specifier: ^10.1.0
-        version: 10.1.0
+        specifier: ^7.0.3
+        version: 7.0.3
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -277,9 +277,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
-
-  '@epic-web/invariant@1.0.0':
-    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
@@ -762,9 +759,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
-  cross-env@10.1.0:
-    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
-    engines: {node: '>=20'}
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
     hasBin: true
 
   cross-spawn@7.0.6:
@@ -1634,8 +1631,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@epic-web/invariant@1.0.0': {}
-
   '@exodus/bytes@1.15.0': {}
 
   '@inquirer/ansi@1.0.2': {}
@@ -2046,9 +2041,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  cross-env@10.1.0:
+  cross-env@7.0.3:
     dependencies:
-      '@epic-web/invariant': 1.0.0
       cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -191,24 +194,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.8':
     resolution: {integrity: sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.8':
     resolution: {integrity: sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.8':
     resolution: {integrity: sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.8':
     resolution: {integrity: sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==}
@@ -270,6 +277,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
@@ -393,36 +403,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
     resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
@@ -511,24 +527,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -742,6 +762,15 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -871,6 +900,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -932,24 +964,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1025,6 +1061,10 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -1107,6 +1147,14 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1317,6 +1365,11 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -1580,6 +1633,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@epic-web/invariant@1.0.0': {}
 
   '@exodus/bytes@1.15.0': {}
 
@@ -1991,6 +2046,17 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -2079,6 +2145,8 @@ snapshots:
   is-node-process@1.2.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  isexe@2.0.0: {}
 
   jiti@2.6.1: {}
 
@@ -2222,6 +2290,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  path-key@3.1.1: {}
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
@@ -2302,6 +2372,12 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
 
@@ -2449,6 +2525,10 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -23,18 +23,18 @@ export function ExRHeaderOptionControl({
 		return state.effectiveSelections[uniqueId];
 	});
 	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const values = option.RangeMeta.Values as number[];
 
 	const handleSelectionChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const handleInputChange = (val: number) => {
-		TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+		updateExROptionSelection(uniqueId, findClosestIndex(values, val));
 	};
 
 	return (

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -22,12 +22,12 @@ export function ExROptionControl({
 		return state.effectiveSelections[uniqueId];
 	});
 	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const handleChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const { Type, Values } = option.RangeMeta;

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -39,16 +39,16 @@ export function ExRPairedOptionRow({
 	const minSelection = effectiveMinSelection ?? min.Selection;
 	const maxSelection = effectiveMaxSelection ?? max.Selection;
 
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const handleMinChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(minUniqueId, newSelection);
+		updateExROptionSelection(minUniqueId, newSelection);
 	};
 
 	const handleMaxChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(maxUniqueId, newSelection);
+		updateExROptionSelection(maxUniqueId, newSelection);
 	};
 
 	const content = (

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -16,6 +16,9 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 	const isOpendCategory = useStore((state) => {
 		return state.openedExRCategoryIds[category.Id];
 	});
+	const isPending = useStore((state) => {
+		return state.pendingCategoryIds[category.Id] ?? false;
+	});
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
 	});
@@ -45,10 +48,12 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 
 	return (
 		<div
-			className="border border-gray-700 rounded-lg overflow-hidden mb-2"
+			className="border border-gray-700 rounded-lg overflow-hidden mb-2 relative"
 			data-testid={`exr-category-${category.Id}`}
 		>
-			<div className="flex items-center bg-gray-800 hover:bg-gray-700 transition-colors">
+			<div
+				className={`flex items-center bg-gray-800 hover:bg-gray-700 transition-all duration-200 ${isPending ? "opacity-50 pointer-events-none" : "opacity-100"}`}
+			>
 				<button
 					type="button"
 					onClick={() => {
@@ -88,9 +93,9 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 			</div>
 
 			<div
-				className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
+				className={`grid transition-all duration-200 ease-in-out overflow-hidden ${
 					isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
-				}`}
+				} ${isPending ? "opacity-50 pointer-events-none" : "opacity-100"}`}
 			>
 				<div className="min-h-0">
 					{isOpen && (
@@ -103,6 +108,12 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 					)}
 				</div>
 			</div>
+
+			{isPending && (
+				<div className="absolute inset-0 flex items-center justify-center bg-black/10 z-10 pointer-events-none">
+					<div className="w-8 h-8 border-3 border-blue-500 border-t-transparent rounded-full animate-spin" />
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -28,8 +28,8 @@ export function ExRRoleSpawnControls({
 		return state.effectiveSelections[uniqueCountId];
 	});
 
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const spawnRateSelection =
@@ -48,11 +48,11 @@ export function ExRRoleSpawnControls({
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
 	const handleRateChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueRateId, newSelection);
+		updateExROptionSelection(uniqueRateId, newSelection);
 
 		// スポーンレートが0%なら、スポーン数も0としてリセット
 		if (rateValues[newSelection] === 0) {
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			updateExROptionSelection(uniqueCountId, 0);
 		}
 	};
 
@@ -63,20 +63,20 @@ export function ExRRoleSpawnControls({
 	const handleCountUIChange = (newUISelection: number) => {
 		if (newUISelection === 0) {
 			// 数を0にすると、レートも0%にする
-			TEMP_updateExROptionSelection(
+			updateExROptionSelection(
 				uniqueRateId,
 				findClosestIndex(rateValues, 0),
 			);
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			updateExROptionSelection(uniqueCountId, 0);
 		} else {
 			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
 			if (isSpawnRateZero) {
-				TEMP_updateExROptionSelection(
+				updateExROptionSelection(
 					uniqueRateId,
 					findClosestIndex(rateValues, 10),
 				);
 			}
-			TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
+			updateExROptionSelection(uniqueCountId, newUISelection - 1);
 		}
 	};
 

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -63,10 +63,7 @@ export function ExRRoleSpawnControls({
 	const handleCountUIChange = (newUISelection: number) => {
 		if (newUISelection === 0) {
 			// 数を0にすると、レートも0%にする
-			updateExROptionSelection(
-				uniqueRateId,
-				findClosestIndex(rateValues, 0),
-			);
+			updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 0));
 			updateExROptionSelection(uniqueCountId, 0);
 		} else {
 			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる

--- a/src/feature/ExRStandardCategoryItem.tsx
+++ b/src/feature/ExRStandardCategoryItem.tsx
@@ -18,6 +18,9 @@ export function ExRStandardCategoryItem({
 	const isOpen = useStore((state) => {
 		return state.openedExRCategoryIds[category.Id] ?? false;
 	});
+	const isPending = useStore((state) => {
+		return state.pendingCategoryIds[category.Id] ?? false;
+	});
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
 	});
@@ -31,19 +34,31 @@ export function ExRStandardCategoryItem({
 	}
 
 	return (
-		<div data-testid={`exr-category-${category.Id}`}>
-			<Accordion
-				title={<ColoredText text={category.Name} />}
-				isOpen={isOpen}
-				onToggle={() => {
-					toggleExRCategory(category.Id);
-				}}
+		<div
+			data-testid={`exr-category-${category.Id}`}
+			className="relative overflow-hidden"
+		>
+			<div
+				className={`transition-opacity duration-200 ${isPending ? "opacity-50 pointer-events-none" : "opacity-100"}`}
 			>
-				<ExRCategoryOptionList
-					categoryId={category.Id}
-					options={filteredOptions}
-				/>
-			</Accordion>
+				<Accordion
+					title={<ColoredText text={category.Name} />}
+					isOpen={isOpen}
+					onToggle={() => {
+						toggleExRCategory(category.Id);
+					}}
+				>
+					<ExRCategoryOptionList
+						categoryId={category.Id}
+						options={filteredOptions}
+					/>
+				</Accordion>
+			</div>
+			{isPending && (
+				<div className="absolute inset-0 flex items-center justify-center bg-black/10 z-10">
+					<div className="w-8 h-8 border-3 border-blue-500 border-t-transparent rounded-full animate-spin" />
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -42,8 +42,8 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 	const updatePresetName = useStore((state) => {
 		return state.updatePresetName;
 	});
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 	const setPresetDropdownOpen = useStore((state) => {
 		return state.setPresetDropdownOpen;
@@ -78,7 +78,7 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
 	const handlePresetSelect = (index: number) => {
-		TEMP_updateExROptionSelection(uniqueId, index);
+		updateExROptionSelection(uniqueId, index);
 		setPresetDropdownOpen(false);
 	};
 

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -1,15 +1,21 @@
 import type {
 	AuOptionCategoryDto,
-	ExRTabDto,
 	ExROptionPutRequest,
+	ExRTabDto,
 	UpdatedOptions,
 } from "../type";
 
 /**
  * API エンドポイントの定数定義
  */
-const EXR_OPTION_URL = "/exr/option/";
-const AU_OPTION_URL = "/au/option/";
+const EXR_OPTION_URL = `${import.meta.env.BASE_URL ?? "/"}exr/option/`.replace(
+	/\/+/g,
+	"/",
+);
+const AU_OPTION_URL = `${import.meta.env.BASE_URL ?? "/"}au/option/`.replace(
+	/\/+/g,
+	"/",
+);
 
 /**
  * APIからデータを取得するPromiseをキャッシュするためのグローバル変数
@@ -120,56 +126,63 @@ export async function updateExrOptionsCache(updatedData: UpdatedOptions) {
 		return;
 	}
 
-	const currentTabs = await exrOptionsPromise;
-	const newTabs = [...currentTabs];
+	// 複数の更新が並列で走った際のレースコンディションを防ぐため、
+	// Promiseを連鎖させて順次実行されるようにします。
+	exrOptionsPromise = (async () => {
+		const currentTabs = await exrOptionsPromise!;
+		const newTabs = [...currentTabs];
 
-	// UpdatedCategory の反映
-	if (updatedData.UpdatedCategory) {
-		const cat = updatedData.UpdatedCategory;
-		for (let i = 0; i < newTabs.length; i++) {
-			const tab = newTabs[i];
-			const categoryIndex = tab.Categories.findIndex((c) => {
-				return c.Id === cat.Id;
-			});
-			if (categoryIndex !== -1) {
-				const newCategories = [...tab.Categories];
-				newCategories[categoryIndex] = cat;
-				newTabs[i] = { ...tab, Categories: newCategories };
-			}
-		}
-	}
-
-	// ChainUpdatedOption の反映
-	for (const chain of updatedData.ChainUpdatedOption) {
-		for (let i = 0; i < newTabs.length; i++) {
-			const tab = newTabs[i];
-			const categoryIndex = tab.Categories.findIndex((c) => {
-				return c.Id === chain.Id;
-			});
-			if (categoryIndex !== -1) {
-				const targetCategory = tab.Categories[categoryIndex];
-				const newOptions = [...targetCategory.Options];
-
-				for (const newOpt of chain.Options) {
-					const optIndex = newOptions.findIndex((o) => {
-						return o.Id === newOpt.Id;
-					});
-					if (optIndex !== -1) {
-						newOptions[optIndex] = newOpt;
-					} else {
-						newOptions.push(newOpt);
-					}
+		// UpdatedCategory の反映
+		if (updatedData.UpdatedCategory) {
+			const cat = updatedData.UpdatedCategory;
+			for (let i = 0; i < newTabs.length; i++) {
+				const tab = newTabs[i];
+				const categoryIndex = tab.Categories.findIndex((c) => {
+					return c.Id === cat.Id;
+				});
+				if (categoryIndex !== -1) {
+					const newCategories = [...tab.Categories];
+					newCategories[categoryIndex] = cat;
+					newTabs[i] = { ...tab, Categories: newCategories };
 				}
-
-				const newCategories = [...tab.Categories];
-				newCategories[categoryIndex] = {
-					...targetCategory,
-					Options: newOptions,
-				};
-				newTabs[i] = { ...tab, Categories: newCategories };
 			}
 		}
-	}
 
-	exrOptionsPromise = Promise.resolve(newTabs);
+		// ChainUpdatedOption の反映
+		for (const chain of updatedData.ChainUpdatedOption) {
+			for (let i = 0; i < newTabs.length; i++) {
+				const tab = newTabs[i];
+				const categoryIndex = tab.Categories.findIndex((c) => {
+					return c.Id === chain.Id;
+				});
+				if (categoryIndex !== -1) {
+					const targetCategory = tab.Categories[categoryIndex];
+					const newOptions = [...targetCategory.Options];
+
+					for (const newOpt of chain.Options) {
+						const optIndex = newOptions.findIndex((o) => {
+							return o.Id === newOpt.Id;
+						});
+						if (optIndex !== -1) {
+							newOptions[optIndex] = newOpt;
+						} else {
+							newOptions.push(newOpt);
+						}
+					}
+
+					const newCategories = [...tab.Categories];
+					newCategories[categoryIndex] = {
+						...targetCategory,
+						Options: newOptions,
+					};
+					newTabs[i] = { ...tab, Categories: newCategories };
+				}
+			}
+		}
+
+		return newTabs;
+	})();
+
+	// 更新完了を待機
+	await exrOptionsPromise;
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -132,61 +132,72 @@ export async function updateExrOptionsCache(updatedData: UpdatedOptions) {
 		return;
 	}
 
+	// チェーン更新用のルックアップマップを作成 (O(1)アクセス用)
+	const chainMap = new Map(
+		updatedData.ChainUpdatedOption.map((c) => {
+			return [c.Id, c.Options];
+		}),
+	);
+
 	// 複数の更新が並列で走った際のレースコンディションを防ぐため、
 	// Promiseを連鎖させて順次実行されるようにします。
 	exrOptionsPromise = (async () => {
-		const currentTabs = await exrOptionsPromise!;
-		const newTabs = [...currentTabs];
+		const currentPromise = exrOptionsPromise;
+		if (!currentPromise) return [];
+		const currentTabs = await currentPromise;
 
-		// UpdatedCategory の反映
-		if (updatedData.UpdatedCategory) {
-			const cat = updatedData.UpdatedCategory;
-			for (let i = 0; i < newTabs.length; i++) {
-				const tab = newTabs[i];
-				const categoryIndex = tab.Categories.findIndex((c) => {
-					return c.Id === cat.Id;
-				});
-				if (categoryIndex !== -1) {
-					const newCategories = [...tab.Categories];
-					newCategories[categoryIndex] = cat;
-					newTabs[i] = { ...tab, Categories: newCategories };
-				}
+		return currentTabs.map((tab) => {
+			// このタブ内に更新対象のカテゴリが含まれているかチェック
+			const hasTargetCategory = tab.Categories.some((cat) => {
+				return (
+					cat.Id === updatedData.UpdatedCategory?.Id || chainMap.has(cat.Id)
+				);
+			});
+
+			if (!hasTargetCategory) {
+				return tab;
 			}
-		}
 
-		// ChainUpdatedOption の反映
-		for (const chain of updatedData.ChainUpdatedOption) {
-			for (let i = 0; i < newTabs.length; i++) {
-				const tab = newTabs[i];
-				const categoryIndex = tab.Categories.findIndex((c) => {
-					return c.Id === chain.Id;
-				});
-				if (categoryIndex !== -1) {
-					const targetCategory = tab.Categories[categoryIndex];
-					const newOptions = [...targetCategory.Options];
+			// カテゴリをマッピングして更新
+			const newCategories = tab.Categories.map((cat) => {
+				// 1. UpdatedCategory の完全置き換え
+				if (cat.Id === updatedData.UpdatedCategory?.Id) {
+					return updatedData.UpdatedCategory;
+				}
 
-					for (const newOpt of chain.Options) {
-						const optIndex = newOptions.findIndex((o) => {
-							return o.Id === newOpt.Id;
-						});
-						if (optIndex !== -1) {
-							newOptions[optIndex] = newOpt;
-						} else {
+				// 2. ChainUpdatedOption による部分更新
+				const chainOptions = chainMap.get(cat.Id);
+				if (chainOptions) {
+					// オプションIDでのルックアップ用マップ
+					const newOptMap = new Map(
+						chainOptions.map((o) => {
+							return [o.Id, o];
+						}),
+					);
+
+					const newOptions = cat.Options.map((opt) => {
+						return newOptMap.get(opt.Id) ?? opt;
+					});
+
+					// 既存に存在しない新しいオプションがあれば追加
+					for (const newOpt of chainOptions) {
+						if (
+							!cat.Options.some((o) => {
+								return o.Id === newOpt.Id;
+							})
+						) {
 							newOptions.push(newOpt);
 						}
 					}
 
-					const newCategories = [...tab.Categories];
-					newCategories[categoryIndex] = {
-						...targetCategory,
-						Options: newOptions,
-					};
-					newTabs[i] = { ...tab, Categories: newCategories };
+					return { ...cat, Options: newOptions };
 				}
-			}
-		}
 
-		return newTabs;
+				return cat;
+			});
+
+			return { ...tab, Categories: newCategories };
+		});
 	})();
 
 	// 更新完了を待機

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -1,4 +1,9 @@
-import type { AuOptionCategoryDto, ExRTabDto } from "../type";
+import type {
+	AuOptionCategoryDto,
+	ExRTabDto,
+	ExROptionPutRequest,
+	UpdatedOptions,
+} from "../type";
 
 /**
  * API エンドポイントの定数定義
@@ -80,4 +85,91 @@ export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
  */
 export function getAllOptions(): Promise<[ExRTabDto[], AuOptionCategoryDto[]]> {
 	return Promise.all([getExrOptions(), getAuOptions()]);
+}
+
+/**
+ * ExRオプションを更新する
+ */
+export async function updateExrOption(
+	params: ExROptionPutRequest,
+): Promise<UpdatedOptions | null> {
+	const res = await fetch(EXR_OPTION_URL, {
+		method: "PUT",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(params),
+	});
+
+	if (!res.ok) {
+		throw new Error(`Failed to update ExR option: ${res.statusText}`);
+	}
+
+	if (res.status === 202) {
+		return null;
+	}
+
+	return res.json();
+}
+
+/**
+ * ExRオプションのキャッシュを差分更新する
+ */
+export async function updateExrOptionsCache(updatedData: UpdatedOptions) {
+	if (!exrOptionsPromise) {
+		return;
+	}
+
+	const currentTabs = await exrOptionsPromise;
+	const newTabs = [...currentTabs];
+
+	// UpdatedCategory の反映
+	if (updatedData.UpdatedCategory) {
+		const cat = updatedData.UpdatedCategory;
+		for (let i = 0; i < newTabs.length; i++) {
+			const tab = newTabs[i];
+			const categoryIndex = tab.Categories.findIndex((c) => {
+				return c.Id === cat.Id;
+			});
+			if (categoryIndex !== -1) {
+				const newCategories = [...tab.Categories];
+				newCategories[categoryIndex] = cat;
+				newTabs[i] = { ...tab, Categories: newCategories };
+			}
+		}
+	}
+
+	// ChainUpdatedOption の反映
+	for (const chain of updatedData.ChainUpdatedOption) {
+		for (let i = 0; i < newTabs.length; i++) {
+			const tab = newTabs[i];
+			const categoryIndex = tab.Categories.findIndex((c) => {
+				return c.Id === chain.Id;
+			});
+			if (categoryIndex !== -1) {
+				const targetCategory = tab.Categories[categoryIndex];
+				const newOptions = [...targetCategory.Options];
+
+				for (const newOpt of chain.Options) {
+					const optIndex = newOptions.findIndex((o) => {
+						return o.Id === newOpt.Id;
+					});
+					if (optIndex !== -1) {
+						newOptions[optIndex] = newOpt;
+					} else {
+						newOptions.push(newOpt);
+					}
+				}
+
+				const newCategories = [...tab.Categories];
+				newCategories[categoryIndex] = {
+					...targetCategory,
+					Options: newOptions,
+				};
+				newTabs[i] = { ...tab, Categories: newCategories };
+			}
+		}
+	}
+
+	exrOptionsPromise = Promise.resolve(newTabs);
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -7,15 +7,21 @@ import type {
 
 /**
  * API エンドポイントの定数定義
+ * Node.js (Vitest) 環境での相対パス問題を解決するため、絶対URLを生成します。
  */
-const EXR_OPTION_URL = `${import.meta.env.BASE_URL ?? "/"}exr/option/`.replace(
-	/\/+/g,
-	"/",
-);
-const AU_OPTION_URL = `${import.meta.env.BASE_URL ?? "/"}au/option/`.replace(
-	/\/+/g,
-	"/",
-);
+function getAbsoluteUrl(path: string): string {
+	const baseUrl = import.meta.env.BASE_URL ?? "/";
+	const fullPath = `${baseUrl}${path}`.replace(/\/+/g, "/");
+
+	if (typeof window !== "undefined") {
+		return new URL(fullPath, window.location.origin).toString();
+	}
+	// フォールバック (主にテスト環境用)
+	return new URL(fullPath, "http://localhost:5173").toString();
+}
+
+const EXR_OPTION_URL = getAbsoluteUrl("exr/option/");
+const AU_OPTION_URL = getAbsoluteUrl("au/option/");
 
 /**
  * APIからデータを取得するPromiseをキャッシュするためのグローバル変数

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,10 +10,15 @@ if (import.meta.env.DEV) {
 }
 
 /**
- * 開発環境の場合にMSWを有効化
+ * 開発環境かつモックが有効な場合にMSWを有効化
  */
 async function enableMocking() {
 	if (!import.meta.env.DEV) {
+		return;
+	}
+
+	const useMock = import.meta.env.VITE_USE_MOCK !== "false";
+	if (!useMock) {
 		return;
 	}
 

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -89,7 +89,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 			const CategoryId = Number.parseInt(catIdStr, 10);
 			const OptionId = Number.parseInt(optIdStr, 10);
 
-			const TabId = get().selectedExRTabId ?? 0;
+			const TabId = get().selectedExRTabId;
 
 			// 楽観的更新 (テスト互換性のため)
 			set((state) => {
@@ -115,6 +115,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 
 				// Preset設定（0-0）以外は、楽観的更新に使用した一時的な選択状態をクリアし、
 				// コンポーネントがサーバーから提供された最新データ（キャッシュ側）を参照するようにします。
+				// Preset設定はCookieベースの管理と同期するため、有効な選択状態を維持します。
 				if (CategoryId !== 0 || OptionId !== 0) {
 					set((state) => {
 						const newEffectiveSelections = { ...state.effectiveSelections };

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -113,16 +113,17 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 					await updateExrOptionsCache(updatedData);
 				}
 
-				// サーバーからの最新データで状態を上書き (必要であれば)
-				set((state) => {
-					const newEffectiveSelections = { ...state.effectiveSelections };
-					// Preset 以外は最終的にはキャッシュ (option.Selection) を見るので、
-					// ここで effectiveSelections をクリアしても良いが、
-					// 今回はシンプルに維持する
-					return {
-						effectiveSelections: newEffectiveSelections,
-					};
-				});
+				// Preset設定（0-0）以外は、楽観的更新に使用した一時的な選択状態をクリアし、
+				// コンポーネントがサーバーから提供された最新データ（キャッシュ側）を参照するようにします。
+				if (CategoryId !== 0 || OptionId !== 0) {
+					set((state) => {
+						const newEffectiveSelections = { ...state.effectiveSelections };
+						delete newEffectiveSelections[uniqueOptionId];
+						return {
+							effectiveSelections: newEffectiveSelections,
+						};
+					});
+				}
 			} catch (error) {
 				console.error("Failed to update ExR option:", error);
 			}

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -13,12 +13,14 @@ export interface OptionViewerSlice {
 	selectedExRTabId: OptionTab;
 	isTabPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
+	pendingCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<string, boolean>;
 	effectiveSelections: Record<string, number>;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
 	setSelectedExRTabId: (id: OptionTab) => void;
 	setIsTabPending: (isPending: boolean) => void;
+	setCategoryPending: (categoryId: number, isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: string) => void;
 	updateExROptionSelection: (
@@ -41,6 +43,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 		selectedExRTabId: 0,
 		isTabPending: false,
 		openedExRCategoryIds: {},
+		pendingCategoryIds: {},
 		openedExROptionIds: {},
 		effectiveSelections: {},
 		presetNames: loadPresetNamesFromCookie(),
@@ -51,11 +54,22 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 		setIsTabPending: (isPending: boolean) => {
 			set({ isTabPending: isPending });
 		},
+		setCategoryPending: (categoryId: number, isPending: boolean) => {
+			set((state) => {
+				return {
+					pendingCategoryIds: {
+						...state.pendingCategoryIds,
+						[categoryId]: isPending,
+					},
+				};
+			});
+		},
 		resetViewer: () => {
 			set({
 				selectedExRTabId: 0,
 				isTabPending: false,
 				openedExRCategoryIds: {},
+				pendingCategoryIds: {},
 				openedExROptionIds: {},
 				effectiveSelections: {},
 				isPresetDropdownOpen: false,
@@ -91,15 +105,8 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 
 			const TabId = get().selectedExRTabId;
 
-			// 楽観的更新 (テスト互換性のため)
-			set((state) => {
-				return {
-					effectiveSelections: {
-						...state.effectiveSelections,
-						[uniqueOptionId]: selection,
-					},
-				};
-			});
+			// カテゴリをペンディング状態にする
+			get().setCategoryPending(CategoryId, true);
 
 			try {
 				const updatedData = await updateExrOption({
@@ -112,21 +119,11 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				if (updatedData) {
 					await updateExrOptionsCache(updatedData);
 				}
-
-				// Preset設定（0-0）以外は、楽観的更新に使用した一時的な選択状態をクリアし、
-				// コンポーネントがサーバーから提供された最新データ（キャッシュ側）を参照するようにします。
-				// Preset設定はCookieベースの管理と同期するため、有効な選択状態を維持します。
-				if (CategoryId !== 0 || OptionId !== 0) {
-					set((state) => {
-						const newEffectiveSelections = { ...state.effectiveSelections };
-						delete newEffectiveSelections[uniqueOptionId];
-						return {
-							effectiveSelections: newEffectiveSelections,
-						};
-					});
-				}
 			} catch (error) {
 				console.error("Failed to update ExR option:", error);
+			} finally {
+				// ペンディング状態を解除
+				get().setCategoryPending(CategoryId, false);
 			}
 		},
 		updatePresetName: (presetIndex: number, name: string) => {

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from "zustand";
+import { updateExrOption, updateExrOptionsCache } from "../logics/api";
 import {
 	loadPresetNamesFromCookie,
 	savePresetNamesToCookie,
@@ -20,10 +21,10 @@ export interface OptionViewerSlice {
 	setIsTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: string) => void;
-	TEMP_updateExROptionSelection: (
+	updateExROptionSelection: (
 		uniqueOptionId: string,
 		selection: number,
-	) => void;
+	) => Promise<void>;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
 	resetViewer: () => void;
@@ -34,6 +35,7 @@ export interface OptionViewerSlice {
  */
 export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 	set,
+	get,
 ) => {
 	return {
 		selectedExRTabId: 0,
@@ -79,10 +81,17 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				};
 			});
 		},
-		TEMP_updateExROptionSelection: (
+		updateExROptionSelection: async (
 			uniqueOptionId: string,
 			selection: number,
 		) => {
+			const [catIdStr, optIdStr] = uniqueOptionId.split("-");
+			const CategoryId = Number.parseInt(catIdStr, 10);
+			const OptionId = Number.parseInt(optIdStr, 10);
+
+			const TabId = get().selectedExRTabId ?? 0;
+
+			// 楽観的更新 (テスト互換性のため)
 			set((state) => {
 				return {
 					effectiveSelections: {
@@ -91,6 +100,32 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 					},
 				};
 			});
+
+			try {
+				const updatedData = await updateExrOption({
+					TabId,
+					CategoryId,
+					OptionId,
+					Selection: selection,
+				});
+
+				if (updatedData) {
+					await updateExrOptionsCache(updatedData);
+				}
+
+				// サーバーからの最新データで状態を上書き (必要であれば)
+				set((state) => {
+					const newEffectiveSelections = { ...state.effectiveSelections };
+					// Preset 以外は最終的にはキャッシュ (option.Selection) を見るので、
+					// ここで effectiveSelections をクリアしても良いが、
+					// 今回はシンプルに維持する
+					return {
+						effectiveSelections: newEffectiveSelections,
+					};
+				});
+			} catch (error) {
+				console.error("Failed to update ExR option:", error);
+			}
 		},
 		updatePresetName: (presetIndex: number, name: string) => {
 			set((state) => {

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -38,7 +38,8 @@ describe("ExRHeaderOptionControl", () => {
 		expect(textInput).toBeInTheDocument();
 	});
 
-	it("updates selection when slider is moved", () => {
+	it("updates selection when slider is moved", async () => {
+		const updateSpy = vi.spyOn(useStore.getState(), "updateExROptionSelection");
 		render(
 			<ExRHeaderOptionControl
 				categoryId={1}
@@ -50,12 +51,11 @@ describe("ExRHeaderOptionControl", () => {
 		const slider = screen.getByRole("slider");
 		fireEvent.change(slider, { target: { value: "1" } });
 
-		// Check if store was updated
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1);
+		expect(updateSpy).toHaveBeenCalledWith("1-50", 1);
 	});
 
-	it("updates selection when input is changed", () => {
+	it("updates selection when input is changed", async () => {
+		const updateSpy = vi.spyOn(useStore.getState(), "updateExROptionSelection");
 		render(
 			<ExRHeaderOptionControl
 				categoryId={1}
@@ -74,8 +74,7 @@ describe("ExRHeaderOptionControl", () => {
 
 		fireEvent.change(textInput, { target: { value: "100" } });
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(2); // 100 is at index 2
+		expect(updateSpy).toHaveBeenCalledWith("1-50", 2); // 100 is at index 2
 	});
 
 	it("prevents click propagation to parent", () => {

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -62,7 +62,7 @@ describe("ExRRoleSpawnControls", () => {
 
 	it("syncs rate to 0 when count is set to 0", () => {
 		// Set initial rate to 10%
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
+		useStore.getState().updateExROptionSelection("1-50", 1);
 
 		render(
 			<ExRRoleSpawnControls
@@ -105,8 +105,8 @@ describe("ExRRoleSpawnControls", () => {
 
 	it("syncs count to 0 when rate is set to 0%", () => {
 		// Set initial rate to 10% and count to 2
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
-		useStore.getState().TEMP_updateExROptionSelection("1-51", 1); // backend index 1 is value 2
+		useStore.getState().updateExROptionSelection("1-50", 1);
+		useStore.getState().updateExROptionSelection("1-51", 1); // backend index 1 is value 2
 
 		render(
 			<ExRRoleSpawnControls

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -60,14 +60,13 @@ describe("ExRRoleSpawnControls", () => {
 		expect(slider.max).toBe("3");
 	});
 
-	it("syncs rate to 0 when count is set to 0", () => {
-		// Set initial rate to 10%
-		useStore.getState().updateExROptionSelection("1-50", 1);
+	it("syncs rate to 0 when count is set to 0", async () => {
+		const updateSpy = vi.spyOn(useStore.getState(), "updateExROptionSelection");
 
 		render(
 			<ExRRoleSpawnControls
 				categoryId={1}
-				spawnRateOption={spawnRateOption}
+				spawnRateOption={{ ...spawnRateOption, Selection: 1 }} // Initial rate 10%
 				spawnCountOption={spawnCountOption}
 			/>,
 		);
@@ -79,11 +78,13 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "0" } });
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(0); // Rate 0%
+		expect(updateSpy).toHaveBeenCalledWith("1-51", 0);
+		expect(updateSpy).toHaveBeenCalledWith("1-50", 0);
 	});
 
-	it("syncs rate to 10% when count is set to non-zero from zero rate", () => {
+	it("syncs rate to 10% when count is set to non-zero from zero rate", async () => {
+		const updateSpy = vi.spyOn(useStore.getState(), "updateExROptionSelection");
+
 		render(
 			<ExRRoleSpawnControls
 				categoryId={1}
@@ -99,20 +100,18 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "1" } }); // Select '1'
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1); // Rate index 1 is 10%
+		expect(updateSpy).toHaveBeenCalledWith("1-51", 0);
+		expect(updateSpy).toHaveBeenCalledWith("1-50", 1);
 	});
 
-	it("syncs count to 0 when rate is set to 0%", () => {
-		// Set initial rate to 10% and count to 2
-		useStore.getState().updateExROptionSelection("1-50", 1);
-		useStore.getState().updateExROptionSelection("1-51", 1); // backend index 1 is value 2
+	it("syncs count to 0 when rate is set to 0%", async () => {
+		const updateSpy = vi.spyOn(useStore.getState(), "updateExROptionSelection");
 
 		render(
 			<ExRRoleSpawnControls
 				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
+				spawnRateOption={{ ...spawnRateOption, Selection: 1 }} // Initial rate 10%
+				spawnCountOption={{ ...spawnCountOption, Selection: 1 }} // Initial count 2
 			/>,
 		);
 
@@ -123,13 +122,7 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "0" } });
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-51"]).toBe(0); // Count reset to index 0
-
-		// UI should show 0
-		const countDisplay = screen
-			.getByTestId("spawn-count-control")
-			.querySelector('input[type="text"]');
-		expect(countDisplay).toHaveValue("0");
+		expect(updateSpy).toHaveBeenCalledWith("1-50", 0);
+		expect(updateSpy).toHaveBeenCalledWith("1-51", 0);
 	});
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,21 @@
 import "@testing-library/jest-dom";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { handlers } from "../mocks/handlers";
 
-// vitest の node 環境で fetch が相対パスを扱えるようにする (MSW用)
+const server = setupServer(...handlers);
+
+beforeAll(() => {
+	return server.listen();
+});
+afterEach(() => {
+	return server.resetHandlers();
+});
+afterAll(() => {
+	return server.close();
+});
+
+// vitest の node環境で fetch が相対パスを扱えるようにする (MSW用)
 // Node.js 18+ では fetch が標準でグローバルに存在しますが、
 // 相対パスの解決に問題がある場合は baseURL を設定するか MSW の設定で調整します。
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,21 @@
 import "@testing-library/jest-dom";
+
+// vitest の node 環境で fetch が相対パスを扱えるようにする (MSW用)
+if (typeof window === "undefined") {
+	const { fetch, Request, Response, Headers } = require("undici");
+	// @ts-ignore
+	global.fetch = fetch;
+	// @ts-ignore
+	global.Request = Request;
+	// @ts-ignore
+	global.Response = Response;
+	// @ts-ignore
+	global.Headers = Headers;
+}
+
+// テスト環境のベースURLを設定 (JSDOM用)
+if (typeof window !== "undefined") {
+	if (window.location.href === "about:blank") {
+		window.history.replaceState(null, "", "http://localhost:5173/");
+	}
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,17 +1,8 @@
 import "@testing-library/jest-dom";
 
 // vitest の node 環境で fetch が相対パスを扱えるようにする (MSW用)
-if (typeof window === "undefined") {
-	const { fetch, Request, Response, Headers } = require("undici");
-	// @ts-ignore
-	global.fetch = fetch;
-	// @ts-ignore
-	global.Request = Request;
-	// @ts-ignore
-	global.Response = Response;
-	// @ts-ignore
-	global.Headers = Headers;
-}
+// Node.js 18+ では fetch が標準でグローバルに存在しますが、
+// 相対パスの解決に問題がある場合は baseURL を設定するか MSW の設定で調整します。
 
 // テスト環境のベースURLを設定 (JSDOM用)
 if (typeof window !== "undefined") {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,4 +17,16 @@ export default defineConfig({
     tailwindcss(),
     babel({ presets: [reactCompilerPreset()] })
   ],
+  server: {
+    proxy: {
+      '/exr/option/': {
+        target: 'http://localhost:57700',
+        changeOrigin: true,
+      },
+      '/au/option/': {
+        target: 'http://localhost:57700',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
Implemented the backend integration for ExR option updates. The previously temporary `TEMP_updateExROptionSelection` has been replaced with a robust `updateExROptionSelection` that performs an asynchronous PUT request to the backend. The frontend now follows a server-driven update pattern where the global cache is differentially updated based on the `UpdatedOptions` response. Also added a `dev:no-mock` command to run the application against a real backend server at `http://localhost:57700` using Vite's proxy.

---
*PR created automatically by Jules for task [3057101174383204968](https://jules.google.com/task/3057101174383204968) started by @yukieiji*