### PR TITLE
uniqueOptionIdを文字から数字へ変更

### DIFF
--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -18,7 +18,10 @@ export function ExRHeaderOptionControl({
 	option,
 	label,
 }: ExRHeaderOptionControlProps) {
-	const uniqueId = getUniqueOptionId(categoryId, option.Id);
+	const selectedExRTabId = useStore((state) => {
+		return state.selectedExRTabId;
+	});
+	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, option.Id);
 	const effectiveSelection = useStore((state) => {
 		return state.effectiveSelections[uniqueId];
 	});

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -17,7 +17,10 @@ export function ExROptionControl({
 	categoryId,
 	option,
 }: ExROptionControlProps) {
-	const uniqueId = getUniqueOptionId(categoryId, option.Id);
+	const selectedExRTabId = useStore((state) => {
+		return state.selectedExRTabId;
+	});
+	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, option.Id);
 	const effectiveSelection = useStore((state) => {
 		return state.effectiveSelections[uniqueId];
 	});

--- a/src/feature/ExROptionRecursiveItem.tsx
+++ b/src/feature/ExROptionRecursiveItem.tsx
@@ -19,7 +19,10 @@ export function ExROptionRecursiveItem({
 	option,
 	depth = 0,
 }: ExROptionRecursiveItemProps) {
-	const uniqueId = getUniqueOptionId(categoryId, option.Id);
+	const selectedExRTabId = useStore((state) => {
+		return state.selectedExRTabId;
+	});
+	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, option.Id);
 	const isOpen = useStore((state) => {
 		return state.openedExROptionIds[uniqueId];
 	});

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -26,8 +26,11 @@ export function ExRPairedOptionRow({
 	minLabel,
 	maxLabel,
 }: ExRPairedOptionRowProps) {
-	const minUniqueId = getUniqueOptionId(categoryId, min.Id);
-	const maxUniqueId = getUniqueOptionId(categoryId, max.Id);
+	const selectedExRTabId = useStore((state) => {
+		return state.selectedExRTabId;
+	});
+	const minUniqueId = getUniqueOptionId(selectedExRTabId, categoryId, min.Id);
+	const maxUniqueId = getUniqueOptionId(selectedExRTabId, categoryId, max.Id);
 
 	const effectiveMinSelection = useStore((state) => {
 		return state.effectiveSelections[minUniqueId];

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -27,7 +27,10 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 		return opt.Id === 51;
 	});
 
-	const uniqueRateId = getUniqueOptionId(category.Id, 50);
+	const selectedExRTabId = useStore((state) => {
+		return state.selectedExRTabId;
+	});
+	const uniqueRateId = getUniqueOptionId(selectedExRTabId, category.Id, 50);
 	const effectiveSpawnRateSelection = useStore((state) => {
 		return state.effectiveSelections[uniqueRateId];
 	});

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,5 +1,6 @@
 import { ColoredText } from "../components/parts/ColoredText";
 import { getUniqueOptionId, isPresetOption } from "../logics/optionUtils";
+import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../type";
 import type { ExRCategoryDto } from "../type";
 import { useStore } from "../useStore";
 import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
@@ -21,16 +22,20 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 	});
 
 	const spawnRateOption = category.Options.find((opt) => {
-		return opt.Id === 50;
+		return opt.Id === SPAWN_RATE_OPTION_ID;
 	});
 	const spawnCountOption = category.Options.find((opt) => {
-		return opt.Id === 51;
+		return opt.Id === SPAWN_COUNT_OPTION_ID;
 	});
 
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
-	const uniqueRateId = getUniqueOptionId(selectedExRTabId, category.Id, 50);
+	const uniqueRateId = getUniqueOptionId(
+		selectedExRTabId,
+		category.Id,
+		SPAWN_RATE_OPTION_ID,
+	);
 	const effectiveSpawnRateSelection = useStore((state) => {
 		return state.effectiveSelections[uniqueRateId];
 	});
@@ -45,7 +50,7 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 		if (isPresetOption(category.Id, option.Id)) {
 			return [];
 		}
