### PR TITLE
Implement Backend API Integration for ExR Option Updates

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -84,37 +84,41 @@ export const handlers = [
     // 既存のモックデータからカテゴリを探す
     let sourceCategory = null;
     for (const tab of validatedExRMockData) {
-      const cat = tab.Categories.find(c => c.Id === CategoryId);
-      if (cat) {
-        sourceCategory = cat;
+      const catIndex = tab.Categories.findIndex(c => c.Id === CategoryId);
+      if (catIndex !== -1) {
+        sourceCategory = tab.Categories[catIndex];
+
+        // モックデータを更新して状態を保持する
+        let found = false;
+        sourceCategory.Options = sourceCategory.Options.map(opt => {
+          if (opt.Id === OptionId) {
+            found = true;
+            return { ...opt, Selection };
+          }
+          return opt;
+        });
+
+        if (!found) {
+          sourceCategory.Options.push({
+            Id: OptionId,
+            IsActive: true,
+            TranslatedName: "Mock Option",
+            Selection: Selection,
+            Format: "{0}",
+            RangeMeta: {
+              Type: "Int32",
+              Values: [0, 1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+            },
+            Childs: []
+          });
+        }
         break;
       }
     }
 
     let updatedOptions: ExROptionDto[] = [];
     if (sourceCategory) {
-      let found = false;
-      updatedOptions = sourceCategory.Options.map(opt => {
-        if (opt.Id === OptionId) {
-          found = true;
-          return { ...opt, Selection };
-        }
-        return opt;
-      });
-      if (!found) {
-        updatedOptions.push({
-          Id: OptionId,
-          IsActive: true,
-          TranslatedName: "Mock Option",
-          Selection: Selection,
-          Format: "{0}",
-          RangeMeta: {
-            Type: "Int32",
-            Values: [0, 1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
-          },
-          Childs: []
-        });
-      }
+      updatedOptions = sourceCategory.Options;
     } else {
       // 見つからない場合はダミーを生成（テスト用）
       updatedOptions = [

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -6,7 +6,7 @@ import {
   UpdatedOptionsSchema,
   VanillaOptionPutRequestSchema
 } from '../src/type';
-import type { UpdatedOptions, ExRTabDto, AuOptionCategoryDto } from '../src/type';
+import type { UpdatedOptions, ExRTabDto, AuOptionCategoryDto, ExROptionDto } from '../src/type';
 
 // JSONファイルのロード
 import exrOptionData from './get/exr/setting-webui-dev_20260321.json';
@@ -27,9 +27,9 @@ try {
 }
 
 /**
- * 更新されたオプションのモックデータ作成
+ * 更新されたオプションのモックデータ作成 (Vanilla用)
  */
-const mockUpdatedOptions: UpdatedOptions = {
+const mockUpdatedOptionsVanilla: UpdatedOptions = {
   UpdatedCategory: {
     Id: 1,
     Name: 'ゲーム設定',
@@ -51,7 +51,7 @@ const mockUpdatedOptions: UpdatedOptions = {
   ChainUpdatedOption: [],
 };
 
-const validatedUpdatedOptions = UpdatedOptionsSchema.parse(mockUpdatedOptions);
+const validatedUpdatedOptionsVanilla = UpdatedOptionsSchema.parse(mockUpdatedOptionsVanilla);
 
 export const handlers = [
   /**
@@ -67,35 +67,95 @@ export const handlers = [
   http.put('/exr/option/', async ({ request }) => {
     const body = await request.json();
 
-    // Zodを使用してリクエストボディをバリデーション
     const result = ExROptionPutRequestSchema.safeParse(body);
-
     if (!result.success) {
       return new HttpResponse(null, { status: 400 });
     }
 
-    const { CategoryId, OptionId } = result.data;
+    const { CategoryId, OptionId, Selection } = result.data;
 
-    // CategoryIdとOptionIdが0のときは202を返す（ボディなし）
     if (CategoryId === 0 && OptionId === 0) {
       return new HttpResponse(null, { status: 202 });
     }
 
-    // それ以外はUpdatedOptionsを返す
-    const mockUpdatedOptions: UpdatedOptions = {
-      UpdatedCategory: validatedExRMockData[0].Categories[0],
-      ChainUpdatedOption: [
+    // 既存のモックデータからカテゴリを探す
+    let sourceCategory = null;
+    for (const tab of validatedExRMockData) {
+      const cat = tab.Categories.find(c => c.Id === CategoryId);
+      if (cat) {
+        sourceCategory = cat;
+        break;
+      }
+    }
+
+    let updatedOptions: ExROptionDto[] = [];
+    if (sourceCategory) {
+      updatedOptions = sourceCategory.Options.map(opt =>
+        opt.Id === OptionId ? { ...opt, Selection } : opt
+      );
+    } else {
+      // 見つからない場合はダミーを生成（テスト用）
+      updatedOptions = [
         {
-          Id: validatedExRMockData[0].Categories[0].Id,
-          Options: [validatedExRMockData[0].Categories[0].Options[0]],
+          Id: OptionId,
+          IsActive: true,
+          TranslatedName: "Mock Option",
+          Selection: Selection,
+          Format: "{0}",
+          RangeMeta: {
+            Type: "Int32",
+            Values: [0, 1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+          },
+          Childs: []
         },
-      ],
+        {
+          Id: 999, // フィルタリングで消えないためのダミー
+          IsActive: true,
+          TranslatedName: "Dummy Option",
+          Selection: 0,
+          Format: "{0}",
+          RangeMeta: { Type: "Int32", Values: [0, 1] },
+          Childs: []
+        }
+      ];
+    }
+
+    const response: UpdatedOptions = {
+      UpdatedCategory: {
+        Id: CategoryId,
+        Name: sourceCategory ? sourceCategory.Name : "Mock Category",
+        Options: sourceCategory
+          ? updatedOptions
+          : [
+              {
+                Id: OptionId,
+                IsActive: true,
+                TranslatedName: "Mock Option",
+                Selection: Selection,
+                Format: "{0}",
+                RangeMeta: {
+                  Type: "Int32",
+                  Values: [
+                    0, 1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100,
+                  ],
+                },
+                Childs: [],
+              },
+              {
+                Id: 51, // Spawn Count for Role tests
+                IsActive: true,
+                TranslatedName: "Mock Option 2",
+                Selection: Selection, // just a placeholder
+                Format: "{0}",
+                RangeMeta: { Type: "Int32", Values: [0, 1, 2, 3] },
+                Childs: [],
+              },
+            ],
+      },
+      ChainUpdatedOption: [],
     };
 
-    // レスポンスデータのバリデーション
-    const validatedResponse = UpdatedOptionsSchema.parse(mockUpdatedOptions);
-
-    return HttpResponse.json(validatedResponse);
+    return HttpResponse.json(UpdatedOptionsSchema.parse(response));
   }),
 
   /**
@@ -111,12 +171,11 @@ export const handlers = [
   http.put('/au/option/', async ({ request }) => {
     const body = await request.json();
 
-    // リクエストボディのバリデーション
     const validatedRequest = VanillaOptionPutRequestSchema.safeParse(body);
     if (!validatedRequest.success) {
       return HttpResponse.json(validatedRequest.error, { status: 400 });
     }
 
-    return HttpResponse.json(validatedUpdatedOptions);
+    return HttpResponse.json(validatedUpdatedOptionsVanilla);
   }),
 ];

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -67,13 +67,16 @@ export const handlers = [
   http.put('/exr/option/', async ({ request }) => {
     const body = await request.json();
 
+    // Zodを使用してリクエストボディをバリデーション
     const result = ExROptionPutRequestSchema.safeParse(body);
+
     if (!result.success) {
       return new HttpResponse(null, { status: 400 });
     }
 
     const { CategoryId, OptionId, Selection } = result.data;
 
+    // CategoryIdとOptionIdが0のときは202を返す（ボディなし）
     if (CategoryId === 0 && OptionId === 0) {
       return new HttpResponse(null, { status: 202 });
     }
@@ -90,9 +93,28 @@ export const handlers = [
 
     let updatedOptions: ExROptionDto[] = [];
     if (sourceCategory) {
-      updatedOptions = sourceCategory.Options.map(opt =>
-        opt.Id === OptionId ? { ...opt, Selection } : opt
-      );
+      let found = false;
+      updatedOptions = sourceCategory.Options.map(opt => {
+        if (opt.Id === OptionId) {
+          found = true;
+          return { ...opt, Selection };
+        }
+        return opt;
+      });
+      if (!found) {
+        updatedOptions.push({
+          Id: OptionId,
+          IsActive: true,
+          TranslatedName: "Mock Option",
+          Selection: Selection,
+          Format: "{0}",
+          RangeMeta: {
+            Type: "Int32",
+            Values: [0, 1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+          },
+          Childs: []
+        });
+      }
     } else {
       // 見つからない場合はダミーを生成（テスト用）
       updatedOptions = [
@@ -109,12 +131,12 @@ export const handlers = [
           Childs: []
         },
         {
-          Id: 999, // フィルタリングで消えないためのダミー
+          Id: 51, // Spawn Count for Role tests
           IsActive: true,
-          TranslatedName: "Dummy Option",
+          TranslatedName: "Mock Option 2",
           Selection: 0,
           Format: "{0}",
-          RangeMeta: { Type: "Int32", Values: [0, 1] },
+          RangeMeta: { Type: "Int32", Values: [0, 1, 2, 3] },
           Childs: []
         }
       ];
@@ -124,38 +146,15 @@ export const handlers = [
       UpdatedCategory: {
         Id: CategoryId,
         Name: sourceCategory ? sourceCategory.Name : "Mock Category",
-        Options: sourceCategory
-          ? updatedOptions
-          : [
-              {
-                Id: OptionId,
-                IsActive: true,
-                TranslatedName: "Mock Option",
-                Selection: Selection,
-                Format: "{0}",
-                RangeMeta: {
-                  Type: "Int32",
-                  Values: [
-                    0, 1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100,
-                  ],
-                },
-                Childs: [],
-              },
-              {
-                Id: 51, // Spawn Count for Role tests
-                IsActive: true,
-                TranslatedName: "Mock Option 2",
-                Selection: Selection, // just a placeholder
-                Format: "{0}",
-                RangeMeta: { Type: "Int32", Values: [0, 1, 2, 3] },
-                Childs: [],
-              },
-            ],
+        Options: updatedOptions
       },
-      ChainUpdatedOption: [],
+      ChainUpdatedOption: []
     };
 
-    return HttpResponse.json(UpdatedOptionsSchema.parse(response));
+    // レスポンスデータのバリデーション
+    const validatedResponse = UpdatedOptionsSchema.parse(response);
+
+    return HttpResponse.json(validatedResponse);
   }),
 
   /**
@@ -171,6 +170,7 @@ export const handlers = [
   http.put('/au/option/', async ({ request }) => {
     const body = await request.json();
 
+    // リクエストボディのバリデーション
     const validatedRequest = VanillaOptionPutRequestSchema.safeParse(body);
     if (!validatedRequest.success) {
       return HttpResponse.json(validatedRequest.error, { status: 400 });

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -23,18 +23,18 @@ export function ExRHeaderOptionControl({
 		return state.effectiveSelections[uniqueId];
 	});
 	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const values = option.RangeMeta.Values as number[];
 
 	const handleSelectionChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const handleInputChange = (val: number) => {
-		TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+		updateExROptionSelection(uniqueId, findClosestIndex(values, val));
 	};
 
 	return (

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -22,12 +22,12 @@ export function ExROptionControl({
 		return state.effectiveSelections[uniqueId];
 	});
 	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const handleChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const { Type, Values } = option.RangeMeta;

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -39,16 +39,16 @@ export function ExRPairedOptionRow({
 	const minSelection = effectiveMinSelection ?? min.Selection;
 	const maxSelection = effectiveMaxSelection ?? max.Selection;
 
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const handleMinChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(minUniqueId, newSelection);
+		updateExROptionSelection(minUniqueId, newSelection);
 	};
 
 	const handleMaxChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(maxUniqueId, newSelection);
+		updateExROptionSelection(maxUniqueId, newSelection);
 	};
 
 	const content = (

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -53,39 +53,39 @@ export function ExRRoleSpawnControls({
 	const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
-	const handleRateChange = (newSelection: number) => {
-		updateExROptionSelection(uniqueRateId, newSelection);
+	const handleRateChange = async (newSelection: number) => {
+		await updateExROptionSelection(uniqueRateId, newSelection);
 
 		// スポーンレートが0%なら、スポーン数も0としてリセット
 		if (rateValues[newSelection] === 0) {
-			updateExROptionSelection(uniqueCountId, 0);
+			await updateExROptionSelection(uniqueCountId, 0);
 			if (isOpenedCategory) {
 				toggleExRCategory(categoryId);
 			}
 		}
 	};
 
-	const handleRateInputChange = (val: number) => {
-		handleRateChange(findClosestIndex(rateValues, val));
+	const handleRateInputChange = async (val: number) => {
+		await handleRateChange(findClosestIndex(rateValues, val));
 	};
 
-	const handleCountUIChange = (newUISelection: number) => {
+	const handleCountUIChange = async (newUISelection: number) => {
 		if (newUISelection === 0) {
 			// 数を0にすると、レートも0%にする
-			updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 0));
-			updateExROptionSelection(uniqueCountId, 0);
+			await updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 0));
+			await updateExROptionSelection(uniqueCountId, 0);
 			if (isOpenedCategory) {
 				toggleExRCategory(categoryId);
 			}
 		} else {
 			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
 			if (isSpawnRateZero) {
-				updateExROptionSelection(
+				await updateExROptionSelection(
 					uniqueRateId,
 					findClosestIndex(rateValues, 10),
 				);
 			}
-			updateExROptionSelection(uniqueCountId, newUISelection - 1);
+			await updateExROptionSelection(uniqueCountId, newUISelection - 1);
 		}
 	};
 

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -28,8 +28,8 @@ export function ExRRoleSpawnControls({
 		return state.effectiveSelections[uniqueCountId];
 	});
 
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
@@ -54,11 +54,11 @@ export function ExRRoleSpawnControls({
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
 	const handleRateChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueRateId, newSelection);
+		updateExROptionSelection(uniqueRateId, newSelection);
 
 		// スポーンレートが0%なら、スポーン数も0としてリセット
 		if (rateValues[newSelection] === 0) {
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			updateExROptionSelection(uniqueCountId, 0);
 			if (isOpenedCategory) {
 				toggleExRCategory(categoryId);
 			}
@@ -72,23 +72,20 @@ export function ExRRoleSpawnControls({
 	const handleCountUIChange = (newUISelection: number) => {
 		if (newUISelection === 0) {
 			// 数を0にすると、レートも0%にする
-			TEMP_updateExROptionSelection(
-				uniqueRateId,
-				findClosestIndex(rateValues, 0),
-			);
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			updateExROptionSelection(uniqueRateId, findClosestIndex(rateValues, 0));
+			updateExROptionSelection(uniqueCountId, 0);
 			if (isOpenedCategory) {
 				toggleExRCategory(categoryId);
 			}
 		} else {
 			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
 			if (isSpawnRateZero) {
-				TEMP_updateExROptionSelection(
+				updateExROptionSelection(
 					uniqueRateId,
 					findClosestIndex(rateValues, 10),
 				);
 			}
-			TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
+			updateExROptionSelection(uniqueCountId, newUISelection - 1);
 		}
 	};
 

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -40,8 +40,8 @@ export function PresetSelector() {
 	const updatePresetName = useStore((state) => {
 		return state.updatePresetName;
 	});
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 	const setPresetDropdownOpen = useStore((state) => {
 		return state.setPresetDropdownOpen;
@@ -76,7 +76,7 @@ export function PresetSelector() {
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
 	const handlePresetSelect = (index: number) => {
-		TEMP_updateExROptionSelection(uniqueId, index);
+		updateExROptionSelection(uniqueId, index);
 		setPresetDropdownOpen(false);
 	};
 

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -1,5 +1,15 @@
-import type { AuOptionCategoryDto, ExRCategoryDto, ExRTabDto } from "../type";
-import { AuOptionCategoryDtoArraySchema, ExRTabDtoArraySchema } from "../type";
+import type {
+	AuOptionCategoryDto,
+	ExRCategoryDto,
+	ExROptionPutRequest,
+	ExRTabDto,
+	UpdatedOptions,
+} from "../type";
+import {
+	AuOptionCategoryDtoArraySchema,
+	ExRTabDtoArraySchema,
+	UpdatedOptionsSchema,
+} from "../type";
 
 /**
  * API エンドポイントの定数定義
@@ -185,4 +195,48 @@ export function getAuCategoryOptions(
  */
 export function getAllOptions(): Promise<[ExRTabDto[], AuOptionCategoryDto[]]> {
 	return Promise.all([getExrOptions(), getAuOptions()]);
+}
+
+/**
+ * ExRオプションを更新する
+ */
+export async function putExrOption(
+	request: ExROptionPutRequest,
+): Promise<UpdatedOptions> {
+	const res = await fetch(EXR_OPTION_URL, {
+		method: "PUT",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(request),
+	});
+
+	if (!res.ok) {
+		throw new Error(`Failed to update ExR option: ${res.statusText}`);
+	}
+
+	const rawData = await res.json();
+	const data = UpdatedOptionsSchema.parse(rawData);
+
+	// キャッシュの更新
+	if (data.UpdatedCategory) {
+		exrCategoryPromises.set(
+			data.UpdatedCategory.Id,
+			Promise.resolve(data.UpdatedCategory),
+		);
+	}
+
+	for (const chain of data.ChainUpdatedOption) {
+		const cachedPromise = exrCategoryPromises.get(chain.Id);
+		if (cachedPromise) {
+			const cached = await cachedPromise;
+			const updatedCategory: ExRCategoryDto = {
+				...cached,
+				Options: chain.Options,
+			};
+			exrCategoryPromises.set(chain.Id, Promise.resolve(updatedCategory));
+		}
+	}
+
+	return data;
 }

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -1,8 +1,10 @@
 import type { StateCreator } from "zustand";
+import { putExrOption, resetApiCache } from "../logics/api";
 import {
 	loadPresetNamesFromCookie,
 	savePresetNamesToCookie,
 } from "../logics/cookieUtils";
+import { getUniqueOptionId } from "../logics/optionUtils";
 import type { OptionTab } from "../type";
 
 /**
@@ -20,10 +22,10 @@ export interface OptionViewerSlice {
 	setIsTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: string) => void;
-	TEMP_updateExROptionSelection: (
+	updateExROptionSelection: (
 		uniqueOptionId: string,
 		selection: number,
-	) => void;
+	) => Promise<void>;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
 	resetViewer: () => void;
@@ -34,6 +36,7 @@ export interface OptionViewerSlice {
  */
 export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 	set,
+	get,
 ) => {
 	return {
 		selectedExRTabId: 0,
@@ -58,6 +61,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				effectiveSelections: {},
 				isPresetDropdownOpen: false,
 			});
+			resetApiCache();
 		},
 		toggleExRCategory: (categoryId: number) => {
 			set((state) => {
@@ -79,16 +83,57 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				};
 			});
 		},
-		TEMP_updateExROptionSelection: (
+		updateExROptionSelection: async (
 			uniqueOptionId: string,
 			selection: number,
 		) => {
+			const [catIdStr, optIdStr] = uniqueOptionId.split("-");
+			const categoryId = Number.parseInt(catIdStr, 10);
+			const optionId = Number.parseInt(optIdStr, 10);
+			const { selectedExRTabId } = get();
+
+			const result = await putExrOption({
+				TabId: selectedExRTabId,
+				CategoryId: categoryId,
+				OptionId: optionId,
+				Selection: selection,
+			});
+
 			set((state) => {
+				const newSelections = { ...state.effectiveSelections };
+
+				// 更新されたカテゴリ内の全オプションを effectiveSelections に反映
+				if (result.UpdatedCategory) {
+					const cid = result.UpdatedCategory.Id;
+					const traverse = (opts: typeof result.UpdatedCategory.Options) => {
+						for (const opt of opts) {
+							const uid = getUniqueOptionId(cid, opt.Id);
+							newSelections[uid] = opt.Selection;
+							if (opt.Childs) {
+								traverse(opt.Childs);
+							}
+						}
+					};
+					traverse(result.UpdatedCategory.Options);
+				}
+
+				// 連鎖的に更新されたオプションも反映
+				for (const chain of result.ChainUpdatedOption) {
+					const cid = chain.Id;
+					const traverseChain = (opts: typeof chain.Options) => {
+						for (const opt of opts) {
+							const uid = getUniqueOptionId(cid, opt.Id);
+							newSelections[uid] = opt.Selection;
+							if (opt.Childs) {
+								traverseChain(opt.Childs);
+							}
+						}
+					};
+					traverseChain(chain.Options);
+				}
+
 				return {
-					effectiveSelections: {
-						...state.effectiveSelections,
-						[uniqueOptionId]: selection,
-					},
+					effectiveSelections: newSelections,
 				};
 			});
 		},

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -102,6 +102,9 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 			set((state) => {
 				const newSelections = { ...state.effectiveSelections };
 
+				// ターゲットとなったオプションをまず更新（結果に含まれない場合への備え）
+				newSelections[uniqueOptionId] = selection;
+
 				// 更新されたカテゴリ内の全オプションを effectiveSelections に反映
 				if (result.UpdatedCategory) {
 					const cid = result.UpdatedCategory.Id;

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -117,7 +117,7 @@ describe("ExRCategoryList Component Selection", { timeout: 15000 }, () => {
 	it("filters out 50 and 51 from role category body", async () => {
 		await act(async () => {
 			useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
-			useStore.getState().TEMP_updateExROptionSelection("2-50", 1);
+			await useStore.getState().updateExROptionSelection("2-50", 1);
 		});
 
 		await act(async () => {

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ExRCategoryList } from "../src/feature/ExRCategoryList";
 import { resetApiCache } from "../src/logics/api";
-import { type ExRTabDto, OptionTab } from "../src/type";
+import { type ExRTabDto, OptionTab, type UpdatedOptions } from "../src/type";
 import { useStore } from "../src/useStore";
 import { server } from "./msw-server";
 
@@ -76,6 +76,40 @@ describe("ExRCategoryList Component Selection", { timeout: 15000 }, () => {
 		resetApiCache();
 		useStore.getState().resetViewer();
 		server.use(http.get("/exr/option/", () => HttpResponse.json(mockTabs)));
+
+		// PUT ハンドラーをこのテストの mockTabs に合わせる
+		server.use(
+			http.put("/exr/option/", async ({ request }) => {
+				const body = (await request.json()) as {
+					CategoryId: number;
+					OptionId: number;
+					Selection: number;
+				};
+				const { CategoryId, OptionId, Selection } = body;
+
+				let sourceCategory = null;
+				for (const tab of mockTabs) {
+					const cat = tab.Categories.find((c) => c.Id === CategoryId);
+					if (cat) {
+						sourceCategory = cat;
+						break;
+					}
+				}
+
+				const response: UpdatedOptions = {
+					UpdatedCategory: sourceCategory
+						? {
+								...sourceCategory,
+								Options: sourceCategory.Options.map((opt) =>
+									opt.Id === OptionId ? { ...opt, Selection } : opt,
+								),
+							}
+						: null,
+					ChainUpdatedOption: [],
+				};
+				return HttpResponse.json(response);
+			}),
+		);
 	});
 
 	it("renders ExRStandardCategoryItem for General Tab", async () => {

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -38,7 +38,7 @@ describe("ExRHeaderOptionControl", () => {
 		expect(textInput).toBeInTheDocument();
 	});
 
-	it("updates selection when slider is moved", () => {
+	it("updates selection when slider is moved", async () => {
 		render(
 			<ExRHeaderOptionControl
 				categoryId={1}
@@ -50,12 +50,12 @@ describe("ExRHeaderOptionControl", () => {
 		const slider = screen.getByRole("slider");
 		fireEvent.change(slider, { target: { value: "1" } });
 
-		// Check if store was updated
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1);
+		await vi.waitFor(() => {
+			expect(useStore.getState().effectiveSelections["1-50"]).toBe(1);
+		});
 	});
 
-	it("updates selection when input is changed", () => {
+	it("updates selection when input is changed", async () => {
 		render(
 			<ExRHeaderOptionControl
 				categoryId={1}
@@ -74,8 +74,9 @@ describe("ExRHeaderOptionControl", () => {
 
 		fireEvent.change(textInput, { target: { value: "100" } });
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(2); // 100 is at index 2
+		await vi.waitFor(() => {
+			expect(useStore.getState().effectiveSelections["1-50"]).toBe(2);
+		});
 	});
 
 	it("prevents click propagation to parent", () => {

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
 import type { ExROptionDto } from "../src/type";
 import { useStore } from "../src/useStore";
@@ -60,9 +60,9 @@ describe("ExRRoleSpawnControls", () => {
 		expect(slider.max).toBe("3");
 	});
 
-	it("syncs rate to 0 when count is set to 0", () => {
+	it("syncs rate to 0 when count is set to 0", async () => {
 		// Set initial rate to 10%
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
+		await useStore.getState().updateExROptionSelection("1-50", 1);
 
 		render(
 			<ExRRoleSpawnControls
@@ -79,11 +79,12 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "0" } });
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(0); // Rate 0%
+		await vi.waitFor(() => {
+			expect(useStore.getState().effectiveSelections["1-50"]).toBe(0);
+		});
 	});
 
-	it("syncs rate to 10% when count is set to non-zero from zero rate", () => {
+	it("syncs rate to 10% when count is set to non-zero from zero rate", async () => {
 		render(
 			<ExRRoleSpawnControls
 				categoryId={1}
@@ -99,14 +100,15 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "1" } }); // Select '1'
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1); // Rate index 1 is 10%
+		await vi.waitFor(() => {
+			expect(useStore.getState().effectiveSelections["1-50"]).toBe(1);
+		});
 	});
 
-	it("syncs count to 0 when rate is set to 0%", () => {
+	it("syncs count to 0 when rate is set to 0%", async () => {
 		// Set initial rate to 10% and count to 2
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
-		useStore.getState().TEMP_updateExROptionSelection("1-51", 1); // backend index 1 is value 2
+		await useStore.getState().updateExROptionSelection("1-50", 1);
+		await useStore.getState().updateExROptionSelection("1-51", 1); // backend index 1 is value 2
 
 		render(
 			<ExRRoleSpawnControls
@@ -123,8 +125,9 @@ describe("ExRRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "0" } });
 
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-51"]).toBe(0); // Count reset to index 0
+		await vi.waitFor(() => {
+			expect(useStore.getState().effectiveSelections["1-51"]).toBe(0);
+		});
 
 		// UI should show 0
 		const countDisplay = screen


### PR DESCRIPTION
The temporary function `TEMP_updateExROptionSelection` has been replaced with a permanent `updateExROptionSelection` that calls the backend API's PUT `/exr/option/` endpoint. 

Key changes:
1.  **API Implementation**: Added `putExrOption` in `src/logics/api.ts` to handle the PUT request and update the local category cache.
2.  **State Management**: Updated `src/slices/optionViewerSlice.ts` to make the selection update function asynchronous. It now waits for the API response and updates `effectiveSelections` by traversing the returned `UpdatedOptions` tree.
3.  **Renaming**: Systematically renamed `TEMP_updateExROptionSelection` to `updateExROptionSelection` across the codebase.
4.  **Test Stability**:
    -   Updated `tests/ExRRoleSpawnControls.test.tsx`, `tests/ExRHeaderOptionControl.test.tsx`, and `tests/ExRCategoryList.test.tsx` to correctly handle asynchronous state updates.
    -   Enhanced `mocks/handlers.ts` to dynamically generate responses based on request parameters, ensuring that test-specific IDs are preserved in the UI state after API calls.
5.  **Cleanliness**: Removed optimistic update logic as per user feedback, ensuring the UI reflects the authoritative state from the backend.

All 110 existing tests are passing.

---
*PR created automatically by Jules for task [18117635926347449497](https://jules.google.com/task/18117635926347449497) started by @yukieiji*