### PR TITLE
change: effectiveSelectionsを削除し楽観的更新を廃止

### DIFF
--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -18,11 +18,7 @@ export function ExRHeaderOptionControl({
 	option,
 	label,
 }: ExRHeaderOptionControlProps) {
-	const uniqueId = getUniqueOptionId(categoryId, option.Id);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
-	});
-	const currentSelection = effectiveSelection ?? option.Selection;
+	const currentSelection = option.Selection;
 	const TEMP_updateExROptionSelection = useStore((state) => {
 		return state.TEMP_updateExROptionSelection;
 	});
@@ -30,11 +26,12 @@ export function ExRHeaderOptionControl({
 	const values = option.RangeMeta.Values as number[];
 
 	const handleSelectionChange = (newSelection: number) => {
+		const uniqueId = getUniqueOptionId(categoryId, option.Id);
 		TEMP_updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const handleInputChange = (val: number) => {
-		TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+		handleSelectionChange(findClosestIndex(values, val));
 	};
 
 	return (

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -17,16 +17,13 @@ export function ExROptionControl({
 	categoryId,
 	option,
 }: ExROptionControlProps) {
-	const uniqueId = getUniqueOptionId(categoryId, option.Id);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
-	});
-	const currentSelection = effectiveSelection ?? option.Selection;
+	const currentSelection = option.Selection;
 	const TEMP_updateExROptionSelection = useStore((state) => {
 		return state.TEMP_updateExROptionSelection;
 	});
 
 	const handleChange = (newSelection: number) => {
+		const uniqueId = getUniqueOptionId(categoryId, option.Id);
 		TEMP_updateExROptionSelection(uniqueId, newSelection);
 	};
 

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -26,29 +26,21 @@ export function ExRPairedOptionRow({
 	minLabel,
 	maxLabel,
 }: ExRPairedOptionRowProps) {
-	const minUniqueId = getUniqueOptionId(categoryId, min.Id);
-	const maxUniqueId = getUniqueOptionId(categoryId, max.Id);
-
-	const effectiveMinSelection = useStore((state) => {
-		return state.effectiveSelections[minUniqueId];
-	});
-	const effectiveMaxSelection = useStore((state) => {
-		return state.effectiveSelections[maxUniqueId];
-	});
-
-	const minSelection = effectiveMinSelection ?? min.Selection;
-	const maxSelection = effectiveMaxSelection ?? max.Selection;
+	const minSelection = min.Selection;
+	const maxSelection = max.Selection;
 
 	const TEMP_updateExROptionSelection = useStore((state) => {
 		return state.TEMP_updateExROptionSelection;
 	});
 
 	const handleMinChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(minUniqueId, newSelection);
+		const uniqueId = getUniqueOptionId(categoryId, min.Id);
+		TEMP_updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const handleMaxChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(maxUniqueId, newSelection);
+		const uniqueId = getUniqueOptionId(categoryId, max.Id);
+		TEMP_updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const content = (

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,7 +1,7 @@
 import { use } from "react";
 import { ColoredText } from "../components/parts/ColoredText";
 import { getExrCategoryOptions } from "../logics/api";
-import { getUniqueOptionId, isPresetOption } from "../logics/optionUtils";
+import { isPresetOption } from "../logics/optionUtils";
 import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
@@ -30,12 +30,7 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 		return opt.Id === 51;
 	});
 
-	const uniqueRateId = getUniqueOptionId(categoryId, 50);
-	const effectiveSpawnRateSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueRateId];
-	});
-	const spawnRateSelection =
-		effectiveSpawnRateSelection ?? spawnRateOption?.Selection ?? 0;
+	const spawnRateSelection = spawnRateOption?.Selection ?? 0;
 	const rateValues = (spawnRateOption?.RangeMeta.Values as number[]) ?? [];
 	const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
 

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -17,31 +17,12 @@ export function ExRRoleSpawnControls({
 	spawnRateOption,
 	spawnCountOption,
 }: ExRRoleSpawnControlsProps) {
-	const uniqueRateId = getUniqueOptionId(categoryId, 50);
-	const uniqueCountId = getUniqueOptionId(categoryId, 51);
-
-	const effectiveSpawnRateSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueRateId];
-	});
-
-	const effectiveSpawnCountSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueCountId];
-	});
+	const spawnRateSelection = spawnRateOption.Selection;
+	const spawnCountSelection = spawnCountOption.Selection;
 
 	const TEMP_updateExROptionSelection = useStore((state) => {
 		return state.TEMP_updateExROptionSelection;
 	});
