### PR TITLE
Decompose ExR and Au options promises into granular getters

### DIFF
--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -11,14 +11,19 @@ const AU_OPTION_URL = "/au/option/";
  * React 19 の use() で扱うためにリクエストを一度だけ実行するようにします
  */
 let exrOptionsPromise: Promise<ExRTabDto[]> | null = null;
+const exrTabPromises = new Map<number, Promise<ExRTabDto>>();
+
 let auOptionsPromise: Promise<AuOptionCategoryDto[]> | null = null;
+const auCategoryPromises = new Map<string, Promise<AuOptionCategoryDto>>();
 
 /**
  * キャッシュをリセットする（テスト用）
  */
 export function resetApiCache() {
 	exrOptionsPromise = null;
+	exrTabPromises.clear();
 	auOptionsPromise = null;
+	auCategoryPromises.clear();
 }
 
 /**
@@ -42,10 +47,40 @@ export function getExrOptions(): Promise<ExRTabDto[]> {
 		if (!res.ok) {
 			throw new Error(`Failed to fetch ExR options: ${res.statusText}`);
 		}
-		return res.json();
+		const data: ExRTabDto[] = await res.json();
+
+		// タブごとのPromiseを事前に解決済みの状態でキャッシュに格納する
+		for (const tab of data) {
+			if (!exrTabPromises.has(tab.Id)) {
+				exrTabPromises.set(tab.Id, Promise.resolve(tab));
+			}
+		}
+
+		return data;
 	})();
 
 	return exrOptionsPromise;
+}
+
+/**
+ * 特定のExRタブのオプションを取得する
+ */
+export function getExrTabOptions(tabId: number): Promise<ExRTabDto> {
+	const cached = exrTabPromises.get(tabId);
+	if (cached) {
+		return cached;
+	}
+
+	const promise = getExrOptions().then((tabs) => {
+		const tab = tabs.find((t) => t.Id === tabId);
+		if (!tab) {
+			throw new Error(`ExR tab not found: ${tabId}`);
+		}
+		return tab;
+	});
+
+	exrTabPromises.set(tabId, promise);
+	return promise;
 }
 
 /**
@@ -69,10 +104,45 @@ export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
 		if (!res.ok) {
 			throw new Error(`Failed to fetch Au options: ${res.statusText}`);
 		}
-		return res.json();
+		const data: AuOptionCategoryDto[] = await res.json();
+
+		// カテゴリーごとのPromiseを事前に解決済みの状態でキャッシュに格納する
+		for (const category of data) {
+			if (!auCategoryPromises.has(category.TranslatedTitle)) {
+				auCategoryPromises.set(
+					category.TranslatedTitle,
+					Promise.resolve(category),
+				);
+			}
+		}
+
+		return data;
 	})();
 
 	return auOptionsPromise;
+}
+
+/**
+ * 特定のAuカテゴリーのオプションを取得する
+ */
+export function getAuCategoryOptions(
+	categoryName: string,
+): Promise<AuOptionCategoryDto> {
+	const cached = auCategoryPromises.get(categoryName);
+	if (cached) {
+		return cached;
+	}
+
+	const promise = getAuOptions().then((categories) => {
+		const category = categories.find((c) => c.TranslatedTitle === categoryName);
+		if (!category) {
+			throw new Error(`Au category not found: ${categoryName}`);
+		}
+		return category;
+	});
+
+	auCategoryPromises.set(categoryName, promise);
+	return promise;
 }
 
 /**

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -12,6 +12,7 @@ const AU_OPTION_URL = "/au/option/";
  */
 let exrOptionsPromise: Promise<ExRTabDto[]> | null = null;
 const exrTabPromises = new Map<number, Promise<ExRTabDto>>();
+const exrCategoryPromises = new Map<number, Promise<ExRCategoryDto>>();
 
 let auOptionsPromise: Promise<AuOptionCategoryDto[]> | null = null;
 const auCategoryPromises = new Map<string, Promise<AuOptionCategoryDto>>();
@@ -22,6 +23,7 @@ const auCategoryPromises = new Map<string, Promise<AuOptionCategoryDto>>();
 export function resetApiCache() {
 	exrOptionsPromise = null;
 	exrTabPromises.clear();
+	exrCategoryPromises.clear();
 	auOptionsPromise = null;
 	auCategoryPromises.clear();
 }
@@ -49,10 +51,15 @@ export function getExrOptions(): Promise<ExRTabDto[]> {
 		}
 		const data: ExRTabDto[] = await res.json();
 
