### PR TITLE
Disable role accordion on zero spawn rate

### DIFF
--- a/e2e/exr_role_accordion_disabled.spec.ts
+++ b/e2e/exr_role_accordion_disabled.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	// API遅延を最小限にしてテストを高速化
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 0;
+	});
+	await page.goto("/");
+	// ローディング画面が消えるのを待つ
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+
+	// ExR Options タブに切り替え
+	await page.getByRole("button", { name: "ExR Options" }).click();
+	await page.waitForSelector('[data-testid="exr-category-list"]');
+});
+
+test.describe("ExR Role Accordion Disabled State", () => {
+	const SHERIFF_ID = "270";
+
+	test("should disable accordion when spawn rate is 0", async ({ page }) => {
+		// 役職タブ（クルーメイト）に切り替え
+		await page
+			.getByRole("button", { name: "クルーメイト役職設定", exact: true })
+			.click();
+
+		const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+		const toggleButton = sheriffCategory.getByRole("button", {
+			name: "シェリフ",
+		});
+		const rateSlider = sheriffCategory
+			.getByTestId("spawn-rate-control")
+			.locator('input[type="range"]');
+
+		// 1. まずレートを 10% にしてアコーディオンを開く
+		await rateSlider.fill("1"); // 10%
+		await toggleButton.click();
+		const content = sheriffCategory.getByTestId("exr-category-list-container");
+		await expect(content).toBeVisible();
+
+		// 2. レートを 0% にするとアコーディオンが閉じ、無効化されることを確認
+		await rateSlider.fill("0"); // 0%
+		await expect(content).not.toBeVisible();
+		await expect(toggleButton).toBeDisabled();
+
+		// 3. アイコンがドット「・」になっていることを確認
+		await expect(toggleButton.getByText("・")).toBeVisible();
+		await expect(toggleButton.locator("svg")).not.toBeVisible();
+
+		// 4. レートを 10% に戻すと再度有効化されることを確認
+		await rateSlider.fill("1"); // 10%
+		await expect(toggleButton).toBeEnabled();
+		await expect(toggleButton.locator("svg")).toBeVisible();
+		await expect(toggleButton.getByText("・")).not.toBeVisible();
+
+		// 5. 再度開けることを確認
+		// 少し待ってからクリック（状態遷移後の安定を待つ）
+		await page.waitForTimeout(100);
+		await toggleButton.click();
+		await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+	});
+});

