### PR TITLE
FirefoxでのE2Eテスト失敗の修正

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -13,6 +13,11 @@ test.beforeEach(async ({ page }) => {
 	await expect(page.getByText("Loading data...")).not.toBeVisible({
 		timeout: 30000,
 	});
+
+	// サイドバーが表示されるまで待機（アプリケーションがインタラクティブになったことの確認）
+	await expect(page.getByLabel("オプションサイドバー")).toBeVisible({
+		timeout: 15000,
+	});
 });
 
 test("ExR Option Accordion behavior", async ({ page }) => {

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -13,12 +13,16 @@ test.beforeEach(async ({ page }) => {
 	await expect(page.getByText("Loading data...")).not.toBeVisible({
 		timeout: 30000,
 	});
+
+	// サイドバーが表示されるまで待機（アプリケーションがインタラクティブになったことの確認）
+	await expect(page.getByLabel("オプションサイドバー")).toBeVisible({
+		timeout: 15000,
+	});
 });
 
 test("has sidebar and json viewer", async ({ page }) => {
 	// サイドバーが表示されていることを確認
 	const sidebar = page.getByLabel("オプションサイドバー");
-	await expect(sidebar).toBeVisible({ timeout: 15000 });
 
 	// サイドバー内のボタンを明示的に指定
 	await expect(

--- a/e2e/reproduction_issue.spec.ts
+++ b/e2e/reproduction_issue.spec.ts
@@ -10,6 +10,11 @@ test.beforeEach(async ({ page }) => {
 		timeout: 30000,
 	});
 
+	// サイドバーが表示されるまで待機（アプリケーションがインタラクティブになったことの確認）
+	await expect(page.getByLabel("オプションサイドバー")).toBeVisible({
+		timeout: 15000,
+	});
+
 	await page.getByRole("button", { name: "ExR Options" }).click();
 });
 
@@ -38,7 +43,8 @@ test("Option ID 52 and higher should be visible in role categories when active",
 	const content = forasCategory.locator(
 		'[data-testid="exr-category-list-container"]',
 	);
-	await expect(content).toBeVisible();
+	// アコーディオンの開閉アニメーションや、レンダリングの遅延を考慮して待機
+	await expect(content).toBeVisible({ timeout: 10000 });
 
 	// 6. ID 52 のオプション（アサインウェイト）が表示されているか確認
 	// 修正前は ID 50/51 の子要素として定義されているため表示されないはず


### PR DESCRIPTION
FirefoxでのE2Eテストがタイムアウトや要素未検出により不安定だった問題を修正しました。

主な変更点:
1. `e2e/app.spec.ts`, `e2e/accordion.spec.ts`, `e2e/reproduction_issue.spec.ts` の `beforeEach` フックにおいて、ローディング画面が消えた後に「オプションサイドバー」が表示されるまで待機するロジックを追加しました。これにより、MSWの初期化とReactのハイドレーションが完了し、アプリが操作可能になったことを確実に保証します。
2. `e2e/reproduction_issue.spec.ts` において、アコーディオンの内容（`exr-category-list-container`）が表示されるまでのタイムアウトを10秒に延長しました。Firefox等のブラウザでアニメーションやレンダリングが遅延した場合でもテストが失敗しにくくなります。
3. `e2e/app.spec.ts` 内の冗長なサイドバー表示確認を整理しました。

これらの修正により、FirefoxおよびChromium環境でのE2Eテストの安定性が向上しました。

---
*PR created automatically by Jules for task [7101390805133158092](https://jules.google.com/task/7101390805133158092) started by @yukieiji*