### PR TITLE
effectiveSelectionsの削除と楽観的更新の廃止

### DIFF
--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -1,7 +1,6 @@
 import { CompactSlider } from "../components/parts/CompactSlider";
-import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
+import { findClosestIndex } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
-import { useStore } from "../useStore";
 
 interface ExRHeaderOptionControlProps {
 	categoryId: number;
@@ -14,27 +13,18 @@ interface ExRHeaderOptionControlProps {
  * (ストア接続済みラッパー)
  */
 export function ExRHeaderOptionControl({
-	categoryId,
 	option,
 	label,
 }: ExRHeaderOptionControlProps) {
-	const uniqueId = getUniqueOptionId(categoryId, option.Id);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
-	});
-	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
-	});
-
+	const currentSelection = option.Selection;
 	const values = option.RangeMeta.Values as number[];
 
-	const handleSelectionChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+	const handleSelectionChange = (_newSelection: number) => {
+		// PUTリクエストはまだ実装しない
 	};
 
 	const handleInputChange = (val: number) => {
-		TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+		handleSelectionChange(findClosestIndex(values, val));
 	};
 
 	return (

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -13,6 +13,7 @@ interface ExRHeaderOptionControlProps {
  * (ストア接続済みラッパー)
  */
 export function ExRHeaderOptionControl({
+	categoryId,
 	option,
 	label,
 }: ExRHeaderOptionControlProps) {

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -11,9 +11,7 @@ interface ExROptionControlProps {
 /**
  * オプションの種類に応じた操作用コンポーネントをレンダリングする
  */
-export function ExROptionControl({
-	option,
-}: ExROptionControlProps) {
+export function ExROptionControl({ option }: ExROptionControlProps) {
 	const currentSelection = option.Selection;
 
 	const handleChange = (_newSelection: number) => {

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -1,9 +1,7 @@
 import { OptionToggleControl } from "../components/blocks/OptionToggleControl";
 import { OptionDropdownControl } from "../components/parts/OptionDropdownControl";
 import { OptionSliderControl } from "../components/parts/OptionSliderControl";
-import { getUniqueOptionId } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
-import { useStore } from "../useStore";
 
 interface ExROptionControlProps {
 	categoryId: number;
@@ -14,20 +12,12 @@ interface ExROptionControlProps {
  * オプションの種類に応じた操作用コンポーネントをレンダリングする
  */
 export function ExROptionControl({
-	categoryId,
 	option,
 }: ExROptionControlProps) {
-	const uniqueId = getUniqueOptionId(categoryId, option.Id);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
-	});
-	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
-	});
+	const currentSelection = option.Selection;
 
-	const handleChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+	const handleChange = (_newSelection: number) => {
+		// PUTリクエストはまだ実装しないため、ここでは何もしない
 	};
 
 	const { Type, Values } = option.RangeMeta;

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -11,7 +11,10 @@ interface ExROptionControlProps {
 /**
  * オプションの種類に応じた操作用コンポーネントをレンダリングする
  */
-export function ExROptionControl({ option }: ExROptionControlProps) {
+export function ExROptionControl({
+	categoryId,
+	option,
+}: ExROptionControlProps) {
 	const currentSelection = option.Selection;
 
 	const handleChange = (_newSelection: number) => {

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -2,9 +2,7 @@ import { OptionPairedSliderControl } from "../components/blocks/OptionPairedSlid
 import { OptionItem } from "../components/parts/OptionItem";
 import { OptionNameDisplay } from "../components/parts/OptionNameDisplay";
 import { OptionRowContainer } from "../components/parts/OptionRowContainer";
-import { getUniqueOptionId } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
-import { useStore } from "../useStore";
 
 interface ExRPairedOptionRowProps {
 	categoryId: number;
@@ -19,36 +17,21 @@ interface ExRPairedOptionRowProps {
  * 最小・最大ペアのオプションを1行で表示するコンポーネント
  */
 export function ExRPairedOptionRow({
-	categoryId,
 	baseName,
 	min,
 	max,
 	minLabel,
 	maxLabel,
 }: ExRPairedOptionRowProps) {
-	const minUniqueId = getUniqueOptionId(categoryId, min.Id);
-	const maxUniqueId = getUniqueOptionId(categoryId, max.Id);
+	const minSelection = min.Selection;
+	const maxSelection = max.Selection;
 
-	const effectiveMinSelection = useStore((state) => {
-		return state.effectiveSelections[minUniqueId];
-	});
-	const effectiveMaxSelection = useStore((state) => {
-		return state.effectiveSelections[maxUniqueId];
-	});
-
-	const minSelection = effectiveMinSelection ?? min.Selection;
-	const maxSelection = effectiveMaxSelection ?? max.Selection;
-
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
-	});
-
-	const handleMinChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(minUniqueId, newSelection);
+	const handleMinChange = (_newSelection: number) => {
+		// PUTリクエストはまだ実装しない
 	};
 
-	const handleMaxChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(maxUniqueId, newSelection);
+	const handleMaxChange = (_newSelection: number) => {
+		// PUTリクエストはまだ実装しない
 	};
 
 	const content = (

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -17,6 +17,7 @@ interface ExRPairedOptionRowProps {
  * 最小・最大ペアのオプションを1行で表示するコンポーネント
  */
 export function ExRPairedOptionRow({
+	categoryId,
 	baseName,
 	min,
 	max,

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,7 +1,7 @@
 import { use } from "react";
 import { ColoredText } from "../components/parts/ColoredText";
 import { getExrCategoryOptions } from "../logics/api";
-import { getUniqueOptionId, isPresetOption } from "../logics/optionUtils";
+import { isPresetOption } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
@@ -30,12 +30,7 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 		return opt.Id === 51;
 	});
 
-	const uniqueRateId = getUniqueOptionId(categoryId, 50);
-	const effectiveSpawnRateSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueRateId];
-	});
-	const spawnRateSelection =
-		effectiveSpawnRateSelection ?? spawnRateOption?.Selection ?? 0;
+	const spawnRateSelection = spawnRateOption?.Selection ?? 0;
 	const rateValues = (spawnRateOption?.RangeMeta.Values as number[]) ?? [];
 	const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
 

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -1,7 +1,6 @@
 import { CompactSlider } from "../components/parts/CompactSlider";
-import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
+import { findClosestIndex } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
-import { useStore } from "../useStore";
 
 interface ExRRoleSpawnControlsProps {
 	categoryId: number;
@@ -13,35 +12,11 @@ interface ExRRoleSpawnControlsProps {
  * 役職のスポーンレートとスポーン数をセットで管理し、同期させるためのコンポーネント
  */
 export function ExRRoleSpawnControls({
-	categoryId,
 	spawnRateOption,
 	spawnCountOption,
 }: ExRRoleSpawnControlsProps) {
-	const uniqueRateId = getUniqueOptionId(categoryId, 50);
-	const uniqueCountId = getUniqueOptionId(categoryId, 51);
-
-	const effectiveSpawnRateSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueRateId];
-	});
-
-	const effectiveSpawnCountSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueCountId];
-	});
-
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
-	});
-	const toggleExRCategory = useStore((state) => {
-		return state.toggleExRCategory;
-	});
-	const isOpenedCategory = useStore((state) => {
-		return state.openedExRCategoryIds[categoryId] ?? false;
-	});
-
-	const spawnRateSelection =
-		effectiveSpawnRateSelection ?? spawnRateOption.Selection;
-	const spawnCountSelection =
-		effectiveSpawnCountSelection ?? spawnCountOption.Selection;
+	const spawnRateSelection = spawnRateOption.Selection;
+	const spawnCountSelection = spawnCountOption.Selection;
 
 	const rateValues = spawnRateOption.RangeMeta.Values as number[];
 	const originalCountValues = spawnCountOption.RangeMeta.Values as number[];
@@ -53,43 +28,16 @@ export function ExRRoleSpawnControls({
 	const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
-	const handleRateChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueRateId, newSelection);
-
-		// スポーンレートが0%なら、スポーン数も0としてリセット
-		if (rateValues[newSelection] === 0) {
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
-			if (isOpenedCategory) {
-				toggleExRCategory(categoryId);
-			}
-		}
+	const handleRateChange = (_newSelection: number) => {
+		// PUTリクエストはまだ実装しない
 	};
 
 	const handleRateInputChange = (val: number) => {
 		handleRateChange(findClosestIndex(rateValues, val));
 	};
 
-	const handleCountUIChange = (newUISelection: number) => {
-		if (newUISelection === 0) {
-			// 数を0にすると、レートも0%にする
-			TEMP_updateExROptionSelection(
-				uniqueRateId,
-				findClosestIndex(rateValues, 0),
-			);
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
-			if (isOpenedCategory) {
-				toggleExRCategory(categoryId);
-			}
-		} else {
-			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
-			if (isSpawnRateZero) {
-				TEMP_updateExROptionSelection(
-					uniqueRateId,
-					findClosestIndex(rateValues, 10),
-				);
-			}
-			TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
-		}
+	const handleCountUIChange = (_newUISelection: number) => {
+		// PUTリクエストはまだ実装しない
 	};
 
 	const handleCountUIInputChange = (val: number) => {

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -12,6 +12,7 @@ interface ExRRoleSpawnControlsProps {
  * 役職のスポーンレートとスポーン数をセットで管理し、同期させるためのコンポーネント
  */
 export function ExRRoleSpawnControls({
+	categoryId,
 	spawnRateOption,
 	spawnCountOption,
 }: ExRRoleSpawnControlsProps) {

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -1,6 +1,5 @@
 import { use, useEffect, useRef } from "react";
 import { getExrOptions } from "../logics/api";
-import { getUniqueOptionId } from "../logics/optionUtils";
 import { useStore } from "../useStore";
 
 /**
@@ -25,11 +24,7 @@ export function PresetSelector() {
 		return o.Id === 0;
 	});
 
-	const uniqueId = getUniqueOptionId(0, 0);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
-	});
-	const currentSelection = effectiveSelection ?? presetOption?.Selection ?? 0;
+	const currentSelection = presetOption?.Selection ?? 0;
 
 	const presetNames = useStore((state) => {
 		return state.presetNames;
@@ -39,9 +34,6 @@ export function PresetSelector() {
 	});
 	const updatePresetName = useStore((state) => {
 		return state.updatePresetName;
-	});
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
 	});
 	const setPresetDropdownOpen = useStore((state) => {
 		return state.setPresetDropdownOpen;
@@ -75,8 +67,8 @@ export function PresetSelector() {
 	const currentPresetName =
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
-	const handlePresetSelect = (index: number) => {
-		TEMP_updateExROptionSelection(uniqueId, index);
+	const handlePresetSelect = (_index: number) => {
+		// PUTリクエストはまだ実装しない
 		setPresetDropdownOpen(false);
 	};
 

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -13,17 +13,12 @@ export interface OptionViewerSlice {
 	isTabPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<string, boolean>;
-	effectiveSelections: Record<string, number>;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
 	setSelectedExRTabId: (id: OptionTab) => void;
 	setIsTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: string) => void;
-	TEMP_updateExROptionSelection: (
-		uniqueOptionId: string,
-		selection: number,
-	) => void;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
 	resetViewer: () => void;
@@ -40,7 +35,6 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 		isTabPending: false,
 		openedExRCategoryIds: {},
 		openedExROptionIds: {},
-		effectiveSelections: {},
 		presetNames: loadPresetNamesFromCookie(),
 		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: OptionTab) => {
@@ -55,7 +49,6 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				isTabPending: false,
 				openedExRCategoryIds: {},
 				openedExROptionIds: {},
-				effectiveSelections: {},
 				isPresetDropdownOpen: false,
 			});
 		},
@@ -75,19 +68,6 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 					openedExROptionIds: {
 						...state.openedExROptionIds,
 						[uniqueOptionId]: !state.openedExROptionIds[uniqueOptionId],
-					},
-				};
-			});
-		},
-		TEMP_updateExROptionSelection: (
-			uniqueOptionId: string,
-			selection: number,
-		) => {
-			set((state) => {
-				return {
-					effectiveSelections: {
-						...state.effectiveSelections,
-						[uniqueOptionId]: selection,
 					},
 				};
 			});

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -43,7 +43,7 @@ describe("ExRCategoryList Component Selection", { timeout: 15000 }, () => {
 							Id: 50,
 							IsActive: true,
 							TranslatedName: "Spawn Rate",
-							Selection: 0,
+							Selection: 1, // 100%
 							Format: "{0}",
 							RangeMeta: { Type: "Int32", Values: [0, 100] },
 							Childs: [],
@@ -117,7 +117,6 @@ describe("ExRCategoryList Component Selection", { timeout: 15000 }, () => {
 	it("filters out 50 and 51 from role category body", async () => {
 		await act(async () => {
 			useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
-			useStore.getState().TEMP_updateExROptionSelection("2-50", 1);
 		});
 
 		await act(async () => {

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
 import type { ExROptionDto } from "../src/type";
@@ -38,46 +38,6 @@ describe("ExRHeaderOptionControl", () => {
 		expect(textInput).toBeInTheDocument();
 	});
 
-	it("updates selection when slider is moved", () => {
-		render(
-			<ExRHeaderOptionControl
-				categoryId={1}
-				option={mockOption}
-				label="Rate"
-			/>,
-		);
-
-		const slider = screen.getByRole("slider");
-		fireEvent.change(slider, { target: { value: "1" } });
-
-		// Check if store was updated
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1);
-	});
-
-	it("updates selection when input is changed", () => {
-		render(
-			<ExRHeaderOptionControl
-				categoryId={1}
-				option={mockOption}
-				label="Rate"
-			/>,
-		);
-
-		const inputs = screen.getAllByDisplayValue("0");
-		const textInput = inputs.find(
-			(i) => (i as HTMLInputElement).type === "text",
-		);
-		if (!textInput) {
-			throw new Error("Text input not found");
-		}
-
-		fireEvent.change(textInput, { target: { value: "100" } });
-
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(2); // 100 is at index 2
-	});
-
 	it("prevents click propagation to parent", () => {
 		const parentClick = vi.fn();
 		render(
@@ -96,8 +56,16 @@ describe("ExRHeaderOptionControl", () => {
 		);
 
 		const label = screen.getByText("Rate");
-		fireEvent.click(label);
+		fireEventClick(label);
 
 		expect(parentClick).not.toHaveBeenCalled();
 	});
+
+	function fireEventClick(element: HTMLElement) {
+		const event = new MouseEvent("click", {
+			bubbles: true,
+			cancelable: true,
+		});
+		element.dispatchEvent(event);
+	}
 });

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
 import type { ExROptionDto } from "../src/type";
@@ -56,16 +56,8 @@ describe("ExRHeaderOptionControl", () => {
 		);
 
 		const label = screen.getByText("Rate");
-		fireEventClick(label);
+		fireEvent.click(label);
 
 		expect(parentClick).not.toHaveBeenCalled();
 	});
-
-	function fireEventClick(element: HTMLElement) {
-		const event = new MouseEvent("click", {
-			bubbles: true,
-			cancelable: true,
-		});
-		element.dispatchEvent(event);
-	}
 });

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
 import type { ExROptionDto } from "../src/type";
@@ -58,78 +58,5 @@ describe("ExRRoleSpawnControls", () => {
 
 		// Max should be 3 (virtual values: [0, 1, 2, 3] from backend [1, 2, 3])
 		expect(slider.max).toBe("3");
-	});
-
-	it("syncs rate to 0 when count is set to 0", () => {
-		// Set initial rate to 10%
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
-
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
-
-		const countControl = screen.getByTestId("spawn-count-control");
-		const slider = countControl.querySelector(
-			'input[type="range"]',
-		) as HTMLInputElement;
-
-		fireEvent.change(slider, { target: { value: "0" } });
-
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(0); // Rate 0%
-	});
-
-	it("syncs rate to 10% when count is set to non-zero from zero rate", () => {
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
-
-		const countControl = screen.getByTestId("spawn-count-control");
-		const slider = countControl.querySelector(
-			'input[type="range"]',
-		) as HTMLInputElement;
-
-		fireEvent.change(slider, { target: { value: "1" } }); // Select '1'
-
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1); // Rate index 1 is 10%
-	});
-
-	it("syncs count to 0 when rate is set to 0%", () => {
-		// Set initial rate to 10% and count to 2
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
-		useStore.getState().TEMP_updateExROptionSelection("1-51", 1); // backend index 1 is value 2
-
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
-
-		const rateControl = screen.getByTestId("spawn-rate-control");
-		const slider = rateControl.querySelector(
-			'input[type="range"]',
-		) as HTMLInputElement;
-
-		fireEvent.change(slider, { target: { value: "0" } });
-
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-51"]).toBe(0); // Count reset to index 0
-
-		// UI should show 0
-		const countDisplay = screen
-			.getByTestId("spawn-count-control")
-			.querySelector('input[type="text"]');
-		expect(countDisplay).toHaveValue("0");
 	});
 });


### PR DESCRIPTION
effectiveSelectionsを削除し、楽観的更新を行わないように変更しました。オプションの選択状態は常にサーバーから提供されるDTOのSelection値を参照するようになり、現在PUTリクエストが未実装のため、ユーザーによる変更操作は反映されない挙動（楽観的更新を行わない）となります。これに伴い、関連するテストコードの修正も行いました。

---
*PR created automatically by Jules for task [3850968428503760132](https://jules.google.com/task/3850968428503760132) started by @yukieiji*