-		// タブごとのPromiseを事前に解決済みの状態でキャッシュに格納する
+		// タブごとおよびカテゴリーごとのPromiseを事前に解決済みの状態でキャッシュに格納する
 		for (const tab of data) {
 			if (!exrTabPromises.has(tab.Id)) {
 				exrTabPromises.set(tab.Id, Promise.resolve(tab));
+			}
+			for (const category of tab.Categories) {
+				if (!exrCategoryPromises.has(category.Id)) {
+					exrCategoryPromises.set(category.Id, Promise.resolve(category));
+				}
 			}
 		}
 
@@ -80,6 +87,31 @@ export function getExrTabOptions(tabId: number): Promise<ExRTabDto> {
 	});
 
 	exrTabPromises.set(tabId, promise);
+	return promise;
+}
+
+/**
+ * 特定のExRカテゴリーのオプションを取得する
+ */
+export function getExrCategoryOptions(
+	categoryId: number,
+): Promise<ExRCategoryDto> {
+	const cached = exrCategoryPromises.get(categoryId);
+	if (cached) {
+		return cached;
+	}
+
+	const promise = getExrOptions().then((tabs) => {
+		for (const tab of tabs) {
+			const category = tab.Categories.find((c) => c.Id === categoryId);
+			if (category) {
+				return category;
+			}
+		}
+		throw new Error(`ExR category not found: ${categoryId}`);
+	});
+
+	exrCategoryPromises.set(categoryId, promise);
 	return promise;
 }
 

--- a/tests/api-decomposition.test.ts
+++ b/tests/api-decomposition.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getAuCategoryOptions,
+	getAuOptions,
+	getExrOptions,
+	getExrTabOptions,
+	resetApiCache,
+} from "../src/logics/api";
+
+// Mock fetch
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+describe("Granular API Promise decomposition", () => {
+	beforeEach(() => {
+		resetApiCache();
+		vi.clearAllMocks();
+	});
+
+	it("getExrTabOptions should trigger getExrOptions and return the specific tab", async () => {
+		const mockTabs = [
+			{ Id: 0, Name: "General", Categories: [] },
+			{ Id: 1, Name: "Crewmate", Categories: [] },
+		];
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => mockTabs,
+		} as Response);
+
+		const tabPromise = getExrTabOptions(1);
+		expect(fetch).toHaveBeenCalledTimes(1);
+
+		const tab = await tabPromise;
+		expect(tab.Id).toBe(1);
+		expect(tab.Name).toBe("Crewmate");
+	});
+
+	it("getExrTabOptions should return the same promise instance for the same tabId", () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => [{ Id: 0, Name: "General", Categories: [] }],
+		} as Response);
+
+		const p1 = getExrTabOptions(0);
+		const p2 = getExrTabOptions(0);
+		expect(p1).toBe(p2);
+	});
+
+	it("getExrOptions should populate individual tab promises", async () => {
+		const mockTabs = [
+			{ Id: 0, Name: "General", Categories: [] },
+			{ Id: 1, Name: "Crewmate", Categories: [] },
+		];
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => mockTabs,
+		} as Response);
+
+		await getExrOptions();
+
+		// Now getExrTabOptions should return a resolved promise without fetching again
+		const p0 = getExrTabOptions(0);
+		const tab0 = await p0;
+		expect(tab0.Name).toBe("General");
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("getAuCategoryOptions should trigger getAuOptions and return the specific category", async () => {
+		const mockCategories = [
+			{ TranslatedTitle: "Game Settings", Options: [] },
+			{ TranslatedTitle: "Role Settings", Options: [] },
+		];
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => mockCategories,
+		} as Response);
+
+		const categoryPromise = getAuCategoryOptions("Role Settings");
+		expect(fetch).toHaveBeenCalledTimes(1);
+
+		const category = await categoryPromise;
+		expect(category.TranslatedTitle).toBe("Role Settings");
+	});
+
+	it("getAuCategoryOptions should return the same promise instance for the same categoryName", () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => [{ TranslatedTitle: "Game Settings", Options: [] }],
+		} as Response);
+
+		const p1 = getAuCategoryOptions("Game Settings");
+		const p2 = getAuCategoryOptions("Game Settings");
+		expect(p1).toBe(p2);
+	});
+
+	it("getAuOptions should populate individual category promises", async () => {
+		const mockCategories = [{ TranslatedTitle: "Game Settings", Options: [] }];
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => mockCategories,
+		} as Response);
+
+		await getAuOptions();
+
+		const p = getAuCategoryOptions("Game Settings");
+		const cat = await p;
+		expect(cat.TranslatedTitle).toBe("Game Settings");
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("resetApiCache should clear granular promises", async () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => [{ Id: 0, Name: "General", Categories: [] }],
+		} as Response);
+
+		const p1 = getExrTabOptions(0);
+		resetApiCache();
+		const p2 = getExrTabOptions(0);
+
+		expect(p1).not.toBe(p2);
+	});
+});