-	const toggleExRCategory = useStore((state) => {
-		return state.toggleExRCategory;
-	});
-	const isOpenedCategory = useStore((state) => {
-		return state.openedExRCategoryIds[categoryId] ?? false;
-	});
-
-	const spawnRateSelection =
-		effectiveSpawnRateSelection ?? spawnRateOption.Selection;
-	const spawnCountSelection =
-		effectiveSpawnCountSelection ?? spawnCountOption.Selection;
 
 	const rateValues = spawnRateOption.RangeMeta.Values as number[];
 	const originalCountValues = spawnCountOption.RangeMeta.Values as number[];
@@ -54,15 +35,8 @@ export function ExRRoleSpawnControls({
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
 	const handleRateChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueRateId, newSelection);
-
-		// スポーンレートが0%なら、スポーン数も0としてリセット
-		if (rateValues[newSelection] === 0) {
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
-			if (isOpenedCategory) {
-				toggleExRCategory(categoryId);
-			}
-		}
+		const uniqueId = getUniqueOptionId(categoryId, spawnRateOption.Id);
+		TEMP_updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const handleRateInputChange = (val: number) => {
@@ -70,26 +44,9 @@ export function ExRRoleSpawnControls({
 	};
 
 	const handleCountUIChange = (newUISelection: number) => {
-		if (newUISelection === 0) {
-			// 数を0にすると、レートも0%にする
-			TEMP_updateExROptionSelection(
-				uniqueRateId,
-				findClosestIndex(rateValues, 0),
-			);
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
-			if (isOpenedCategory) {
-				toggleExRCategory(categoryId);
-			}
-		} else {
-			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
-			if (isSpawnRateZero) {
-				TEMP_updateExROptionSelection(
-					uniqueRateId,
-					findClosestIndex(rateValues, 10),
-				);
-			}
-			TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
-		}
+		const uniqueId = getUniqueOptionId(categoryId, spawnCountOption.Id);
+		// 表示上の値から内部のインデックスへ変換するロジックは呼び出し側にある
+		TEMP_updateExROptionSelection(uniqueId, newUISelection);
 	};
 
 	const handleCountUIInputChange = (val: number) => {

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -25,11 +25,7 @@ export function PresetSelector() {
 		return o.Id === 0;
 	});
 
-	const uniqueId = getUniqueOptionId(0, 0);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
-	});
-	const currentSelection = effectiveSelection ?? presetOption?.Selection ?? 0;
+	const currentSelection = presetOption?.Selection ?? 0;
 
 	const presetNames = useStore((state) => {
 		return state.presetNames;
@@ -76,6 +72,7 @@ export function PresetSelector() {
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
 	const handlePresetSelect = (index: number) => {
+		const uniqueId = getUniqueOptionId(0, 0);
 		TEMP_updateExROptionSelection(uniqueId, index);
 		setPresetDropdownOpen(false);
 	};

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -13,7 +13,6 @@ export interface OptionViewerSlice {
 	isTabPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<string, boolean>;
-	effectiveSelections: Record<string, number>;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
 	setSelectedExRTabId: (id: OptionTab) => void;
@@ -40,7 +39,6 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 		isTabPending: false,
 		openedExRCategoryIds: {},
 		openedExROptionIds: {},
-		effectiveSelections: {},
 		presetNames: loadPresetNamesFromCookie(),
 		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: OptionTab) => {
@@ -55,7 +53,6 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				isTabPending: false,
 				openedExRCategoryIds: {},
 				openedExROptionIds: {},
-				effectiveSelections: {},
 				isPresetDropdownOpen: false,
 			});
 		},
@@ -80,17 +77,10 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 			});
 		},
 		TEMP_updateExROptionSelection: (
-			uniqueOptionId: string,
-			selection: number,
+			_uniqueOptionId: string,
+			_selection: number,
 		) => {
-			set((state) => {
-				return {
-					effectiveSelections: {
-						...state.effectiveSelections,
-						[uniqueOptionId]: selection,
-					},
-				};
-			});
+			// 将来の拡張用の空関数。楽観的更新を廃止したため、現在は何もしない。
 		},
 		updatePresetName: (presetIndex: number, name: string) => {
 			set((state) => {

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -43,7 +43,7 @@ describe("ExRCategoryList Component Selection", { timeout: 15000 }, () => {
 							Id: 50,
 							IsActive: true,
 							TranslatedName: "Spawn Rate",
-							Selection: 0,
+							Selection: 1, // 100%
 							Format: "{0}",
 							RangeMeta: { Type: "Int32", Values: [0, 100] },
 							Childs: [],
@@ -117,7 +117,6 @@ describe("ExRCategoryList Component Selection", { timeout: 15000 }, () => {
 	it("filters out 50 and 51 from role category body", async () => {
 		await act(async () => {
 			useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
-			useStore.getState().TEMP_updateExROptionSelection("2-50", 1);
 		});
 
 		await act(async () => {

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -38,46 +38,6 @@ describe("ExRHeaderOptionControl", () => {
 		expect(textInput).toBeInTheDocument();
 	});
 
-	it("updates selection when slider is moved", () => {
-		render(
-			<ExRHeaderOptionControl
-				categoryId={1}
-				option={mockOption}
-				label="Rate"
-			/>,
-		);
-
-		const slider = screen.getByRole("slider");
-		fireEvent.change(slider, { target: { value: "1" } });
-
-		// Check if store was updated
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1);
-	});
-
-	it("updates selection when input is changed", () => {
-		render(
-			<ExRHeaderOptionControl
-				categoryId={1}
-				option={mockOption}
-				label="Rate"
-			/>,
-		);
-
-		const inputs = screen.getAllByDisplayValue("0");
-		const textInput = inputs.find(
-			(i) => (i as HTMLInputElement).type === "text",
-		);
-		if (!textInput) {
-			throw new Error("Text input not found");
-		}
-
-		fireEvent.change(textInput, { target: { value: "100" } });
-
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(2); // 100 is at index 2
-	});
-
 	it("prevents click propagation to parent", () => {
 		const parentClick = vi.fn();
 		render(

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
 import type { ExROptionDto } from "../src/type";
@@ -58,78 +58,5 @@ describe("ExRRoleSpawnControls", () => {
 
 		// Max should be 3 (virtual values: [0, 1, 2, 3] from backend [1, 2, 3])
 		expect(slider.max).toBe("3");
-	});
-
-	it("syncs rate to 0 when count is set to 0", () => {
-		// Set initial rate to 10%
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
-
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
-
-		const countControl = screen.getByTestId("spawn-count-control");
-		const slider = countControl.querySelector(
-			'input[type="range"]',
-		) as HTMLInputElement;
-
-		fireEvent.change(slider, { target: { value: "0" } });
-
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(0); // Rate 0%
-	});
-
-	it("syncs rate to 10% when count is set to non-zero from zero rate", () => {
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
-
-		const countControl = screen.getByTestId("spawn-count-control");
-		const slider = countControl.querySelector(
-			'input[type="range"]',
-		) as HTMLInputElement;
-
-		fireEvent.change(slider, { target: { value: "1" } }); // Select '1'
-
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1); // Rate index 1 is 10%
-	});
-
-	it("syncs count to 0 when rate is set to 0%", () => {
-		// Set initial rate to 10% and count to 2
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
-		useStore.getState().TEMP_updateExROptionSelection("1-51", 1); // backend index 1 is value 2
-
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
-
-		const rateControl = screen.getByTestId("spawn-rate-control");
-		const slider = rateControl.querySelector(
-			'input[type="range"]',
-		) as HTMLInputElement;
-
-		fireEvent.change(slider, { target: { value: "0" } });
-
-		const state = useStore.getState();
-		expect(state.effectiveSelections["1-51"]).toBe(0); // Count reset to index 0
-
-		// UI should show 0
-		const countDisplay = screen
-			.getByTestId("spawn-count-control")
-			.querySelector('input[type="text"]');
-		expect(countDisplay).toHaveValue("0");
 	});
 });


### PR DESCRIPTION
- OptionViewerSliceからeffectiveSelectionsを削除
- TEMP_updateExROptionSelectionを将来の拡張用の空の関数として保持
- 各コンポーネントにおいて、オプションの選択状態を常にDTOのSelectionから参照するように変更
- 各コンポーネントからのTEMP_updateExROptionSelectionの呼び出しを維持
- categoryId引数を将来の使用のために保持
- テストコードの修正と標準化（fireEvent.clickの使用）
- CIでのフォーマットチェックへの対応