### PR TITLE
Implement ExR option update API integration

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -74,22 +74,43 @@ export const handlers = [
       return new HttpResponse(null, { status: 400 });
     }
 
-    const { CategoryId, OptionId } = result.data;
+    const { TabId, CategoryId, OptionId, Selection } = result.data;
 
     // CategoryIdとOptionIdが0のときは202を返す（ボディなし）
     if (CategoryId === 0 && OptionId === 0) {
       return new HttpResponse(null, { status: 202 });
     }
 
+    // モックデータから該当のカテゴリとオプションを探す
+    const tab = validatedExRMockData.find(t => t.Id === TabId);
+    const category = tab?.Categories.find(c => c.Id === CategoryId);
+
+    if (!category) {
+      return new HttpResponse(null, { status: 404 });
+    }
+
+    // オプションの値を更新した新しいカテゴリデータを作成
+    const updateOptionInList = (options: any[]): any[] => {
+      return options.map(opt => {
+        if (opt.Id === OptionId) {
+          return { ...opt, Selection };
+        }
+        if (opt.Childs && opt.Childs.length > 0) {
+          return { ...opt, Childs: updateOptionInList(opt.Childs) };
+        }
+        return opt;
+      });
+    };
+
+    const updatedCategory = {
+      ...category,
+      Options: updateOptionInList(category.Options)
+    };
+
     // それ以外はUpdatedOptionsを返す
     const mockUpdatedOptions: UpdatedOptions = {
-      UpdatedCategory: validatedExRMockData[0].Categories[0],
-      ChainUpdatedOption: [
-        {
-          Id: validatedExRMockData[0].Categories[0].Id,
-          Options: [validatedExRMockData[0].Categories[0].Options[0]],
-        },
-      ],
+      UpdatedCategory: updatedCategory,
+      ChainUpdatedOption: [],
     };
 
     // レスポンスデータのバリデーション

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -13,6 +13,8 @@ export function ExRCategoryList() {
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
+	// データ更新時に再レンダリングを強制するため、exrVersionを監視する
+	useStore((state) => state.exrVersion);
 	const isTabPending = useStore((state) => {
 		return state.isTabPending;
 	});

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -19,15 +19,18 @@ export function ExRHeaderOptionControl({
 	label,
 }: ExRHeaderOptionControlProps) {
 	const currentSelection = option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
+	});
+	const isPending = useStore((state) => {
+		const uniqueId = getUniqueOptionId(categoryId, option.Id);
+		return !!state.pendingExROptionIds[uniqueId];
 	});
 
 	const values = option.RangeMeta.Values as number[];
 
 	const handleSelectionChange = (newSelection: number) => {
-		const uniqueId = getUniqueOptionId(categoryId, option.Id);
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(categoryId, option.Id, newSelection);
 	};
 
 	const handleInputChange = (val: number) => {
@@ -35,12 +38,14 @@ export function ExRHeaderOptionControl({
 	};
 
 	return (
-		<CompactSlider
-			label={label}
-			values={values}
-			currentSelection={currentSelection}
-			onSelectionChange={handleSelectionChange}
-			onInputChange={handleInputChange}
-		/>
+		<div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+			<CompactSlider
+				label={label}
+				values={values}
+				currentSelection={currentSelection}
+				onSelectionChange={handleSelectionChange}
+				onInputChange={handleInputChange}
+			/>
+		</div>
 	);
 }

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -38,7 +38,10 @@ export function ExRHeaderOptionControl({
 	};
 
 	return (
-		<div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+		<div
+			data-is-pending={isPending}
+			className={isPending ? "opacity-50 pointer-events-none" : ""}
+		>
 			<CompactSlider
 				label={label}
 				values={values}

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -42,7 +42,10 @@ export function ExROptionControl({
 
 		if (isToggleType) {
 			return (
-				<div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+				<div
+					data-is-pending={isPending}
+					className={isPending ? "opacity-50 pointer-events-none" : ""}
+				>
 					<OptionToggleControl
 						selection={currentSelection}
 						values={stringValues}
@@ -53,7 +56,10 @@ export function ExROptionControl({
 		}
 
 		return (
-			<div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+			<div
+				data-is-pending={isPending}
+				className={isPending ? "opacity-50 pointer-events-none" : ""}
+			>
 				<OptionDropdownControl
 					selection={currentSelection}
 					values={stringValues}
@@ -65,7 +71,10 @@ export function ExROptionControl({
 
 	if (Type === "Int32" || Type === "Single") {
 		return (
-			<div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+			<div
+				data-is-pending={isPending}
+				className={isPending ? "opacity-50 pointer-events-none" : ""}
+			>
 				<OptionSliderControl
 					selection={currentSelection}
 					values={Values as number[]}

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -18,13 +18,16 @@ export function ExROptionControl({
 	option,
 }: ExROptionControlProps) {
 	const currentSelection = option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
+	});
+	const isPending = useStore((state) => {
+		const uniqueId = getUniqueOptionId(categoryId, option.Id);
+		return !!state.pendingExROptionIds[uniqueId];
 	});
 
 	const handleChange = (newSelection: number) => {
-		const uniqueId = getUniqueOptionId(categoryId, option.Id);
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(categoryId, option.Id, newSelection);
 	};
 
 	const { Type, Values } = option.RangeMeta;
@@ -39,31 +42,37 @@ export function ExROptionControl({
 
 		if (isToggleType) {
 			return (
-				<OptionToggleControl
-					selection={currentSelection}
-					values={stringValues}
-					onChange={handleChange}
-				/>
+				<div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+					<OptionToggleControl
+						selection={currentSelection}
+						values={stringValues}
+						onChange={handleChange}
+					/>
+				</div>
 			);
 		}
 
 		return (
-			<OptionDropdownControl
-				selection={currentSelection}
-				values={stringValues}
-				onChange={handleChange}
-			/>
+			<div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+				<OptionDropdownControl
+					selection={currentSelection}
+					values={stringValues}
+					onChange={handleChange}
+				/>
+			</div>
 		);
 	}
 
 	if (Type === "Int32" || Type === "Single") {
 		return (
-			<OptionSliderControl
-				selection={currentSelection}
-				values={Values as number[]}
-				format={option.Format}
-				onChange={handleChange}
-			/>
+			<div className={isPending ? "opacity-50 pointer-events-none" : ""}>
+				<OptionSliderControl
+					selection={currentSelection}
+					values={Values as number[]}
+					format={option.Format}
+					onChange={handleChange}
+				/>
+			</div>
 		);
 	}
 

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -57,6 +57,7 @@ export function ExRPairedOptionRow({
 				</span>
 			</div>
 			<div
+				data-is-pending={isMinPending || isMaxPending}
 				className={`flex-shrink-0 flex items-center gap-2 ${isMinPending || isMaxPending ? "opacity-50 pointer-events-none" : ""}`}
 			>
 				<OptionPairedSliderControl

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -29,18 +29,24 @@ export function ExRPairedOptionRow({
 	const minSelection = min.Selection;
 	const maxSelection = max.Selection;
 
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
+	});
+	const isMinPending = useStore((state) => {
+		const uniqueId = getUniqueOptionId(categoryId, min.Id);
+		return !!state.pendingExROptionIds[uniqueId];
+	});
+	const isMaxPending = useStore((state) => {
+		const uniqueId = getUniqueOptionId(categoryId, max.Id);
+		return !!state.pendingExROptionIds[uniqueId];
 	});
 
 	const handleMinChange = (newSelection: number) => {
-		const uniqueId = getUniqueOptionId(categoryId, min.Id);
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(categoryId, min.Id, newSelection);
 	};
 
 	const handleMaxChange = (newSelection: number) => {
-		const uniqueId = getUniqueOptionId(categoryId, max.Id);
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(categoryId, max.Id, newSelection);
 	};
 
 	const content = (
@@ -50,7 +56,9 @@ export function ExRPairedOptionRow({
 					<OptionNameDisplay name={baseName} />
 				</span>
 			</div>
-			<div className="flex-shrink-0 flex items-center gap-2">
+			<div
+				className={`flex-shrink-0 flex items-center gap-2 ${isMinPending || isMaxPending ? "opacity-50 pointer-events-none" : ""}`}
+			>
 				<OptionPairedSliderControl
 					minSelection={minSelection}
 					maxSelection={maxSelection}

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -15,6 +15,8 @@ interface ExRRoleCategoryItemProps {
  * 役職タブで使用される、スポーン設定をヘッダーに持つカテゴリ表示コンポーネント
  */
 export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
+	// データ更新時に再レンダリングを強制するため、exrVersionを監視する
+	useStore((state) => state.exrVersion);
 	const category = use(getExrCategoryOptions(categoryId));
 	const isOpendCategory = useStore((state) => {
 		return state.openedExRCategoryIds[categoryId];

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -51,8 +51,15 @@ export function ExRRoleSpawnControls({
 	};
 
 	const handleCountUIChange = (newUISelection: number) => {
-		// 表示上の値から内部のインデックスへ変換するロジックは呼び出し側にある
-		updateExROptionSelection(categoryId, spawnCountOption.Id, newUISelection);
+		// UI上のインデックス（0=0, 1=1枚目...）を
+		// 内部のインデックス（0=1枚目...）に変換。0の場合は何もしない。
+		if (newUISelection > 0) {
+			updateExROptionSelection(
+				categoryId,
+				spawnCountOption.Id,
+				newUISelection - 1,
+			);
+		}
 	};
 
 	const handleCountUIInputChange = (val: number) => {

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -20,8 +20,16 @@ export function ExRRoleSpawnControls({
 	const spawnRateSelection = spawnRateOption.Selection;
 	const spawnCountSelection = spawnCountOption.Selection;
 
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
+	});
+	const isRatePending = useStore((state) => {
+		const uniqueId = getUniqueOptionId(categoryId, spawnRateOption.Id);
+		return !!state.pendingExROptionIds[uniqueId];
+	});
+	const isCountPending = useStore((state) => {
+		const uniqueId = getUniqueOptionId(categoryId, spawnCountOption.Id);
+		return !!state.pendingExROptionIds[uniqueId];
 	});
 
 	const rateValues = spawnRateOption.RangeMeta.Values as number[];
@@ -35,8 +43,7 @@ export function ExRRoleSpawnControls({
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
 	const handleRateChange = (newSelection: number) => {
-		const uniqueId = getUniqueOptionId(categoryId, spawnRateOption.Id);
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(categoryId, spawnRateOption.Id, newSelection);
 	};
 
 	const handleRateInputChange = (val: number) => {
@@ -44,9 +51,8 @@ export function ExRRoleSpawnControls({
 	};
 
 	const handleCountUIChange = (newUISelection: number) => {
-		const uniqueId = getUniqueOptionId(categoryId, spawnCountOption.Id);
 		// 表示上の値から内部のインデックスへ変換するロジックは呼び出し側にある
-		TEMP_updateExROptionSelection(uniqueId, newUISelection);
+		updateExROptionSelection(categoryId, spawnCountOption.Id, newUISelection);
 	};
 
 	const handleCountUIInputChange = (val: number) => {
@@ -54,7 +60,9 @@ export function ExRRoleSpawnControls({
 	};
 
 	return (
-		<div className="flex items-center gap-4">
+		<div
+			className={`flex items-center gap-4 ${isRatePending || isCountPending ? "opacity-50 pointer-events-none" : ""}`}
+		>
 			<CompactSlider
 				label="レート"
 				values={rateValues}

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -61,6 +61,7 @@ export function ExRRoleSpawnControls({
 
 	return (
 		<div
+			data-is-pending={isRatePending || isCountPending}
 			className={`flex items-center gap-4 ${isRatePending || isCountPending ? "opacity-50 pointer-events-none" : ""}`}
 		>
 			<CompactSlider

--- a/src/feature/ExRStandardCategoryItem.tsx
+++ b/src/feature/ExRStandardCategoryItem.tsx
@@ -17,6 +17,8 @@ interface ExRStandardCategoryItemProps {
 export function ExRStandardCategoryItem({
 	categoryId,
 }: ExRStandardCategoryItemProps) {
+	// データ更新時に再レンダリングを強制するため、exrVersionを監視する
+	useStore((state) => state.exrVersion);
 	const category = use(getExrCategoryOptions(categoryId));
 	const isOpen = useStore((state) => {
 		return state.openedExRCategoryIds[categoryId] ?? false;

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -36,11 +36,15 @@ export function PresetSelector() {
 	const updatePresetName = useStore((state) => {
 		return state.updatePresetName;
 	});
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 	const setPresetDropdownOpen = useStore((state) => {
 		return state.setPresetDropdownOpen;
+	});
+	const isPending = useStore((state) => {
+		const uniqueId = getUniqueOptionId(0, 0);
+		return !!state.pendingExROptionIds[uniqueId];
 	});
 
 	const dropdownRef = useRef<HTMLDivElement>(null);
@@ -72,8 +76,7 @@ export function PresetSelector() {
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
 	const handlePresetSelect = (index: number) => {
-		const uniqueId = getUniqueOptionId(0, 0);
-		TEMP_updateExROptionSelection(uniqueId, index);
+		updateExROptionSelection(0, 0, index);
 		setPresetDropdownOpen(false);
 	};
 
@@ -107,7 +110,10 @@ export function PresetSelector() {
 	};
 
 	return (
-		<div className="relative flex items-center gap-2" ref={dropdownRef}>
+		<div
+			className={`relative flex items-center gap-2 ${isPending ? "opacity-50 pointer-events-none" : ""}`}
+			ref={dropdownRef}
+		>
 			<div className="relative flex items-center bg-gray-800 border border-gray-700 rounded overflow-hidden focus-within:border-blue-500">
 				<input
 					ref={inputRef}

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -12,6 +12,8 @@ import { useStore } from "../useStore";
  * ユーザー入力ごとの Cookie 書き込みを避けるため、onBlur または Enter キー入力時に更新を行います。
  */
 export function PresetSelector() {
+	// データ更新時に再レンダリングを強制するため、exrVersionを監視する
+	useStore((state) => state.exrVersion);
 	const tabs = use(getExrOptions());
 
 	// GeneralTab (Id: 0) から プリセットカテゴリ (Id: 0) を探す
@@ -111,6 +113,7 @@ export function PresetSelector() {
 
 	return (
 		<div
+			data-is-pending={isPending}
 			className={`relative flex items-center gap-2 ${isPending ? "opacity-50 pointer-events-none" : ""}`}
 			ref={dropdownRef}
 		>

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -215,8 +215,16 @@ export async function updateExrOption(
 		throw new Error(`Failed to update ExR option: ${res.statusText}`);
 	}
 
-	const rawData = await res.json();
-	const data = UpdatedOptionsSchema.parse(rawData);
+	let data: UpdatedOptions;
+	if (res.status === 202) {
+		data = {
+			UpdatedCategory: null,
+			ChainUpdatedOption: [],
+		};
+	} else {
+		const rawData = await res.json();
+		data = UpdatedOptionsSchema.parse(rawData);
+	}
 
 	// キャッシュを更新する
 	if (exrAllTabsPromise) {

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -1,5 +1,15 @@
-import type { AuOptionCategoryDto, ExRCategoryDto, ExRTabDto } from "../type";
-import { AuOptionCategoryDtoArraySchema, ExRTabDtoArraySchema } from "../type";
+import type {
+	AuOptionCategoryDto,
+	ExRCategoryDto,
+	ExROptionPutRequest,
+	ExRTabDto,
+	UpdatedOptions,
+} from "../type";
+import {
+	AuOptionCategoryDtoArraySchema,
+	ExRTabDtoArraySchema,
+	UpdatedOptionsSchema,
+} from "../type";
 
 /**
  * API エンドポイントの定数定義
@@ -185,4 +195,70 @@ export function getAuCategoryOptions(
  */
 export function getAllOptions(): Promise<[ExRTabDto[], AuOptionCategoryDto[]]> {
 	return Promise.all([getExrOptions(), getAuOptions()]);
+}
+
+/**
+ * ExRオプションを更新する
+ */
+export async function updateExrOption(
+	request: ExROptionPutRequest,
+): Promise<UpdatedOptions> {
+	const res = await fetch(EXR_OPTION_URL, {
+		method: "PUT",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(request),
+	});
+
+	if (!res.ok) {
+		throw new Error(`Failed to update ExR option: ${res.statusText}`);
+	}
+
+	const rawData = await res.json();
+	const data = UpdatedOptionsSchema.parse(rawData);
+
+	// キャッシュを更新する
+	if (exrAllTabsPromise) {
+		const oldTabs = await exrAllTabsPromise;
+		const newTabs = oldTabs.map((tab) => {
+			const newCategories = tab.Categories.map((category) => {
+				// 直接更新されたカテゴリがある場合
+				if (data.UpdatedCategory && category.Id === data.UpdatedCategory.Id) {
+					return data.UpdatedCategory;
+				}
+
+				// 連鎖的に更新されたオプションがある場合
+				const chainUpdate = data.ChainUpdatedOption.find((c) => {
+					return c.Id === category.Id;
+				});
+				if (chainUpdate) {
+					return {
+						...category,
+						Options: chainUpdate.Options,
+					};
+				}
+
+				return category;
+			});
+
+			return {
+				...tab,
+				Categories: newCategories,
+			};
+		});
+
+		// 新しいPromiseでキャッシュを上書き
+		exrAllTabsPromise = Promise.resolve(newTabs);
+
+		// 個別のキャッシュも更新
+		for (const tab of newTabs) {
+			exrTabPromises.set(tab.Id, Promise.resolve(tab));
+			for (const category of tab.Categories) {
+				exrCategoryPromises.set(category.Id, Promise.resolve(category));
+			}
+		}
+	}
+
+	return data;
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -226,46 +226,49 @@ export async function updateExrOption(
 		data = UpdatedOptionsSchema.parse(rawData);
 	}
 
-	// キャッシュを更新する
+	// キャッシュを更新する。レースコンディションを防ぐため、既存のPromiseに連鎖させる
 	if (exrAllTabsPromise) {
-		const oldTabs = await exrAllTabsPromise;
-		const newTabs = oldTabs.map((tab) => {
-			const newCategories = tab.Categories.map((category) => {
-				// 直接更新されたカテゴリがある場合
-				if (data.UpdatedCategory && category.Id === data.UpdatedCategory.Id) {
-					return data.UpdatedCategory;
-				}
+		exrAllTabsPromise = exrAllTabsPromise.then((oldTabs) => {
+			const newTabs = oldTabs.map((tab) => {
+				const newCategories = tab.Categories.map((category) => {
+					// 直接更新されたカテゴリがある場合
+					if (data.UpdatedCategory && category.Id === data.UpdatedCategory.Id) {
+						return data.UpdatedCategory;
+					}
 
-				// 連鎖的に更新されたオプションがある場合
-				const chainUpdate = data.ChainUpdatedOption.find((c) => {
-					return c.Id === category.Id;
+					// 連鎖的に更新されたオプションがある場合
+					const chainUpdate = data.ChainUpdatedOption.find((c) => {
+						return c.Id === category.Id;
+					});
+					if (chainUpdate) {
+						return {
+							...category,
+							Options: chainUpdate.Options,
+						};
+					}
+
+					return category;
 				});
-				if (chainUpdate) {
-					return {
-						...category,
-						Options: chainUpdate.Options,
-					};
-				}
 
-				return category;
+				return {
+					...tab,
+					Categories: newCategories,
+				};
 			});
 
-			return {
-				...tab,
-				Categories: newCategories,
-			};
+			// 個別のキャッシュも更新
+			for (const tab of newTabs) {
+				exrTabPromises.set(tab.Id, Promise.resolve(tab));
+				for (const category of tab.Categories) {
+					exrCategoryPromises.set(category.Id, Promise.resolve(category));
+				}
+			}
+
+			return newTabs;
 		});
 
-		// 新しいPromiseでキャッシュを上書き
-		exrAllTabsPromise = Promise.resolve(newTabs);
-
-		// 個別のキャッシュも更新
-		for (const tab of newTabs) {
-			exrTabPromises.set(tab.Id, Promise.resolve(tab));
-			for (const category of tab.Categories) {
-				exrCategoryPromises.set(category.Id, Promise.resolve(category));
-			}
-		}
+		// キャッシュの更新が完了するまで待機
+		await exrAllTabsPromise;
 	}
 
 	return data;

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from "zustand";
+import { updateExrOption } from "../logics/api";
 import {
 	loadPresetNamesFromCookie,
 	savePresetNamesToCookie,
@@ -13,16 +14,18 @@ export interface OptionViewerSlice {
 	isTabPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<string, boolean>;
+	pendingExROptionIds: Record<string, boolean>;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
 	setSelectedExRTabId: (id: OptionTab) => void;
 	setIsTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: string) => void;
-	TEMP_updateExROptionSelection: (
-		uniqueOptionId: string,
+	updateExROptionSelection: (
+		categoryId: number,
+		optionId: number,
 		selection: number,
-	) => void;
+	) => Promise<void>;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
 	resetViewer: () => void;
@@ -33,12 +36,14 @@ export interface OptionViewerSlice {
  */
 export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 	set,
+	get,
 ) => {
 	return {
 		selectedExRTabId: 0,
 		isTabPending: false,
 		openedExRCategoryIds: {},
 		openedExROptionIds: {},
+		pendingExROptionIds: {},
 		presetNames: loadPresetNamesFromCookie(),
 		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: OptionTab) => {
@@ -76,11 +81,40 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				};
 			});
 		},
-		TEMP_updateExROptionSelection: (
-			_uniqueOptionId: string,
-			_selection: number,
+		updateExROptionSelection: async (
+			categoryId: number,
+			optionId: number,
+			selection: number,
 		) => {
-			// 将来の拡張用の空関数。楽観的更新を廃止したため、現在は何もしない。
+			const uniqueId = `${categoryId}-${optionId}`;
+			set((state) => {
+				return {
+					pendingExROptionIds: {
+						...state.pendingExROptionIds,
+						[uniqueId]: true,
+					},
+				};
+			});
+
+			try {
+				const tabId = get().selectedExRTabId;
+				await updateExrOption({
+					TabId: tabId,
+					CategoryId: categoryId,
+					OptionId: optionId,
+					Selection: selection,
+				});
+			} catch (error) {
+				console.error("Failed to update ExR option:", error);
+			} finally {
+				set((state) => {
+					const newPending = { ...state.pendingExROptionIds };
+					delete newPending[uniqueId];
+					return {
+						pendingExROptionIds: newPending,
+					};
+				});
+			}
 		},
 		updatePresetName: (presetIndex: number, name: string) => {
 			set((state) => {

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -4,6 +4,7 @@ import {
 	loadPresetNamesFromCookie,
 	savePresetNamesToCookie,
 } from "../logics/cookieUtils";
+import { getUniqueOptionId, isPresetOption } from "../logics/optionUtils";
 import type { OptionTab } from "../type";
 
 /**
@@ -88,7 +89,10 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 			optionId: number,
 			selection: number,
 		) => {
-			const uniqueId = `${categoryId}-${optionId}`;
+			const uniqueId = getUniqueOptionId(categoryId, optionId);
+			const isPreset = isPresetOption(categoryId, optionId);
+			const tabId = isPreset ? 0 : get().selectedExRTabId;
+
 			set((state) => {
 				return {
 					pendingExROptionIds: {
@@ -99,7 +103,6 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 			});
 
 			try {
-				const tabId = get().selectedExRTabId;
 				await updateExrOption({
 					TabId: tabId,
 					CategoryId: categoryId,

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -15,6 +15,7 @@ export interface OptionViewerSlice {
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<string, boolean>;
 	pendingExROptionIds: Record<string, boolean>;
+	exrVersion: number;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
 	setSelectedExRTabId: (id: OptionTab) => void;
@@ -44,6 +45,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 		openedExRCategoryIds: {},
 		openedExROptionIds: {},
 		pendingExROptionIds: {},
+		exrVersion: 0,
 		presetNames: loadPresetNamesFromCookie(),
 		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: OptionTab) => {
@@ -104,6 +106,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 					OptionId: optionId,
 					Selection: selection,
 				});
+				set((state) => ({ exrVersion: state.exrVersion + 1 }));
 			} catch (error) {
 				console.error("Failed to update ExR option:", error);
 			} finally {

--- a/tests/optionViewerSlice.test.ts
+++ b/tests/optionViewerSlice.test.ts
@@ -63,15 +63,16 @@ describe("optionViewerSlice", () => {
 		const { updateExROptionSelection } = useStore.getState();
 
 		const initialVersion = useStore.getState().exrVersion;
-		const updatePromise = updateExROptionSelection(1, 101, 1);
+		// モックデータに存在するIDを使用する (Tab 0, Category 0, Option 0)
+		const updatePromise = updateExROptionSelection(0, 0, 1);
 
 		// リクエスト中なので pending になっているはず
-		expect(useStore.getState().pendingExROptionIds["1-101"]).toBe(true);
+		expect(useStore.getState().pendingExROptionIds["0-0"]).toBe(true);
 
 		await updatePromise;
 
 		// 完了後は pending から削除されているはず
-		expect(useStore.getState().pendingExROptionIds["1-101"]).toBeUndefined();
+		expect(useStore.getState().pendingExROptionIds["0-0"]).toBeUndefined();
 		// exrVersion がインクリメントされているはず
 		expect(useStore.getState().exrVersion).toBe(initialVersion + 1);
 	});

--- a/tests/optionViewerSlice.test.ts
+++ b/tests/optionViewerSlice.test.ts
@@ -59,9 +59,10 @@ describe("optionViewerSlice", () => {
 		expect(useStore.getState().presetNames[1]).toBeUndefined();
 	});
 
-	it("should update pendingExROptionIds when calling updateExROptionSelection", async () => {
+	it("should update pendingExROptionIds and exrVersion when calling updateExROptionSelection", async () => {
 		const { updateExROptionSelection } = useStore.getState();
 
+		const initialVersion = useStore.getState().exrVersion;
 		const updatePromise = updateExROptionSelection(1, 101, 1);
 
 		// リクエスト中なので pending になっているはず
@@ -71,5 +72,7 @@ describe("optionViewerSlice", () => {
 
 		// 完了後は pending から削除されているはず
 		expect(useStore.getState().pendingExROptionIds["1-101"]).toBeUndefined();
+		// exrVersion がインクリメントされているはず
+		expect(useStore.getState().exrVersion).toBe(initialVersion + 1);
 	});
 });

--- a/tests/optionViewerSlice.test.ts
+++ b/tests/optionViewerSlice.test.ts
@@ -58,4 +58,18 @@ describe("optionViewerSlice", () => {
 		updatePresetName(1, "  ");
 		expect(useStore.getState().presetNames[1]).toBeUndefined();
 	});
+
+	it("should update pendingExROptionIds when calling updateExROptionSelection", async () => {
+		const { updateExROptionSelection } = useStore.getState();
+
+		const updatePromise = updateExROptionSelection(1, 101, 1);
+
+		// リクエスト中なので pending になっているはず
+		expect(useStore.getState().pendingExROptionIds["1-101"]).toBe(true);
+
+		await updatePromise;
+
+		// 完了後は pending から削除されているはず
+		expect(useStore.getState().pendingExROptionIds["1-101"]).toBeUndefined();
+	});
 });


### PR DESCRIPTION
This change implements the backend integration for updating ExR options.
Key changes:
1. `src/logics/api.ts`: Added `updateExrOption` function that performs a PUT request and updates the local promise-based cache with the returned `UpdatedOptions`.
2. `src/slices/optionViewerSlice.ts`: Renamed the update function and implemented it with pending state management.
3. UI Components: Updated `ExROptionControl`, `ExRPairedOptionRow`, `ExRRoleSpawnControls`, `ExRHeaderOptionControl`, and `PresetSelector` to use the new function and show a loading state (reduced opacity and disabled interaction) while the request is in progress.
4. Tests: Added a test case to `tests/optionViewerSlice.test.ts` to verify the pending state lifecycle.

---
*PR created automatically by Jules for task [8141860837625250967](https://jules.google.com/task/8141860837625250967) started by @yukieiji*