--- a/e2e/exr_role_spawn_options.spec.ts
+++ b/e2e/exr_role_spawn_options.spec.ts
@@ -92,11 +92,11 @@ test.describe("ExR Role Spawn Options in Header", () => {
 		// 最初は閉じている
 		await expect(content).not.toBeVisible();
 
-		// レートのスライダーを操作
+		// レートを 0% から 10% に変更（アコーディオンを有効化）
 		const rateSlider = sheriffCategory
 			.getByTestId("spawn-rate-control")
 			.locator('input[type="range"]');
-		await rateSlider.fill("10");
+		await rateSlider.fill("1");
 
 		// まだ閉じているはず（stopPropagationが効いている）
 		await expect(content).not.toBeVisible();
@@ -123,6 +123,12 @@ test.describe("ExR Role Spawn Options in Header", () => {
 			.click();
 
 		const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
+
+		// レートを 10% に変更（アコーディオンを有効化）
+		await sheriffCategory
+			.getByTestId("spawn-rate-control")
+			.locator('input[type="range"]')
+			.fill("1");
 
 		// アコーディオンを開く
 		await sheriffCategory.getByRole("button", { name: "シェリフ" }).click();

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -21,7 +21,10 @@ export function ExRCategoryOptionList({
 	const groupedItems = shouldGroup ? groupOptionPairs(options) : options;
 
 	return (
-		<div className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
+		<div
+			data-testid="exr-category-list-container"
+			className="flex flex-col gap-px bg-gray-800 rounded-lg overflow-hidden border border-gray-700"
+		>
 			{groupedItems.map((item) => {
 				if ("type" in item && item.type === "pair") {
 					return (

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,5 +1,5 @@
 import { ColoredText } from "../components/parts/ColoredText";
-import { isPresetOption } from "../logics/optionUtils";
+import { getUniqueOptionId, isPresetOption } from "../logics/optionUtils";
 import type { ExRCategoryDto } from "../type";
 import { useStore } from "../useStore";
 import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
@@ -20,14 +20,23 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 		return state.toggleExRCategory;
 	});
 
-	const isOpen = isOpendCategory ?? false;
-
 	const spawnRateOption = category.Options.find((opt) => {
 		return opt.Id === 50;
 	});
 	const spawnCountOption = category.Options.find((opt) => {
 		return opt.Id === 51;
 	});
+
+	const uniqueRateId = getUniqueOptionId(category.Id, 50);
+	const effectiveSpawnRateSelection = useStore((state) => {
+		return state.effectiveSelections[uniqueRateId];
+	});
+	const spawnRateSelection =
+		effectiveSpawnRateSelection ?? spawnRateOption?.Selection ?? 0;
+	const rateValues = (spawnRateOption?.RangeMeta.Values as number[]) ?? [];
+	const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
+
+	const isOpen = !isSpawnRateZero && (isOpendCategory ?? false);
 
 	const filteredOptions = category.Options.filter((option) => {
 		if (isPresetOption(category.Id, option.Id)) {
@@ -48,29 +57,40 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 			className="border border-gray-700 rounded-lg overflow-hidden mb-2"
 			data-testid={`exr-category-${category.Id}`}
 		>
-			<div className="flex items-center bg-gray-800 hover:bg-gray-700 transition-colors">
+			<div
+				className={`flex items-center bg-gray-800 ${!isSpawnRateZero ? "hover:bg-gray-700 transition-colors" : ""}`}
+			>
 				<button
 					type="button"
 					onClick={() => {
-						toggleExRCategory(category.Id);
+						if (!isSpawnRateZero) {
+							toggleExRCategory(category.Id);
+						}
 					}}
-					className="flex-1 flex items-center gap-3 p-4 text-left"
+					className={`flex-1 flex items-center gap-3 p-4 text-left ${isSpawnRateZero ? "cursor-default" : ""}`}
 					aria-expanded={isOpen}
+					disabled={isSpawnRateZero}
 				>
-					<svg
-						className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpen ? "rotate-180" : ""}`}
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
-					>
-						<title>{isOpen ? "Collapse" : "Expand"}</title>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							strokeWidth={2}
-							d="M19 9l-7 7-7-7"
-						/>
-					</svg>
+					{isSpawnRateZero ? (
+						<div className="w-5 h-5 flex items-center justify-center text-gray-500 font-bold">
+							・
+						</div>
+					) : (
+						<svg
+							className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpen ? "rotate-180" : ""}`}
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<title>{isOpen ? "Collapse" : "Expand"}</title>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M19 9l-7 7-7-7"
+							/>
+						</svg>
+					)}
 					<span className="font-semibold text-gray-200">
 						<ColoredText text={category.Name} />
 					</span>

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -31,6 +31,12 @@ export function ExRRoleSpawnControls({
 	const TEMP_updateExROptionSelection = useStore((state) => {
 		return state.TEMP_updateExROptionSelection;
 	});
+	const toggleExRCategory = useStore((state) => {
+		return state.toggleExRCategory;
+	});
+	const isOpenedCategory = useStore((state) => {
+		return state.openedExRCategoryIds[categoryId] ?? false;
+	});
 
 	const spawnRateSelection =
 		effectiveSpawnRateSelection ?? spawnRateOption.Selection;
@@ -53,6 +59,9 @@ export function ExRRoleSpawnControls({
 		// スポーンレートが0%なら、スポーン数も0としてリセット
 		if (rateValues[newSelection] === 0) {
 			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			if (isOpenedCategory) {
+				toggleExRCategory(categoryId);
+			}
 		}
 	};
 
@@ -68,6 +77,9 @@ export function ExRRoleSpawnControls({
 				findClosestIndex(rateValues, 0),
 			);
 			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			if (isOpenedCategory) {
+				toggleExRCategory(categoryId);
+			}
 		} else {
 			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
 			if (isSpawnRateZero) {

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -96,6 +96,8 @@ describe("ExRCategoryList Component Selection", () => {
 
 	it("filters out 50 and 51 from role category body", () => {
 		useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
+		// Set a non-zero spawn rate so the accordion is enabled
+		useStore.getState().TEMP_updateExROptionSelection("2-50", 1); // Category 2, Option 50, Index 1 (Value 100)
 		render(<ExRCategoryList tabs={mockTabs} />);
 
 		// Open accordion - RoleCategoryItem uses a custom layout,


### PR DESCRIPTION
Implement a feature to prevent opening role settings accordions when the spawn rate or count is 0.
When the spawn rate is 0:
1. The accordion toggle button is disabled and its hover effect is removed.
2. The expansion chevron icon is replaced with a dot icon (·).
3. If the accordion was open, it automatically closes.

This change is specific to the role tabs (Crewmate, Impostor, Neutral, etc.) where spawn rate controls are present in the header.

---
*PR created automatically by Jules for task [6729876524762960468](https://jules.google.com/task/6729876524762960468) started by @yukieiji*