-		if (option.Id === 50 || option.Id === 51) {
+		if (option.Id === SPAWN_RATE_OPTION_ID || option.Id === SPAWN_COUNT_OPTION_ID) {
 			return option.Childs || [];
 		}
 		return [option];
@@ -53,7 +58,7 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 
 	// ID 50 と 51 を除外しつつ、重複（トップレベルと子要素の両方に存在する場合など）を排除
 	const filteredOptions = allPotentialOptions.filter((option, index, self) => {
-		if (option.Id === 50 || option.Id === 51) {
+		if (option.Id === SPAWN_RATE_OPTION_ID || option.Id === SPAWN_COUNT_OPTION_ID) {
 			return false;
 		}
 		return (

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,7 +1,7 @@
 import { ColoredText } from "../components/parts/ColoredText";
 import { getUniqueOptionId, isPresetOption } from "../logics/optionUtils";
-import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../type";
 import type { ExRCategoryDto } from "../type";
+import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../type";
 import { useStore } from "../useStore";
 import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
 import { ExRRoleSpawnControls } from "./ExRRoleSpawnControls";
@@ -50,7 +50,10 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 		if (isPresetOption(category.Id, option.Id)) {
 			return [];
 		}
-		if (option.Id === SPAWN_RATE_OPTION_ID || option.Id === SPAWN_COUNT_OPTION_ID) {
+		if (
+			option.Id === SPAWN_RATE_OPTION_ID ||
+			option.Id === SPAWN_COUNT_OPTION_ID
+		) {
 			return option.Childs || [];
 		}
 		return [option];
@@ -58,7 +61,10 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 
 	// ID 50 と 51 を除外しつつ、重複（トップレベルと子要素の両方に存在する場合など）を排除
 	const filteredOptions = allPotentialOptions.filter((option, index, self) => {
-		if (option.Id === SPAWN_RATE_OPTION_ID || option.Id === SPAWN_COUNT_OPTION_ID) {
+		if (
+			option.Id === SPAWN_RATE_OPTION_ID ||
+			option.Id === SPAWN_COUNT_OPTION_ID
+		) {
 			return false;
 		}
 		return (

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -1,7 +1,7 @@
 import { CompactSlider } from "../components/parts/CompactSlider";
 import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
-import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../type";
 import type { ExROptionDto } from "../type";
+import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../type";
 import { useStore } from "../useStore";
 
 interface ExRRoleSpawnControlsProps {

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -17,8 +17,11 @@ export function ExRRoleSpawnControls({
 	spawnRateOption,
 	spawnCountOption,
 }: ExRRoleSpawnControlsProps) {
-	const uniqueRateId = getUniqueOptionId(categoryId, 50);
-	const uniqueCountId = getUniqueOptionId(categoryId, 51);
+	const selectedExRTabId = useStore((state) => {
+		return state.selectedExRTabId;
+	});
+	const uniqueRateId = getUniqueOptionId(selectedExRTabId, categoryId, 50);
+	const uniqueCountId = getUniqueOptionId(selectedExRTabId, categoryId, 51);
 
 	const effectiveSpawnRateSelection = useStore((state) => {
 		return state.effectiveSelections[uniqueRateId];

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -1,5 +1,6 @@
 import { CompactSlider } from "../components/parts/CompactSlider";
 import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
+import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../type";
 import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 
@@ -20,8 +21,16 @@ export function ExRRoleSpawnControls({
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
-	const uniqueRateId = getUniqueOptionId(selectedExRTabId, categoryId, 50);
-	const uniqueCountId = getUniqueOptionId(selectedExRTabId, categoryId, 51);
+	const uniqueRateId = getUniqueOptionId(
+		selectedExRTabId,
+		categoryId,
+		SPAWN_RATE_OPTION_ID,
+	);
+	const uniqueCountId = getUniqueOptionId(
+		selectedExRTabId,
+		categoryId,
+		SPAWN_COUNT_OPTION_ID,
+	);
 
 	const effectiveSpawnRateSelection = useStore((state) => {
 		return state.effectiveSelections[uniqueRateId];

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -27,7 +27,7 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 		return o.Id === 0;
 	});
 
-	const uniqueId = getUniqueOptionId(0, 0);
+	const uniqueId = getUniqueOptionId(0, 0, 0);
 	const effectiveSelection = useStore((state) => {
 		return state.effectiveSelections[uniqueId];
 	});

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -1,13 +1,15 @@
 import type { ExROptionDto } from "../type";
 
 /**
- * カテゴリIDとオプションIDを組み合わせて、アプリケーション内で一意なIDを生成します。
+ * タブID、カテゴリID、オプションIDを組み合わせて、アプリケーション内で一意な数値IDを生成します。
+ * 9桁目以降：タブID、5～8桁目：カテゴリーID、1～4桁目：オプションID
  */
 export function getUniqueOptionId(
+	tabId: number,
 	categoryId: number,
 	optionId: number,
-): string {
-	return `${categoryId}-${optionId}`;
+): number {
+	return tabId * 100_000_000 + categoryId * 10_000 + optionId;
 }
 
 /**

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -12,16 +12,16 @@ export interface OptionViewerSlice {
 	selectedExRTabId: OptionTab;
 	isTabPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
-	openedExROptionIds: Record<string, boolean>;
-	effectiveSelections: Record<string, number>;
+	openedExROptionIds: Record<number, boolean>;
+	effectiveSelections: Record<number, number>;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
 	setSelectedExRTabId: (id: OptionTab) => void;
 	setIsTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
-	toggleExROption: (uniqueOptionId: string) => void;
+	toggleExROption: (uniqueOptionId: number) => void;
 	TEMP_updateExROptionSelection: (
-		uniqueOptionId: string,
+		uniqueOptionId: number,
 		selection: number,
 	) => void;
 	updatePresetName: (presetIndex: number, name: string) => void;
@@ -69,7 +69,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				};
 			});
 		},
-		toggleExROption: (uniqueOptionId: string) => {
+		toggleExROption: (uniqueOptionId: number) => {
 			set((state) => {
 				return {
 					openedExROptionIds: {
@@ -80,7 +80,7 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 			});
 		},
 		TEMP_updateExROptionSelection: (
-			uniqueOptionId: string,
+			uniqueOptionId: number,
 			selection: number,
 		) => {
 			set((state) => {

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 
 /**
+ * 特別な意味を持つオプションIDの定数
+ */
+export const SPAWN_RATE_OPTION_ID = 50;
+export const SPAWN_COUNT_OPTION_ID = 51;
+
+/**
  * タブの種類を表す定数
  */
 export const OptionTab = {

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -3,10 +3,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { ExRCategoryList } from "../src/feature/ExRCategoryList";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
 import {
+	type ExRTabDto,
 	OptionTab,
 	SPAWN_COUNT_OPTION_ID,
 	SPAWN_RATE_OPTION_ID,
-	type ExRTabDto,
 } from "../src/type";
 import { useStore } from "../src/useStore";
 

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -2,7 +2,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ExRCategoryList } from "../src/feature/ExRCategoryList";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
-import { type ExRTabDto, OptionTab } from "../src/type";
+import {
+	OptionTab,
+	SPAWN_COUNT_OPTION_ID,
+	SPAWN_RATE_OPTION_ID,
+	type ExRTabDto,
+} from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("ExRCategoryList Component Selection", () => {
@@ -37,7 +42,7 @@ describe("ExRCategoryList Component Selection", () => {
 					Name: "Sheriff",
 					Options: [
 						{
-							Id: 50,
+							Id: SPAWN_RATE_OPTION_ID,
 							IsActive: true,
 							TranslatedName: "Spawn Rate",
 							Selection: 0,
@@ -46,7 +51,7 @@ describe("ExRCategoryList Component Selection", () => {
 							Childs: [],
 						},
 						{
-							Id: 51,
+							Id: SPAWN_COUNT_OPTION_ID,
 							IsActive: true,
 							TranslatedName: "Spawn Count",
 							Selection: 0,
@@ -101,7 +106,7 @@ describe("ExRCategoryList Component Selection", () => {
 		useStore
 			.getState()
 			.TEMP_updateExROptionSelection(
-				getUniqueOptionId(OptionTab.CrewmateTab, 2, 50),
+				getUniqueOptionId(OptionTab.CrewmateTab, 2, SPAWN_RATE_OPTION_ID),
 				1,
 			); // Category 2, Option 50, Index 1 (Value 100)
 		render(<ExRCategoryList tabs={mockTabs} />);

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ExRCategoryList } from "../src/feature/ExRCategoryList";
+import { getUniqueOptionId } from "../src/logics/optionUtils";
 import { type ExRTabDto, OptionTab } from "../src/type";
 import { useStore } from "../src/useStore";
 
@@ -97,7 +98,12 @@ describe("ExRCategoryList Component Selection", () => {
 	it("filters out 50 and 51 from role category body", () => {
 		useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
 		// Set a non-zero spawn rate so the accordion is enabled
-		useStore.getState().TEMP_updateExROptionSelection("2-50", 1); // Category 2, Option 50, Index 1 (Value 100)
+		useStore
+			.getState()
+			.TEMP_updateExROptionSelection(
+				getUniqueOptionId(OptionTab.CrewmateTab, 2, 50),
+				1,
+			); // Category 2, Option 50, Index 1 (Value 100)
 		render(<ExRCategoryList tabs={mockTabs} />);
 
 		// Open accordion - RoleCategoryItem uses a custom layout,

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -2,12 +2,13 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
+import { SPAWN_RATE_OPTION_ID } from "../src/type";
 import type { ExROptionDto } from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("ExRHeaderOptionControl", () => {
 	const mockOption: ExROptionDto = {
-		Id: 50,
+		Id: SPAWN_RATE_OPTION_ID,
 		IsActive: true,
 		TranslatedName: "レート",
 		Selection: 0,
@@ -54,7 +55,9 @@ describe("ExRHeaderOptionControl", () => {
 		// Check if store was updated
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
-		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 50)]).toBe(1);
+		expect(
+			state.effectiveSelections[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)],
+		).toBe(1);
 	});
 
 	it("updates selection when input is changed", () => {
@@ -78,7 +81,9 @@ describe("ExRHeaderOptionControl", () => {
 
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
-		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 50)]).toBe(2); // 100 is at index 2
+		expect(
+			state.effectiveSelections[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)],
+		).toBe(2); // 100 is at index 2
 	});
 
 	it("prevents click propagation to parent", () => {

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
+import { getUniqueOptionId } from "../src/logics/optionUtils";
 import type { ExROptionDto } from "../src/type";
 import { useStore } from "../src/useStore";
 
@@ -52,7 +53,8 @@ describe("ExRHeaderOptionControl", () => {
 
 		// Check if store was updated
 		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1);
+		const tabId = state.selectedExRTabId;
+		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 50)]).toBe(1);
 	});
 
 	it("updates selection when input is changed", () => {
@@ -75,7 +77,8 @@ describe("ExRHeaderOptionControl", () => {
 		fireEvent.change(textInput, { target: { value: "100" } });
 
 		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(2); // 100 is at index 2
+		const tabId = state.selectedExRTabId;
+		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 50)]).toBe(2); // 100 is at index 2
 	});
 
 	it("prevents click propagation to parent", () => {

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
-import { SPAWN_RATE_OPTION_ID } from "../src/type";
 import type { ExROptionDto } from "../src/type";
+import { SPAWN_RATE_OPTION_ID } from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("ExRHeaderOptionControl", () => {
@@ -56,7 +56,9 @@ describe("ExRHeaderOptionControl", () => {
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
 		expect(
-			state.effectiveSelections[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)],
+			state.effectiveSelections[
+				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)
+			],
 		).toBe(1);
 	});
 
@@ -82,7 +84,9 @@ describe("ExRHeaderOptionControl", () => {
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
 		expect(
-			state.effectiveSelections[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)],
+			state.effectiveSelections[
+				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)
+			],
 		).toBe(2); // 100 is at index 2
 	});
 

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -2,12 +2,13 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
+import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../src/type";
 import type { ExROptionDto } from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("ExRRoleSpawnControls", () => {
 	const spawnRateOption: ExROptionDto = {
-		Id: 50,
+		Id: SPAWN_RATE_OPTION_ID,
 		IsActive: true,
 		TranslatedName: "レート",
 		Selection: 0,
@@ -17,7 +18,7 @@ describe("ExRRoleSpawnControls", () => {
 	};
 
 	const spawnCountOption: ExROptionDto = {
-		Id: 51,
+		Id: SPAWN_COUNT_OPTION_ID,
 		IsActive: true,
 		TranslatedName: "数",
 		Selection: 0,
@@ -66,7 +67,10 @@ describe("ExRRoleSpawnControls", () => {
 		const tabId = useStore.getState().selectedExRTabId;
 		useStore
 			.getState()
-			.TEMP_updateExROptionSelection(getUniqueOptionId(tabId, 1, 50), 1);
+			.TEMP_updateExROptionSelection(
+				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID),
+				1,
+			);
 
 		render(
 			<ExRRoleSpawnControls
@@ -84,7 +88,9 @@ describe("ExRRoleSpawnControls", () => {
 		fireEvent.change(slider, { target: { value: "0" } });
 
 		const state = useStore.getState();
-		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 50)]).toBe(0); // Rate 0%
+		expect(
+			state.effectiveSelections[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)],
+		).toBe(0); // Rate 0%
 	});
 
 	it("syncs rate to 10% when count is set to non-zero from zero rate", () => {
@@ -105,7 +111,9 @@ describe("ExRRoleSpawnControls", () => {
 
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
-		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 50)]).toBe(1); // Rate index 1 is 10%
+		expect(
+			state.effectiveSelections[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)],
+		).toBe(1); // Rate index 1 is 10%
 	});
 
 	it("syncs count to 0 when rate is set to 0%", () => {
@@ -113,10 +121,16 @@ describe("ExRRoleSpawnControls", () => {
 		const tabId = useStore.getState().selectedExRTabId;
 		useStore
 			.getState()
-			.TEMP_updateExROptionSelection(getUniqueOptionId(tabId, 1, 50), 1);
+			.TEMP_updateExROptionSelection(
+				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID),
+				1,
+			);
 		useStore
 			.getState()
-			.TEMP_updateExROptionSelection(getUniqueOptionId(tabId, 1, 51), 1); // backend index 1 is value 2
+			.TEMP_updateExROptionSelection(
+				getUniqueOptionId(tabId, 1, SPAWN_COUNT_OPTION_ID),
+				1,
+			); // backend index 1 is value 2
 
 		render(
 			<ExRRoleSpawnControls
@@ -134,7 +148,11 @@ describe("ExRRoleSpawnControls", () => {
 		fireEvent.change(slider, { target: { value: "0" } });
 
 		const state = useStore.getState();
-		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 51)]).toBe(0); // Count reset to index 0
+		expect(
+			state.effectiveSelections[
+				getUniqueOptionId(tabId, 1, SPAWN_COUNT_OPTION_ID)
+			],
+		).toBe(0); // Count reset to index 0
 
 		// UI should show 0
 		const countDisplay = screen

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
-import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../src/type";
 import type { ExROptionDto } from "../src/type";
+import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("ExRRoleSpawnControls", () => {
@@ -89,7 +89,9 @@ describe("ExRRoleSpawnControls", () => {
 
 		const state = useStore.getState();
 		expect(
-			state.effectiveSelections[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)],
+			state.effectiveSelections[
+				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)
+			],
 		).toBe(0); // Rate 0%
 	});
 
@@ -112,7 +114,9 @@ describe("ExRRoleSpawnControls", () => {
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
 		expect(
-			state.effectiveSelections[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)],
+			state.effectiveSelections[
+				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)
+			],
 		).toBe(1); // Rate index 1 is 10%
 	});
 

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
+import { getUniqueOptionId } from "../src/logics/optionUtils";
 import type { ExROptionDto } from "../src/type";
 import { useStore } from "../src/useStore";
 
@@ -62,7 +63,10 @@ describe("ExRRoleSpawnControls", () => {
 
 	it("syncs rate to 0 when count is set to 0", () => {
 		// Set initial rate to 10%
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
+		const tabId = useStore.getState().selectedExRTabId;
+		useStore
+			.getState()
+			.TEMP_updateExROptionSelection(getUniqueOptionId(tabId, 1, 50), 1);
 
 		render(
 			<ExRRoleSpawnControls
@@ -80,7 +84,7 @@ describe("ExRRoleSpawnControls", () => {
 		fireEvent.change(slider, { target: { value: "0" } });
 
 		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(0); // Rate 0%
+		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 50)]).toBe(0); // Rate 0%
 	});
 
 	it("syncs rate to 10% when count is set to non-zero from zero rate", () => {
@@ -100,13 +104,19 @@ describe("ExRRoleSpawnControls", () => {
 		fireEvent.change(slider, { target: { value: "1" } }); // Select '1'
 
 		const state = useStore.getState();
-		expect(state.effectiveSelections["1-50"]).toBe(1); // Rate index 1 is 10%
+		const tabId = state.selectedExRTabId;
+		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 50)]).toBe(1); // Rate index 1 is 10%
 	});
 
 	it("syncs count to 0 when rate is set to 0%", () => {
 		// Set initial rate to 10% and count to 2
-		useStore.getState().TEMP_updateExROptionSelection("1-50", 1);
-		useStore.getState().TEMP_updateExROptionSelection("1-51", 1); // backend index 1 is value 2
+		const tabId = useStore.getState().selectedExRTabId;
+		useStore
+			.getState()
+			.TEMP_updateExROptionSelection(getUniqueOptionId(tabId, 1, 50), 1);
+		useStore
+			.getState()
+			.TEMP_updateExROptionSelection(getUniqueOptionId(tabId, 1, 51), 1); // backend index 1 is value 2
 
 		render(
 			<ExRRoleSpawnControls
@@ -124,7 +134,7 @@ describe("ExRRoleSpawnControls", () => {
 		fireEvent.change(slider, { target: { value: "0" } });
 
 		const state = useStore.getState();
-		expect(state.effectiveSelections["1-51"]).toBe(0); // Count reset to index 0
+		expect(state.effectiveSelections[getUniqueOptionId(tabId, 1, 51)]).toBe(0); // Count reset to index 0
 
 		// UI should show 0
 		const countDisplay = screen

--- a/tests/optionUtils.test.ts
+++ b/tests/optionUtils.test.ts
@@ -4,11 +4,29 @@ import {
 	getBaseOptionName,
 	getOptionLabel,
 	getOptionPairType,
+	getUniqueOptionId,
 	groupOptionPairs,
 } from "../src/logics/optionUtils";
 import type { ExROptionDto } from "../src/type";
 
 describe("optionUtils", () => {
+	describe("getUniqueOptionId", () => {
+		it("should generate numeric ID correctly", () => {
+			// Tab 1, Category 2, Option 3 -> 100,000,000 + 20,000 + 3 = 100,020,003
+			expect(getUniqueOptionId(1, 2, 3)).toBe(100020003);
+		});
+
+		it("should handle tab ID 0", () => {
+			// Tab 0, Category 1, Option 1 -> 10,000 + 1 = 10,001
+			expect(getUniqueOptionId(0, 1, 1)).toBe(10001);
+		});
+
+		it("should handle large IDs", () => {
+			// Tab 10, Category 9999, Option 9999
+			expect(getUniqueOptionId(10, 9999, 9999)).toBe(1099999999);
+		});
+	});
+
 	describe("getOptionPairType", () => {
 		it("should identify Japanese min/max", () => {
 			expect(getOptionPairType("テスト 最小")).toBe("min");

--- a/tests/optionViewerSlice.test.ts
+++ b/tests/optionViewerSlice.test.ts
@@ -58,4 +58,21 @@ describe("optionViewerSlice", () => {
 		updatePresetName(1, "  ");
 		expect(useStore.getState().presetNames[1]).toBeUndefined();
 	});
+
+	it("should toggle option open state with numeric ID", () => {
+		const { toggleExROption } = useStore.getState();
+
+		toggleExROption(10001);
+		expect(useStore.getState().openedExROptionIds[10001]).toBe(true);
+
+		toggleExROption(10001);
+		expect(useStore.getState().openedExROptionIds[10001]).toBe(false);
+	});
+
+	it("should update effective selections with numeric ID", () => {
+		const { TEMP_updateExROptionSelection } = useStore.getState();
+
+		TEMP_updateExROptionSelection(10001, 5);
+		expect(useStore.getState().effectiveSelections[10001]).toBe(5);
+	});
 });


### PR DESCRIPTION
uniqueOptionIdを文字列から数値形式に変更しました。
ご指定の通り、以下のルールで計算しています：
- 9桁目以降：タブID
- 5～8桁目：カテゴリーID
- 1～4桁目：オプションID

あわせて、zustandストアの型定義および全ての利用箇所を修正し、動作確認のためのテストを追加しました。

---
*PR created automatically by Jules for task [116146396622622164](https://jules.google.com/task/116146396622622164) started by @yukieiji*