--- a/tests/api-decomposition.test.ts
+++ b/tests/api-decomposition.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	getAuCategoryOptions,
 	getAuOptions,
+	getExrCategoryOptions,
 	getExrOptions,
 	getExrTabOptions,
 	resetApiCache,
@@ -46,9 +47,13 @@ describe("Granular API Promise decomposition", () => {
 		expect(p1).toBe(p2);
 	});
 
-	it("getExrOptions should populate individual tab promises", async () => {
+	it("getExrOptions should populate individual tab and category promises", async () => {
 		const mockTabs = [
-			{ Id: 0, Name: "General", Categories: [] },
+			{
+				Id: 0,
+				Name: "General",
+				Categories: [{ Id: 10, Name: "SubCat", Options: [] }],
+			},
 			{ Id: 1, Name: "Crewmate", Categories: [] },
 		];
 		fetchMock.mockResolvedValue({
@@ -62,7 +67,47 @@ describe("Granular API Promise decomposition", () => {
 		const p0 = getExrTabOptions(0);
 		const tab0 = await p0;
 		expect(tab0.Name).toBe("General");
+
+		// Now getExrCategoryOptions should return a resolved promise without fetching again
+		const pc = getExrCategoryOptions(10);
+		const cat = await pc;
+		expect(cat.Name).toBe("SubCat");
+
 		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("getExrCategoryOptions should trigger getExrOptions and return the specific category", async () => {
+		const mockTabs = [
+			{
+				Id: 0,
+				Name: "General",
+				Categories: [{ Id: 10, Name: "SubCat", Options: [] }],
+			},
+		];
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => mockTabs,
+		} as Response);
+
+		const categoryPromise = getExrCategoryOptions(10);
+		expect(fetch).toHaveBeenCalledTimes(1);
+
+		const category = await categoryPromise;
+		expect(category.Id).toBe(10);
+		expect(category.Name).toBe("SubCat");
+	});
+
+	it("getExrCategoryOptions should return the same promise instance for the same categoryId", () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => [
+				{ Id: 0, Name: "General", Categories: [{ Id: 10, Name: "SubCat" }] },
+			],
+		} as Response);
+
+		const p1 = getExrCategoryOptions(10);
+		const p2 = getExrCategoryOptions(10);
+		expect(p1).toBe(p2);
 	});
 
 	it("getAuCategoryOptions should trigger getAuOptions and return the specific category", async () => {


### PR DESCRIPTION
The existing `exrOptionsPromise` and `auOptionsPromise` were only providing "all-or-nothing" access to the configuration data. To support more efficient rendering and granular UI updates (especially with React 19's `use()` hook), these have been decomposed.

Changes:
1.  **Granular Caching:** Introduced `Map<number, Promise<ExRTabDto>>` and `Map<string, Promise<AuOptionCategoryDto>>` to store promises for individual tabs and categories.
2.  **New Getters:** 
    - `getExrTabOptions(tabId)`: Retrieves a specific tab's promise.
    - `getAuCategoryOptions(categoryName)`: Retrieves a specific category's promise (using the translated title).
3.  **Automatic Pre-population:** The main fetch functions (`getExrOptions` and `getAuOptions`) now populate these granular caches once the data is received. This ensures that any subsequent requests for a specific tab or category resolve immediately.
4.  **Promise Stability:** Granular getters return the same Promise instance for repeated calls to the same ID/name before the main fetch completes, preventing redundant fetching logic and meeting React 19 requirements.
5.  **Testing:** A new test file `tests/api-decomposition.test.ts` was added to verify:
    - Triggering main fetch from granular getters.
    - Returning the same promise instance.
    - Pre-population behavior.
    - Cache reset behavior.

These changes provide the infrastructure for optimizing component rendering by allowing components to suspend only on the specific data they require.

---
*PR created automatically by Jules for task [1246625209156476023](https://jules.google.com/task/1246625209156476023) started by @yukieiji*