### PR TITLE
Refactor ExR options data management and replace promise

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.13.4'
+const PACKAGE_VERSION = '2.12.13'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.13'
+const PACKAGE_VERSION = '2.13.4'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { AuOptionEditor } from "./feature/AuOptionEditor";
 import { ExROptionEditor } from "./feature/ExROptionEditor";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { PresetSelector } from "./feature/PresetSelector";
-import { getAuOptions, getExrOptions } from "./logics/api";
+import { getAuOptions, getInitialLoadPromise } from "./logics/api";
 import { useStore } from "./useStore";
 
 /**
@@ -12,8 +12,8 @@ import { useStore } from "./useStore";
  * データを取得し、Suspense境界内で動作します
  */
 function PresetSelectorContainer() {
-	const exrData = use(getExrOptions());
-	return <PresetSelector tabs={exrData} />;
+	use(getInitialLoadPromise());
+	return <PresetSelector />;
 }
 
 /**
@@ -26,11 +26,11 @@ function EditorContainer() {
 	});
 
 	// React 19 の use() フックを使用してデータを取得
-	const exrData = use(getExrOptions());
+	use(getInitialLoadPromise());
 	const auData = use(getAuOptions());
 
 	if (selectedTab === "ExR") {
-		return <ExROptionEditor data={exrData} />;
+		return <ExROptionEditor />;
 	}
 
 	return <AuOptionEditor data={auData} />;

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -32,7 +32,11 @@ export function ExRCategoryList() {
 			return !isPreset;
 		});
 		return filteredOptionIds.some((optionId) => {
-			const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
+			const uniqueId = getUniqueOptionId(
+				selectedExRTabId,
+				categoryId,
+				optionId,
+			);
 			return isOptionActive[uniqueId];
 		});
 	});

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -1,44 +1,39 @@
-import { isPresetOption } from "../logics/optionUtils";
-import type { ExRTabDto } from "../type";
+import { exrOptionMetaData } from "../logics/api";
+import { getUniqueOptionId, isPresetOption } from "../logics/optionUtils";
 import { OptionTab } from "../type";
 import { useStore } from "../useStore";
 import { ExRRoleCategoryItem } from "./ExRRoleCategoryItem";
 import { ExRStandardCategoryItem } from "./ExRStandardCategoryItem";
 
-interface ExRCategoryListProps {
-	tabs: ExRTabDto[];
-}
-
 /**
  * 選択されたタブのカテゴリ一覧を表示するコンポーネント
  */
-export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
+export function ExRCategoryList() {
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
 	const isTabPending = useStore((state) => {
 		return state.isTabPending;
 	});
-
-	let selectedTab = tabs.find((tab) => {
-		return tab.Id === selectedExRTabId;
+	const isOptionActive = useStore((state) => {
+		return state.isOptionActive;
 	});
 
-	if (!selectedTab) {
-		selectedTab = tabs[0];
-	}
+	const categoryIds = exrOptionMetaData.categoryIdMap[selectedExRTabId] ?? [];
 
 	const isRoleTab = selectedExRTabId !== OptionTab.GeneralTab;
 
 	// オプションが空でない、かつ少なくとも1つのオプションが有効なカテゴリのみを抽出
 	// ※ プリセット設定が唯一のオプションだった場合も考慮してフィルタリング
-	const visibleCategories = selectedTab.Categories.filter((category) => {
-		const filteredOptions = category.Options.filter((option) => {
-			const isPreset = isPresetOption(category.Id, option.Id);
+	const visibleCategoryIds = categoryIds.filter((categoryId) => {
+		const optionIds = exrOptionMetaData.optionIdMap[categoryId] ?? [];
+		const filteredOptionIds = optionIds.filter((optionId) => {
+			const isPreset = isPresetOption(categoryId, optionId);
 			return !isPreset;
 		});
-		return filteredOptions.some((opt) => {
-			return opt.IsActive;
+		return filteredOptionIds.some((optionId) => {
+			const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
+			return isOptionActive[uniqueId];
 		});
 	});
 
@@ -53,19 +48,19 @@ export function ExRCategoryList({ tabs }: ExRCategoryListProps) {
 					<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
 				</div>
 			)}
-			{visibleCategories.map((category) => {
+			{visibleCategoryIds.map((categoryId) => {
 				if (isRoleTab) {
 					return (
 						<ExRRoleCategoryItem
-							key={`${selectedExRTabId}-${category.Id}`}
-							category={category}
+							key={`${selectedExRTabId}-${categoryId}`}
+							categoryId={categoryId}
 						/>
 					);
 				}
 				return (
 					<ExRStandardCategoryItem
-						key={`${selectedExRTabId}-${category.Id}`}
-						category={category}
+						key={`${selectedExRTabId}-${categoryId}`}
+						categoryId={categoryId}
 					/>
 				);
 			})}

--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { exrOptionMetaData } from "../logics/api";
 import { getUniqueOptionId, isPresetOption } from "../logics/optionUtils";
 import { OptionTab } from "../type";
@@ -15,9 +16,11 @@ export function ExRCategoryList() {
 	const isTabPending = useStore((state) => {
 		return state.isTabPending;
 	});
-	const isOptionActive = useStore((state) => {
-		return state.isOptionActive;
-	});
+	const isOptionActive = useStore(
+		useCallback((state) => {
+			return state.isOptionActive;
+		}, []),
+	);
 
 	const categoryIds = exrOptionMetaData.categoryIdMap[selectedExRTabId] ?? [];
 

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { exrOptionMetaData } from "../logics/api";
 import { getUniqueOptionId, groupOptionPairs } from "../logics/optionUtils";
 import { useStore } from "../useStore";
@@ -21,12 +22,16 @@ export function ExRCategoryOptionList({
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
-	const valueDataRecord = useStore((state) => {
-		return state.valueData;
-	});
-	const isOptionActiveRecord = useStore((state) => {
-		return state.isOptionActive;
-	});
+	const valueDataRecord = useStore(
+		useCallback((state) => {
+			return state.valueData;
+		}, []),
+	);
+	const isOptionActiveRecord = useStore(
+		useCallback((state) => {
+			return state.isOptionActive;
+		}, []),
+	);
 
 	const options = optionIds.map((id) => {
 		const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, id);

--- a/src/feature/ExRCategoryOptionList.tsx
+++ b/src/feature/ExRCategoryOptionList.tsx
@@ -1,5 +1,6 @@
-import { groupOptionPairs } from "../logics/optionUtils";
-import type { ExROptionDto } from "../type";
+import { exrOptionMetaData } from "../logics/api";
+import { getUniqueOptionId, groupOptionPairs } from "../logics/optionUtils";
+import { useStore } from "../useStore";
 import { ExROptionItem } from "./ExROptionItem";
 import { ExRPairedOptionRow } from "./ExRPairedOptionRow";
 
@@ -7,7 +8,7 @@ const GROUPED_CATEGORY_IDS = [5, 6];
 
 interface ExRCategoryOptionListProps {
 	categoryId: number;
-	options: ExROptionDto[];
+	optionIds: number[];
 }
 
 /**
@@ -15,8 +16,38 @@ interface ExRCategoryOptionListProps {
  */
 export function ExRCategoryOptionList({
 	categoryId,
-	options,
+	optionIds,
 }: ExRCategoryOptionListProps) {
+	const selectedExRTabId = useStore((state) => {
+		return state.selectedExRTabId;
+	});
+	const valueDataRecord = useStore((state) => {
+		return state.valueData;
+	});
+	const isOptionActiveRecord = useStore((state) => {
+		return state.isOptionActive;
+	});
+
+	const options = optionIds.map((id) => {
+		const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, id);
+		const meta = exrOptionMetaData.optionMetaData[uniqueId];
+		const valueData = valueDataRecord[uniqueId];
+		const isOptionActive = isOptionActiveRecord[uniqueId];
+
+		return {
+			Id: id,
+			TranslatedName: meta?.translatedName ?? "",
+			Format: meta?.format ?? "",
+			IsActive: isOptionActive ?? false,
+			Selection: valueData?.selection ?? 0,
+			RangeMeta: {
+				Type: meta?.type ?? "Single",
+				Values: valueData?.values ?? [],
+			},
+			Childs: [], // We don't need real Childs here for grouping
+		} as any;
+	});
+
 	const shouldGroup = GROUPED_CATEGORY_IDS.includes(categoryId);
 	const groupedItems = shouldGroup ? groupOptionPairs(options) : options;
 
@@ -32,8 +63,8 @@ export function ExRCategoryOptionList({
 							key={`pair-${item.baseName}`}
 							categoryId={categoryId}
 							baseName={item.baseName}
-							min={item.min}
-							max={item.max}
+							minOptionId={item.min.Id}
+							maxOptionId={item.max.Id}
 							minLabel={item.minLabel}
 							maxLabel={item.maxLabel}
 						/>
@@ -41,9 +72,9 @@ export function ExRCategoryOptionList({
 				}
 				return (
 					<ExROptionItem
-						key={(item as ExROptionDto).Id}
+						key={item.Id}
 						categoryId={categoryId}
-						option={item as ExROptionDto}
+						optionId={item.Id}
 					/>
 				);
 			})}

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { CompactSlider } from "../components/parts/CompactSlider";
 import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
 import { useStore } from "../useStore";
@@ -21,9 +22,14 @@ export function ExRHeaderOptionControl({
 		return state.selectedExRTabId;
 	});
 	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
-	const valueData = useStore((state) => {
-		return state.valueData[uniqueId];
-	});
+	const valueData = useStore(
+		useCallback(
+			(state) => {
+				return state.valueData[uniqueId];
+			},
+			[uniqueId],
+		),
+	);
 	const currentSelection = valueData?.selection ?? 0;
 	const TEMP_updateExROptionSelection = useStore((state) => {
 		return state.TEMP_updateExROptionSelection;

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -25,18 +25,18 @@ export function ExRHeaderOptionControl({
 		return state.valueData[uniqueId];
 	});
 	const currentSelection = valueData?.selection ?? 0;
-	const updateExROptionSelection = useStore((state) => {
-		return state.updateExROptionSelection;
+	const TEMP_updateExROptionSelection = useStore((state) => {
+		return state.TEMP_updateExROptionSelection;
 	});
 
 	const values = (valueData?.values as number[]) ?? [];
 
 	const handleSelectionChange = (newSelection: number) => {
-		updateExROptionSelection(uniqueId, newSelection);
+		TEMP_updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const handleInputChange = (val: number) => {
-		updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+		TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
 	};
 
 	return (

--- a/src/feature/ExRHeaderOptionControl.tsx
+++ b/src/feature/ExRHeaderOptionControl.tsx
@@ -1,11 +1,10 @@
 import { CompactSlider } from "../components/parts/CompactSlider";
 import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
-import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 
 interface ExRHeaderOptionControlProps {
 	categoryId: number;
-	option: ExROptionDto;
+	optionId: number;
 	label: string;
 }
 
@@ -15,29 +14,29 @@ interface ExRHeaderOptionControlProps {
  */
 export function ExRHeaderOptionControl({
 	categoryId,
-	option,
+	optionId,
 	label,
 }: ExRHeaderOptionControlProps) {
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
-	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, option.Id);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
+	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
+	const valueData = useStore((state) => {
+		return state.valueData[uniqueId];
 	});
-	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const currentSelection = valueData?.selection ?? 0;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
-	const values = option.RangeMeta.Values as number[];
+	const values = (valueData?.values as number[]) ?? [];
 
 	const handleSelectionChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const handleInputChange = (val: number) => {
-		TEMP_updateExROptionSelection(uniqueId, findClosestIndex(values, val));
+		updateExROptionSelection(uniqueId, findClosestIndex(values, val));
 	};
 
 	return (

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -1,13 +1,13 @@
 import { OptionToggleControl } from "../components/blocks/OptionToggleControl";
 import { OptionDropdownControl } from "../components/parts/OptionDropdownControl";
 import { OptionSliderControl } from "../components/parts/OptionSliderControl";
+import { exrOptionMetaData } from "../logics/api";
 import { getUniqueOptionId } from "../logics/optionUtils";
-import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 
 interface ExROptionControlProps {
 	categoryId: number;
-	option: ExROptionDto;
+	optionId: number;
 }
 
 /**
@@ -15,25 +15,30 @@ interface ExROptionControlProps {
  */
 export function ExROptionControl({
 	categoryId,
-	option,
+	optionId,
 }: ExROptionControlProps) {
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
-	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, option.Id);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
+	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
+	const valueData = useStore((state) => {
+		return state.valueData[uniqueId];
 	});
-	const currentSelection = effectiveSelection ?? option.Selection;
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const handleChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueId, newSelection);
+		updateExROptionSelection(uniqueId, newSelection);
 	};
 
-	const { Type, Values } = option.RangeMeta;
+	const meta = exrOptionMetaData.optionMetaData[uniqueId];
+	if (!meta || !valueData) {
+		return null;
+	}
+
+	const { type: Type, format: Format } = meta;
+	const { selection: currentSelection, values: Values } = valueData;
 
 	if (Type === "String") {
 		const stringValues = Values as string[];
@@ -67,7 +72,7 @@ export function ExROptionControl({
 			<OptionSliderControl
 				selection={currentSelection}
 				values={Values as number[]}
-				format={option.Format}
+				format={Format}
 				onChange={handleChange}
 			/>
 		);

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -24,12 +24,12 @@ export function ExROptionControl({
 	const valueData = useStore((state) => {
 		return state.valueData[uniqueId];
 	});
-	const updateExROptionSelection = useStore((state) => {
-		return state.updateExROptionSelection;
+	const TEMP_updateExROptionSelection = useStore((state) => {
+		return state.TEMP_updateExROptionSelection;
 	});
 
 	const handleChange = (newSelection: number) => {
-		updateExROptionSelection(uniqueId, newSelection);
+		TEMP_updateExROptionSelection(uniqueId, newSelection);
 	};
 
 	const meta = exrOptionMetaData.optionMetaData[uniqueId];

--- a/src/feature/ExROptionControl.tsx
+++ b/src/feature/ExROptionControl.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { OptionToggleControl } from "../components/blocks/OptionToggleControl";
 import { OptionDropdownControl } from "../components/parts/OptionDropdownControl";
 import { OptionSliderControl } from "../components/parts/OptionSliderControl";
@@ -21,9 +22,14 @@ export function ExROptionControl({
 		return state.selectedExRTabId;
 	});
 	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
-	const valueData = useStore((state) => {
-		return state.valueData[uniqueId];
-	});
+	const valueData = useStore(
+		useCallback(
+			(state) => {
+				return state.valueData[uniqueId];
+			},
+			[uniqueId],
+		),
+	);
 	const TEMP_updateExROptionSelection = useStore((state) => {
 		return state.TEMP_updateExROptionSelection;
 	});

--- a/src/feature/ExROptionEditor.tsx
+++ b/src/feature/ExROptionEditor.tsx
@@ -1,24 +1,15 @@
 import { Suspense } from "react";
-import type { ExRTabDto } from "../type";
 import { ExRCategoryList } from "./ExRCategoryList";
 import { ExRTabSelector } from "./ExRTabSelector";
-
-interface ExROptionEditorProps {
-	data: ExRTabDto[];
-}
 
 /**
  * ExRオプションを表示するコンポーネント。
  * 子コンポーネントに状態を分散させることで、再レンダリングの範囲を最小限に抑えています。
  */
-export function ExROptionEditor({ data }: ExROptionEditorProps) {
-	if (!data || data.length === 0) {
-		return <div className="p-4 text-gray-500">No ExR options available.</div>;
-	}
-
+export function ExROptionEditor() {
 	return (
 		<div className="flex flex-col gap-4">
-			<ExRTabSelector tabs={data} />
+			<ExRTabSelector />
 			<Suspense
 				fallback={
 					<div className="flex items-center justify-center h-full min-h-[200px]">
@@ -26,7 +17,7 @@ export function ExROptionEditor({ data }: ExROptionEditorProps) {
 					</div>
 				}
 			>
-				<ExRCategoryList tabs={data} />
+				<ExRCategoryList />
 			</Suspense>
 		</div>
 	);

--- a/src/feature/ExROptionItem.tsx
+++ b/src/feature/ExROptionItem.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { exrOptionMetaData } from "../logics/api";
 import { getUniqueOptionId } from "../logics/optionUtils";
 import { useStore } from "../useStore";
@@ -22,9 +23,14 @@ export function ExROptionItem({
 		return state.selectedExRTabId;
 	});
 	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
-	const isActive = useStore((state) => {
-		return state.isOptionActive[uniqueId];
-	});
+	const isActive = useStore(
+		useCallback(
+			(state) => {
+				return state.isOptionActive[uniqueId];
+			},
+			[uniqueId],
+		),
+	);
 
 	if (!isActive) {
 		return null;

--- a/src/feature/ExROptionItem.tsx
+++ b/src/feature/ExROptionItem.tsx
@@ -1,10 +1,12 @@
-import type { ExROptionDto } from "../type";
+import { exrOptionMetaData } from "../logics/api";
+import { getUniqueOptionId } from "../logics/optionUtils";
+import { useStore } from "../useStore";
 import { ExROptionRecursiveItem } from "./ExROptionRecursiveItem";
 import { ExROptionRow } from "./ExROptionRow";
 
 interface ExROptionItemProps {
 	categoryId: number;
-	option: ExROptionDto;
+	optionId: number;
 	depth?: number;
 }
 
@@ -13,20 +15,29 @@ interface ExROptionItemProps {
  */
 export function ExROptionItem({
 	categoryId,
-	option,
+	optionId,
 	depth = 0,
 }: ExROptionItemProps) {
-	if (!option.IsActive) {
+	const selectedExRTabId = useStore((state) => {
+		return state.selectedExRTabId;
+	});
+	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
+	const isActive = useStore((state) => {
+		return state.isOptionActive[uniqueId];
+	});
+
+	if (!isActive) {
 		return null;
 	}
 
-	const hasActiveChildren = option.Childs && option.Childs.length > 0;
+	const childOptionIds = exrOptionMetaData.childOptionMap[uniqueId] ?? [];
+	const hasActiveChildren = childOptionIds.length > 0;
 
 	if (hasActiveChildren) {
 		return (
 			<ExROptionRecursiveItem
 				categoryId={categoryId}
-				option={option}
+				optionId={optionId}
 				depth={depth}
 			/>
 		);
@@ -35,7 +46,7 @@ export function ExROptionItem({
 	return (
 		<ExROptionRow
 			categoryId={categoryId}
-			option={option}
+			optionId={optionId}
 			depth={depth}
 			isLeaf={true}
 		/>

--- a/src/feature/ExROptionRecursiveItem.tsx
+++ b/src/feature/ExROptionRecursiveItem.tsx
@@ -1,13 +1,16 @@
 import { OptionAccordion } from "../components/blocks/OptionAccordion";
-import { getUniqueOptionId } from "../logics/optionUtils";
-import type { ExROptionDto } from "../type";
+import { exrOptionMetaData } from "../logics/api";
+import {
+	getOptionIdFromUniqueId,
+	getUniqueOptionId,
+} from "../logics/optionUtils";
 import { useStore } from "../useStore";
 import { ExROptionItem } from "./ExROptionItem";
 import { ExROptionRow } from "./ExROptionRow";
 
 interface ExROptionRecursiveItemProps {
 	categoryId: number;
-	option: ExROptionDto;
+	optionId: number;
 	depth: number;
 }
 
@@ -16,13 +19,13 @@ interface ExROptionRecursiveItemProps {
  */
 export function ExROptionRecursiveItem({
 	categoryId,
-	option,
+	optionId,
 	depth = 0,
 }: ExROptionRecursiveItemProps) {
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
-	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, option.Id);
+	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
 	const isOpen = useStore((state) => {
 		return state.openedExROptionIds[uniqueId];
 	});
@@ -34,8 +37,20 @@ export function ExROptionRecursiveItem({
 		toggleExROption(uniqueId);
 	};
 
-	const hasActiveChildren = option.Childs.some((child) => {
-		return child.IsActive;
+	const childOptionIds = (exrOptionMetaData.childOptionMap[uniqueId] ?? []).map(
+		(id) => {
+			// childOptionMap contains full unique IDs because of how I implemented api.ts
+			// Wait, let me double check api.ts
+			return id;
+		},
+	);
+
+	const isOptionActive = useStore((state) => {
+		return state.isOptionActive;
+	});
+
+	const hasActiveChildren = childOptionIds.some((cid) => {
+		return isOptionActive[cid];
 	});
 
 	return (
@@ -43,7 +58,7 @@ export function ExROptionRecursiveItem({
 			optionItem={
 				<ExROptionRow
 					categoryId={categoryId}
-					option={option}
+					optionId={optionId}
 					depth={depth}
 					isLeaf={false}
 				/>
@@ -54,14 +69,17 @@ export function ExROptionRecursiveItem({
 			className={depth > 0 ? "border-l-2 border-blue-500/30 ml-4" : ""}
 		>
 			<div className="flex flex-col">
-				{option.Childs.map((child) => (
-					<ExROptionItem
-						key={child.Id}
-						categoryId={categoryId}
-						option={child}
-						depth={depth + 1}
-					/>
-				))}
+				{childOptionIds.map((cid) => {
+					const originalOptionId = getOptionIdFromUniqueId(cid);
+					return (
+						<ExROptionItem
+							key={cid}
+							categoryId={categoryId}
+							optionId={originalOptionId}
+							depth={depth + 1}
+						/>
+					);
+				})}
 			</div>
 		</OptionAccordion>
 	);

--- a/src/feature/ExROptionRecursiveItem.tsx
+++ b/src/feature/ExROptionRecursiveItem.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { OptionAccordion } from "../components/blocks/OptionAccordion";
 import { exrOptionMetaData } from "../logics/api";
 import {
@@ -45,9 +46,11 @@ export function ExROptionRecursiveItem({
 		},
 	);
 
-	const isOptionActive = useStore((state) => {
-		return state.isOptionActive;
-	});
+	const isOptionActive = useStore(
+		useCallback((state) => {
+			return state.isOptionActive;
+		}, []),
+	);
 
 	const hasActiveChildren = childOptionIds.some((cid) => {
 		return isOptionActive[cid];

--- a/src/feature/ExROptionRow.tsx
+++ b/src/feature/ExROptionRow.tsx
@@ -1,12 +1,14 @@
 import { OptionItem } from "../components/parts/OptionItem";
 import { OptionNameDisplay } from "../components/parts/OptionNameDisplay";
 import { OptionRowContainer } from "../components/parts/OptionRowContainer";
-import type { ExROptionDto } from "../type";
+import { exrOptionMetaData } from "../logics/api";
+import { getUniqueOptionId } from "../logics/optionUtils";
+import { useStore } from "../useStore";
 import { ExROptionControl } from "./ExROptionControl";
 
 interface ExROptionRowProps {
 	categoryId: number;
-	option: ExROptionDto;
+	optionId: number;
 	depth?: number;
 	isLeaf?: boolean;
 }
@@ -16,19 +18,25 @@ interface ExROptionRowProps {
  */
 export function ExROptionRow({
 	categoryId,
-	option,
+	optionId,
 	depth = 0,
 	isLeaf = false,
 }: ExROptionRowProps) {
+	const selectedExRTabId = useStore((state) => {
+		return state.selectedExRTabId;
+	});
+	const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
+	const meta = exrOptionMetaData.optionMetaData[uniqueId];
+
 	const content = (
 		<OptionItem className="min-h-[3rem]">
 			<div className="flex-1 min-w-0">
 				<span className="text-sm font-medium text-gray-200 break-words">
-					<OptionNameDisplay name={option.TranslatedName} />
+					<OptionNameDisplay name={meta?.translatedName ?? ""} />
 				</span>
 			</div>
 			<div className="flex-shrink-0 flex items-center gap-2">
-				<ExROptionControl categoryId={categoryId} option={option} />
+				<ExROptionControl categoryId={categoryId} optionId={optionId} />
 			</div>
 		</OptionItem>
 	);

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { OptionPairedSliderControl } from "../components/blocks/OptionPairedSliderControl";
 import { OptionItem } from "../components/parts/OptionItem";
 import { OptionNameDisplay } from "../components/parts/OptionNameDisplay";
@@ -40,12 +41,22 @@ export function ExRPairedOptionRow({
 		maxOptionId,
 	);
 
-	const minValueData = useStore((state) => {
-		return state.valueData[minUniqueId];
-	});
-	const maxValueData = useStore((state) => {
-		return state.valueData[maxUniqueId];
-	});
+	const minValueData = useStore(
+		useCallback(
+			(state) => {
+				return state.valueData[minUniqueId];
+			},
+			[minUniqueId],
+		),
+	);
+	const maxValueData = useStore(
+		useCallback(
+			(state) => {
+				return state.valueData[maxUniqueId];
+			},
+			[maxUniqueId],
+		),
+	);
 
 	const minSelection = minValueData?.selection ?? 0;
 	const maxSelection = maxValueData?.selection ?? 0;

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -29,8 +29,16 @@ export function ExRPairedOptionRow({
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
-	const minUniqueId = getUniqueOptionId(selectedExRTabId, categoryId, minOptionId);
-	const maxUniqueId = getUniqueOptionId(selectedExRTabId, categoryId, maxOptionId);
+	const minUniqueId = getUniqueOptionId(
+		selectedExRTabId,
+		categoryId,
+		minOptionId,
+	);
+	const maxUniqueId = getUniqueOptionId(
+		selectedExRTabId,
+		categoryId,
+		maxOptionId,
+	);
 
 	const minValueData = useStore((state) => {
 		return state.valueData[minUniqueId];
@@ -42,16 +50,16 @@ export function ExRPairedOptionRow({
 	const minSelection = minValueData?.selection ?? 0;
 	const maxSelection = maxValueData?.selection ?? 0;
 
-	const updateExROptionSelection = useStore((state) => {
-		return state.updateExROptionSelection;
+	const TEMP_updateExROptionSelection = useStore((state) => {
+		return state.TEMP_updateExROptionSelection;
 	});
 
 	const handleMinChange = (newSelection: number) => {
-		updateExROptionSelection(minUniqueId, newSelection);
+		TEMP_updateExROptionSelection(minUniqueId, newSelection);
 	};
 
 	const handleMaxChange = (newSelection: number) => {
-		updateExROptionSelection(maxUniqueId, newSelection);
+		TEMP_updateExROptionSelection(maxUniqueId, newSelection);
 	};
 
 	const minMeta = exrOptionMetaData.optionMetaData[minUniqueId];

--- a/src/feature/ExRPairedOptionRow.tsx
+++ b/src/feature/ExRPairedOptionRow.tsx
@@ -2,15 +2,15 @@ import { OptionPairedSliderControl } from "../components/blocks/OptionPairedSlid
 import { OptionItem } from "../components/parts/OptionItem";
 import { OptionNameDisplay } from "../components/parts/OptionNameDisplay";
 import { OptionRowContainer } from "../components/parts/OptionRowContainer";
+import { exrOptionMetaData } from "../logics/api";
 import { getUniqueOptionId } from "../logics/optionUtils";
-import type { ExROptionDto } from "../type";
 import { useStore } from "../useStore";
 
 interface ExRPairedOptionRowProps {
 	categoryId: number;
 	baseName: string;
-	min: ExROptionDto;
-	max: ExROptionDto;
+	minOptionId: number;
+	maxOptionId: number;
 	minLabel: string;
 	maxLabel: string;
 }
@@ -21,38 +21,45 @@ interface ExRPairedOptionRowProps {
 export function ExRPairedOptionRow({
 	categoryId,
 	baseName,
-	min,
-	max,
+	minOptionId,
+	maxOptionId,
 	minLabel,
 	maxLabel,
 }: ExRPairedOptionRowProps) {
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
-	const minUniqueId = getUniqueOptionId(selectedExRTabId, categoryId, min.Id);
-	const maxUniqueId = getUniqueOptionId(selectedExRTabId, categoryId, max.Id);
+	const minUniqueId = getUniqueOptionId(selectedExRTabId, categoryId, minOptionId);
+	const maxUniqueId = getUniqueOptionId(selectedExRTabId, categoryId, maxOptionId);
 
-	const effectiveMinSelection = useStore((state) => {
-		return state.effectiveSelections[minUniqueId];
+	const minValueData = useStore((state) => {
+		return state.valueData[minUniqueId];
 	});
-	const effectiveMaxSelection = useStore((state) => {
-		return state.effectiveSelections[maxUniqueId];
+	const maxValueData = useStore((state) => {
+		return state.valueData[maxUniqueId];
 	});
 
-	const minSelection = effectiveMinSelection ?? min.Selection;
-	const maxSelection = effectiveMaxSelection ?? max.Selection;
+	const minSelection = minValueData?.selection ?? 0;
+	const maxSelection = maxValueData?.selection ?? 0;
 
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 
 	const handleMinChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(minUniqueId, newSelection);
+		updateExROptionSelection(minUniqueId, newSelection);
 	};
 
 	const handleMaxChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(maxUniqueId, newSelection);
+		updateExROptionSelection(maxUniqueId, newSelection);
 	};
+
+	const minMeta = exrOptionMetaData.optionMetaData[minUniqueId];
+	const maxMeta = exrOptionMetaData.optionMetaData[maxUniqueId];
+
+	if (!minValueData || !maxValueData || !minMeta || !maxMeta) {
+		return null;
+	}
 
 	const content = (
 		<OptionItem className="min-h-[4.5rem]">
@@ -65,9 +72,9 @@ export function ExRPairedOptionRow({
 				<OptionPairedSliderControl
 					minSelection={minSelection}
 					maxSelection={maxSelection}
-					minValues={min.RangeMeta.Values as number[]}
-					maxValues={max.RangeMeta.Values as number[]}
-					format={min.Format}
+					minValues={minValueData.values as number[]}
+					maxValues={maxValueData.values as number[]}
+					format={minMeta.format}
 					onMinChange={handleMinChange}
 					onMaxChange={handleMaxChange}
 					minLabel={minLabel}

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { ColoredText } from "../components/parts/ColoredText";
 import { exrOptionMetaData } from "../logics/api";
 import {
@@ -40,12 +41,22 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 		SPAWN_COUNT_OPTION_ID,
 	);
 
-	const spawnRateValueData = useStore((state) => {
-		return state.valueData[uniqueRateId];
-	});
-	const spawnCountValueData = useStore((state) => {
-		return state.valueData[uniqueCountId];
-	});
+	const spawnRateValueData = useStore(
+		useCallback(
+			(state) => {
+				return state.valueData[uniqueRateId];
+			},
+			[uniqueRateId],
+		),
+	);
+	const spawnCountValueData = useStore(
+		useCallback(
+			(state) => {
+				return state.valueData[uniqueCountId];
+			},
+			[uniqueCountId],
+		),
+	);
 
 	const spawnRateSelection = spawnRateValueData?.selection ?? 0;
 	const rateValues = (spawnRateValueData?.values as number[]) ?? [];

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -59,8 +59,15 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 		if (isPresetOption(categoryId, optionId)) {
 			return [];
 		}
-		if (optionId === SPAWN_RATE_OPTION_ID || optionId === SPAWN_COUNT_OPTION_ID) {
-			const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
+		if (
+			optionId === SPAWN_RATE_OPTION_ID ||
+			optionId === SPAWN_COUNT_OPTION_ID
+		) {
+			const uniqueId = getUniqueOptionId(
+				selectedExRTabId,
+				categoryId,
+				optionId,
+			);
 			const childUniqueIds = exrOptionMetaData.childOptionMap[uniqueId] ?? [];
 			return childUniqueIds.map((cid) => getOptionIdFromUniqueId(cid));
 		}

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -1,88 +1,90 @@
 import { ColoredText } from "../components/parts/ColoredText";
-import { getUniqueOptionId, isPresetOption } from "../logics/optionUtils";
-import type { ExRCategoryDto } from "../type";
+import { exrOptionMetaData } from "../logics/api";
+import {
+	getOptionIdFromUniqueId,
+	getUniqueOptionId,
+	isPresetOption,
+} from "../logics/optionUtils";
 import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../type";
 import { useStore } from "../useStore";
 import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
 import { ExRRoleSpawnControls } from "./ExRRoleSpawnControls";
 
 interface ExRRoleCategoryItemProps {
-	category: ExRCategoryDto;
+	categoryId: number;
 }
 
 /**
  * 役職タブで使用される、スポーン設定をヘッダーに持つカテゴリ表示コンポーネント
  */
-export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
+export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 	const isOpendCategory = useStore((state) => {
-		return state.openedExRCategoryIds[category.Id];
+		return state.openedExRCategoryIds[categoryId];
 	});
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
 	});
 
-	const spawnRateOption = category.Options.find((opt) => {
-		return opt.Id === SPAWN_RATE_OPTION_ID;
-	});
-	const spawnCountOption = category.Options.find((opt) => {
-		return opt.Id === SPAWN_COUNT_OPTION_ID;
-	});
-
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
+
 	const uniqueRateId = getUniqueOptionId(
 		selectedExRTabId,
-		category.Id,
+		categoryId,
 		SPAWN_RATE_OPTION_ID,
 	);
-	const effectiveSpawnRateSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueRateId];
+	const uniqueCountId = getUniqueOptionId(
+		selectedExRTabId,
+		categoryId,
+		SPAWN_COUNT_OPTION_ID,
+	);
+
+	const spawnRateValueData = useStore((state) => {
+		return state.valueData[uniqueRateId];
 	});
-	const spawnRateSelection =
-		effectiveSpawnRateSelection ?? spawnRateOption?.Selection ?? 0;
-	const rateValues = (spawnRateOption?.RangeMeta.Values as number[]) ?? [];
+	const spawnCountValueData = useStore((state) => {
+		return state.valueData[uniqueCountId];
+	});
+
+	const spawnRateSelection = spawnRateValueData?.selection ?? 0;
+	const rateValues = (spawnRateValueData?.values as number[]) ?? [];
 	const isSpawnRateZero = rateValues[spawnRateSelection] === 0;
 
 	const isOpen = !isSpawnRateZero && (isOpendCategory ?? false);
 
-	const allPotentialOptions = category.Options.flatMap((option) => {
-		if (isPresetOption(category.Id, option.Id)) {
+	const optionIds = exrOptionMetaData.optionIdMap[categoryId] ?? [];
+
+	const allPotentialOptionIds = optionIds.flatMap((optionId) => {
+		if (isPresetOption(categoryId, optionId)) {
 			return [];
 		}
-		if (
-			option.Id === SPAWN_RATE_OPTION_ID ||
-			option.Id === SPAWN_COUNT_OPTION_ID
-		) {
-			return option.Childs || [];
+		if (optionId === SPAWN_RATE_OPTION_ID || optionId === SPAWN_COUNT_OPTION_ID) {
+			const uniqueId = getUniqueOptionId(selectedExRTabId, categoryId, optionId);
+			const childUniqueIds = exrOptionMetaData.childOptionMap[uniqueId] ?? [];
+			return childUniqueIds.map((cid) => getOptionIdFromUniqueId(cid));
 		}
-		return [option];
+		return [optionId];
 	});
 
 	// ID 50 と 51 を除外しつつ、重複（トップレベルと子要素の両方に存在する場合など）を排除
-	const filteredOptions = allPotentialOptions.filter((option, index, self) => {
-		if (
-			option.Id === SPAWN_RATE_OPTION_ID ||
-			option.Id === SPAWN_COUNT_OPTION_ID
-		) {
+	const filteredOptionIds = allPotentialOptionIds.filter((id, index, self) => {
+		if (id === SPAWN_RATE_OPTION_ID || id === SPAWN_COUNT_OPTION_ID) {
 			return false;
 		}
-		return (
-			index ===
-			self.findIndex((o) => {
-				return o.Id === option.Id;
-			})
-		);
+		return index === self.indexOf(id);
 	});
 
-	if (filteredOptions.length === 0) {
+	if (filteredOptionIds.length === 0) {
 		return null;
 	}
+
+	const categoryName = exrOptionMetaData.categoryInfo[categoryId] ?? "";
 
 	return (
 		<div
 			className="border border-gray-700 rounded-lg overflow-hidden mb-2"
-			data-testid={`exr-category-${category.Id}`}
+			data-testid={`exr-category-${categoryId}`}
 		>
 			<div
 				className={`flex items-center bg-gray-800 ${!isSpawnRateZero ? "hover:bg-gray-700 transition-colors" : ""}`}
@@ -91,7 +93,7 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 					type="button"
 					onClick={() => {
 						if (!isSpawnRateZero) {
-							toggleExRCategory(category.Id);
+							toggleExRCategory(categoryId);
 						}
 					}}
 					className={`flex-1 flex items-center gap-3 p-4 text-left ${isSpawnRateZero ? "cursor-default" : ""}`}
@@ -119,17 +121,13 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 						</svg>
 					)}
 					<span className="font-semibold text-gray-200">
-						<ColoredText text={category.Name} />
+						<ColoredText text={categoryName} />
 					</span>
 				</button>
 
 				<div className="flex items-center px-4">
-					{spawnRateOption && spawnCountOption && (
-						<ExRRoleSpawnControls
-							categoryId={category.Id}
-							spawnRateOption={spawnRateOption}
-							spawnCountOption={spawnCountOption}
-						/>
+					{spawnRateValueData && spawnCountValueData && (
+						<ExRRoleSpawnControls categoryId={categoryId} />
 					)}
 				</div>
 			</div>
@@ -143,8 +141,8 @@ export function ExRRoleCategoryItem({ category }: ExRRoleCategoryItemProps) {
 					{isOpen && (
 						<div className="p-4 bg-gray-900 border-t border-gray-700">
 							<ExRCategoryOptionList
-								categoryId={category.Id}
-								options={filteredOptions}
+								categoryId={categoryId}
+								optionIds={filteredOptionIds}
 							/>
 						</div>
 					)}

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -1,23 +1,16 @@
 import { CompactSlider } from "../components/parts/CompactSlider";
 import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
-import type { ExROptionDto } from "../type";
 import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../type";
 import { useStore } from "../useStore";
 
 interface ExRRoleSpawnControlsProps {
 	categoryId: number;
-	spawnRateOption: ExROptionDto;
-	spawnCountOption: ExROptionDto;
 }
 
 /**
  * 役職のスポーンレートとスポーン数をセットで管理し、同期させるためのコンポーネント
  */
-export function ExRRoleSpawnControls({
-	categoryId,
-	spawnRateOption,
-	spawnCountOption,
-}: ExRRoleSpawnControlsProps) {
+export function ExRRoleSpawnControls({ categoryId }: ExRRoleSpawnControlsProps) {
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
@@ -32,16 +25,16 @@ export function ExRRoleSpawnControls({
 		SPAWN_COUNT_OPTION_ID,
 	);
 
-	const effectiveSpawnRateSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueRateId];
+	const spawnRateValueData = useStore((state) => {
+		return state.valueData[uniqueRateId];
 	});
 
-	const effectiveSpawnCountSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueCountId];
+	const spawnCountValueData = useStore((state) => {
+		return state.valueData[uniqueCountId];
 	});
 
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
@@ -50,13 +43,11 @@ export function ExRRoleSpawnControls({
 		return state.openedExRCategoryIds[categoryId] ?? false;
 	});
 
-	const spawnRateSelection =
-		effectiveSpawnRateSelection ?? spawnRateOption.Selection;
-	const spawnCountSelection =
-		effectiveSpawnCountSelection ?? spawnCountOption.Selection;
+	const spawnRateSelection = spawnRateValueData?.selection ?? 0;
+	const spawnCountSelection = spawnCountValueData?.selection ?? 0;
 
-	const rateValues = spawnRateOption.RangeMeta.Values as number[];
-	const originalCountValues = spawnCountOption.RangeMeta.Values as number[];
+	const rateValues = (spawnRateValueData?.values as number[]) ?? [];
+	const originalCountValues = (spawnCountValueData?.values as number[]) ?? [];
 
 	// スポーン数が0をサポートするための仮想的な値リスト
 	const virtualCountValues = [0, ...originalCountValues];
@@ -66,11 +57,11 @@ export function ExRRoleSpawnControls({
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
 	const handleRateChange = (newSelection: number) => {
-		TEMP_updateExROptionSelection(uniqueRateId, newSelection);
+		updateExROptionSelection(uniqueRateId, newSelection);
 
 		// スポーンレートが0%なら、スポーン数も0としてリセット
 		if (rateValues[newSelection] === 0) {
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			updateExROptionSelection(uniqueCountId, 0);
 			if (isOpenedCategory) {
 				toggleExRCategory(categoryId);
 			}
@@ -84,23 +75,23 @@ export function ExRRoleSpawnControls({
 	const handleCountUIChange = (newUISelection: number) => {
 		if (newUISelection === 0) {
 			// 数を0にすると、レートも0%にする
-			TEMP_updateExROptionSelection(
+			updateExROptionSelection(
 				uniqueRateId,
 				findClosestIndex(rateValues, 0),
 			);
-			TEMP_updateExROptionSelection(uniqueCountId, 0);
+			updateExROptionSelection(uniqueCountId, 0);
 			if (isOpenedCategory) {
 				toggleExRCategory(categoryId);
 			}
 		} else {
 			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
 			if (isSpawnRateZero) {
-				TEMP_updateExROptionSelection(
+				updateExROptionSelection(
 					uniqueRateId,
 					findClosestIndex(rateValues, 10),
 				);
 			}
-			TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
+			updateExROptionSelection(uniqueCountId, newUISelection - 1);
 		}
 	};
 

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -10,7 +10,9 @@ interface ExRRoleSpawnControlsProps {
 /**
  * 役職のスポーンレートとスポーン数をセットで管理し、同期させるためのコンポーネント
  */
-export function ExRRoleSpawnControls({ categoryId }: ExRRoleSpawnControlsProps) {
+export function ExRRoleSpawnControls({
+	categoryId,
+}: ExRRoleSpawnControlsProps) {
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
@@ -33,8 +35,8 @@ export function ExRRoleSpawnControls({ categoryId }: ExRRoleSpawnControlsProps) 
 		return state.valueData[uniqueCountId];
 	});
 
-	const updateExROptionSelection = useStore((state) => {
-		return state.updateExROptionSelection;
+	const TEMP_updateExROptionSelection = useStore((state) => {
+		return state.TEMP_updateExROptionSelection;
 	});
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
@@ -57,11 +59,11 @@ export function ExRRoleSpawnControls({ categoryId }: ExRRoleSpawnControlsProps) 
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
 	const handleRateChange = (newSelection: number) => {
-		updateExROptionSelection(uniqueRateId, newSelection);
+		TEMP_updateExROptionSelection(uniqueRateId, newSelection);
 
 		// スポーンレートが0%なら、スポーン数も0としてリセット
 		if (rateValues[newSelection] === 0) {
-			updateExROptionSelection(uniqueCountId, 0);
+			TEMP_updateExROptionSelection(uniqueCountId, 0);
 			if (isOpenedCategory) {
 				toggleExRCategory(categoryId);
 			}
@@ -75,23 +77,23 @@ export function ExRRoleSpawnControls({ categoryId }: ExRRoleSpawnControlsProps) 
 	const handleCountUIChange = (newUISelection: number) => {
 		if (newUISelection === 0) {
 			// 数を0にすると、レートも0%にする
-			updateExROptionSelection(
+			TEMP_updateExROptionSelection(
 				uniqueRateId,
 				findClosestIndex(rateValues, 0),
 			);
-			updateExROptionSelection(uniqueCountId, 0);
+			TEMP_updateExROptionSelection(uniqueCountId, 0);
 			if (isOpenedCategory) {
 				toggleExRCategory(categoryId);
 			}
 		} else {
 			// 数が0以外に変更されたとき、現在レートが0%なら10%に上げる
 			if (isSpawnRateZero) {
-				updateExROptionSelection(
+				TEMP_updateExROptionSelection(
 					uniqueRateId,
 					findClosestIndex(rateValues, 10),
 				);
 			}
-			updateExROptionSelection(uniqueCountId, newUISelection - 1);
+			TEMP_updateExROptionSelection(uniqueCountId, newUISelection - 1);
 		}
 	};
 

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { CompactSlider } from "../components/parts/CompactSlider";
 import { findClosestIndex, getUniqueOptionId } from "../logics/optionUtils";
 import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../type";
@@ -27,13 +28,23 @@ export function ExRRoleSpawnControls({
 		SPAWN_COUNT_OPTION_ID,
 	);
 
-	const spawnRateValueData = useStore((state) => {
-		return state.valueData[uniqueRateId];
-	});
+	const spawnRateValueData = useStore(
+		useCallback(
+			(state) => {
+				return state.valueData[uniqueRateId];
+			},
+			[uniqueRateId],
+		),
+	);
 
-	const spawnCountValueData = useStore((state) => {
-		return state.valueData[uniqueCountId];
-	});
+	const spawnCountValueData = useStore(
+		useCallback(
+			(state) => {
+				return state.valueData[uniqueCountId];
+			},
+			[uniqueCountId],
+		),
+	);
 
 	const TEMP_updateExROptionSelection = useStore((state) => {
 		return state.TEMP_updateExROptionSelection;

--- a/src/feature/ExRStandardCategoryItem.tsx
+++ b/src/feature/ExRStandardCategoryItem.tsx
@@ -1,47 +1,50 @@
 import { Accordion } from "../components/parts/Accordion";
 import { ColoredText } from "../components/parts/ColoredText";
+import { exrOptionMetaData } from "../logics/api";
 import { isPresetOption } from "../logics/optionUtils";
-import type { ExRCategoryDto } from "../type";
 import { useStore } from "../useStore";
 import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
 
 interface ExRStandardCategoryItemProps {
-	category: ExRCategoryDto;
+	categoryId: number;
 }
 
 /**
  * 全般タブなどで使用される標準的なカテゴリ表示コンポーネント
  */
 export function ExRStandardCategoryItem({
-	category,
+	categoryId,
 }: ExRStandardCategoryItemProps) {
 	const isOpen = useStore((state) => {
-		return state.openedExRCategoryIds[category.Id] ?? false;
+		return state.openedExRCategoryIds[categoryId] ?? false;
 	});
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
 	});
 
-	const filteredOptions = category.Options.filter((option) => {
-		return !isPresetOption(category.Id, option.Id);
+	const categoryName = exrOptionMetaData.categoryInfo[categoryId] ?? "";
+	const optionIds = exrOptionMetaData.optionIdMap[categoryId] ?? [];
+
+	const filteredOptionIds = optionIds.filter((optionId) => {
+		return !isPresetOption(categoryId, optionId);
 	});
 
-	if (filteredOptions.length === 0) {
+	if (filteredOptionIds.length === 0) {
 		return null;
 	}
 
 	return (
-		<div data-testid={`exr-category-${category.Id}`}>
+		<div data-testid={`exr-category-${categoryId}`}>
 			<Accordion
-				title={<ColoredText text={category.Name} />}
+				title={<ColoredText text={categoryName} />}
 				isOpen={isOpen}
 				onToggle={() => {
-					toggleExRCategory(category.Id);
+					toggleExRCategory(categoryId);
 				}}
 			>
 				<ExRCategoryOptionList
-					categoryId={category.Id}
-					options={filteredOptions}
+					categoryId={categoryId}
+					optionIds={filteredOptionIds}
 				/>
 			</Accordion>
 		</div>

--- a/src/feature/ExRTabSelector.tsx
+++ b/src/feature/ExRTabSelector.tsx
@@ -37,7 +37,9 @@ export function ExRTabSelector() {
 		});
 	};
 
-	const tabIds = Object.keys(exrOptionMetaData.tabInfo).map(Number) as OptionTab[];
+	const tabIds = Object.keys(exrOptionMetaData.tabInfo).map(
+		Number,
+	) as OptionTab[];
 
 	return (
 		<div className="flex flex-wrap gap-2 border-b border-gray-200 pb-2">

--- a/src/feature/ExRTabSelector.tsx
+++ b/src/feature/ExRTabSelector.tsx
@@ -1,16 +1,13 @@
 import { useEffect, useTransition } from "react";
 import { ColoredText } from "../components/parts/ColoredText";
-import type { ExRTabDto, OptionTab } from "../type";
+import { exrOptionMetaData } from "../logics/api";
+import type { OptionTab } from "../type";
 import { useStore } from "../useStore";
-
-interface ExRTabSelectorProps {
-	tabs: ExRTabDto[];
-}
 
 /**
  * ExRオプションのタブ選択コンポーネント
  */
-export function ExRTabSelector({ tabs }: ExRTabSelectorProps) {
+export function ExRTabSelector() {
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
 	});
@@ -40,22 +37,25 @@ export function ExRTabSelector({ tabs }: ExRTabSelectorProps) {
 		});
 	};
 
+	const tabIds = Object.keys(exrOptionMetaData.tabInfo).map(Number) as OptionTab[];
+
 	return (
 		<div className="flex flex-wrap gap-2 border-b border-gray-200 pb-2">
-			{tabs.map((tab) => {
+			{tabIds.map((tabId) => {
+				const tabName = exrOptionMetaData.tabInfo[tabId];
 				return (
 					<button
-						key={tab.Id}
+						key={tabId}
 						type="button"
 						onClick={() => {
-							handleClick(tab.Id);
+							handleClick(tabId);
 						}}
 						className={`
               px-4 py-2 rounded-t-lg transition-colors font-medium
-              ${selectedExRTabId === tab.Id ? "bg-blue-500 text-white" : "bg-gray-200 text-gray-700 hover:bg-gray-300"}
+              ${selectedExRTabId === tabId ? "bg-blue-500 text-white" : "bg-gray-200 text-gray-700 hover:bg-gray-300"}
             `}
 					>
-						<ColoredText text={tab.Name} />
+						<ColoredText text={tabName} />
 					</button>
 				);
 			})}

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -26,8 +26,8 @@ export function PresetSelector() {
 	const updatePresetName = useStore((state) => {
 		return state.updatePresetName;
 	});
-	const updateExROptionSelection = useStore((state) => {
-		return state.updateExROptionSelection;
+	const TEMP_updateExROptionSelection = useStore((state) => {
+		return state.TEMP_updateExROptionSelection;
 	});
 	const setPresetDropdownOpen = useStore((state) => {
 		return state.setPresetDropdownOpen;
@@ -62,7 +62,7 @@ export function PresetSelector() {
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
 	const handlePresetSelect = (index: number) => {
-		updateExROptionSelection(uniqueId, index);
+		TEMP_updateExROptionSelection(uniqueId, index);
 		setPresetDropdownOpen(false);
 	};
 

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { getUniqueOptionId } from "../logics/optionUtils";
 import { useStore } from "../useStore";
 
@@ -12,9 +12,14 @@ import { useStore } from "../useStore";
  */
 export function PresetSelector() {
 	const uniqueId = getUniqueOptionId(0, 0, 0);
-	const valueData = useStore((state) => {
-		return state.valueData[uniqueId];
-	});
+	const valueData = useStore(
+		useCallback(
+			(state) => {
+				return state.valueData[uniqueId];
+			},
+			[uniqueId],
+		),
+	);
 	const currentSelection = valueData?.selection ?? 0;
 
 	const presetNames = useStore((state) => {

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useRef } from "react";
 import { getUniqueOptionId } from "../logics/optionUtils";
-import type { ExRTabDto } from "../type";
 import { useStore } from "../useStore";
-
-interface PresetSelectorProps {
-	tabs: ExRTabDto[];
-}
 
 /**
  * プリセットを選択・編集するためのコンポーネント。
@@ -15,23 +10,12 @@ interface PresetSelectorProps {
  * 入力更新の最適化:
  * ユーザー入力ごとの Cookie 書き込みを避けるため、onBlur または Enter キー入力時に更新を行います。
  */
-export function PresetSelector({ tabs }: PresetSelectorProps) {
-	// GeneralTab (Id: 0) から プリセットカテゴリ (Id: 0) を探す
-	const generalTab = tabs.find((t) => {
-		return t.Id === 0;
-	});
-	const presetCategory = generalTab?.Categories.find((c) => {
-		return c.Id === 0;
-	});
-	const presetOption = presetCategory?.Options.find((o) => {
-		return o.Id === 0;
-	});
-
+export function PresetSelector() {
 	const uniqueId = getUniqueOptionId(0, 0, 0);
-	const effectiveSelection = useStore((state) => {
-		return state.effectiveSelections[uniqueId];
+	const valueData = useStore((state) => {
+		return state.valueData[uniqueId];
 	});
-	const currentSelection = effectiveSelection ?? presetOption?.Selection ?? 0;
+	const currentSelection = valueData?.selection ?? 0;
 
 	const presetNames = useStore((state) => {
 		return state.presetNames;
@@ -42,8 +26,8 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 	const updatePresetName = useStore((state) => {
 		return state.updatePresetName;
 	});
-	const TEMP_updateExROptionSelection = useStore((state) => {
-		return state.TEMP_updateExROptionSelection;
+	const updateExROptionSelection = useStore((state) => {
+		return state.updateExROptionSelection;
 	});
 	const setPresetDropdownOpen = useStore((state) => {
 		return state.setPresetDropdownOpen;
@@ -68,17 +52,17 @@ export function PresetSelector({ tabs }: PresetSelectorProps) {
 		};
 	}, [setPresetDropdownOpen]);
 
-	if (!presetOption) {
+	if (!valueData) {
 		return null;
 	}
 
-	const presetValues = presetOption.RangeMeta.Values as number[];
+	const presetValues = valueData.values as number[];
 	const currentPresetValue = presetValues[currentSelection];
 	const currentPresetName =
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
 	const handlePresetSelect = (index: number) => {
-		TEMP_updateExROptionSelection(uniqueId, index);
+		updateExROptionSelection(uniqueId, index);
 		setPresetDropdownOpen(false);
 	};
 

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -158,6 +158,6 @@ export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
 /**
  * 両方のオプションをまとめて取得する
  */
-export function getAllOptions(): Promise<[undefined, AuOptionCategoryDto[]]> {
+export function getAllOptions(): Promise<[void, AuOptionCategoryDto[]]> {
 	return Promise.all([getInitialLoadPromise(), getAuOptions()]);
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -1,9 +1,13 @@
+import { useStore } from "../useStore";
 import type {
 	AuOptionCategoryDto,
+	ExROptionDto,
 	ExROptionMetaDataRecords,
+	ExROptionValueData,
 	ExRTabDto,
 	OptionTab,
 } from "../type";
+import { getUniqueOptionId } from "./optionUtils";
 
 /**
  * API エンドポイントの定数定義
@@ -15,10 +19,10 @@ const AU_OPTION_URL = "/au/option/";
  * APIからデータを取得するPromiseをキャッシュするためのグローバル変数
  * React 19 の use() で扱うためにリクエストを一度だけ実行するようにします
  */
-let exrOptionsPromise: Promise<ExRTabDto[]> | null = null;
+let initialLoadPromise: Promise<void> | null = null;
 let auOptionsPromise: Promise<AuOptionCategoryDto[]> | null = null;
 
-const _exrOptionMetaData: ExROptionMetaDataRecords = {
+export const exrOptionMetaData: ExROptionMetaDataRecords = {
 	// OptionTabはAPIから取得したデータに基づいて動的に構築され全てあることが保証されるため、初期値は空のオブジェクトで問題ありません
 	tabInfo: {} as Record<OptionTab, string>,
 	categoryIdMap: {} as Record<OptionTab, number[]>,
@@ -32,22 +36,22 @@ const _exrOptionMetaData: ExROptionMetaDataRecords = {
  * キャッシュをリセットする（テスト用）
  */
 export function resetApiCache() {
-	exrOptionsPromise = null;
+	initialLoadPromise = null;
 	auOptionsPromise = null;
 }
 
 /**
- * ExRオプションを取得する
+ * ExRオプションを取得し、メタデータとストアに分割する
  */
-export function getExrOptions(): Promise<ExRTabDto[]> {
-	if (exrOptionsPromise) {
-		return exrOptionsPromise;
+export function getInitialLoadPromise(): Promise<void> {
+	if (initialLoadPromise) {
+		return initialLoadPromise;
 	}
 
 	// @ts-expect-error - テスト用
 	const delay = typeof window !== "undefined" ? window.__API_DELAY__ || 0 : 0;
 
-	exrOptionsPromise = (async () => {
+	initialLoadPromise = (async () => {
 		if (delay > 0) {
 			await new Promise((resolve) => {
 				return setTimeout(resolve, delay);
@@ -57,10 +61,71 @@ export function getExrOptions(): Promise<ExRTabDto[]> {
 		if (!res.ok) {
 			throw new Error(`Failed to fetch ExR options: ${res.statusText}`);
 		}
-		return res.json();
+		const data: ExRTabDto[] = await res.json();
+
+		const valueData: Record<number, ExROptionValueData> = {};
+		const isOptionActive: Record<number, boolean> = {};
+
+		const processOptions = (
+			options: ExROptionDto[],
+			tabId: OptionTab,
+			categoryId: number,
+			parentOptionId: number | null,
+		) => {
+			const optionIds: number[] = [];
+			for (const opt of options) {
+				const uniqueId = getUniqueOptionId(tabId, categoryId, opt.Id);
+				optionIds.push(opt.Id);
+
+				exrOptionMetaData.optionMetaData[uniqueId] = {
+					translatedName: opt.TranslatedName,
+					format: opt.Format,
+					type: opt.RangeMeta.Type,
+				};
+
+				valueData[uniqueId] = {
+					selection: opt.Selection,
+					values: opt.RangeMeta.Values,
+				};
+				isOptionActive[uniqueId] = opt.IsActive;
+
+				if (parentOptionId !== null) {
+					const parentUniqueId = getUniqueOptionId(
+						tabId,
+						categoryId,
+						parentOptionId,
+					);
+					if (!exrOptionMetaData.childOptionMap[parentUniqueId]) {
+						exrOptionMetaData.childOptionMap[parentUniqueId] = [];
+					}
+					exrOptionMetaData.childOptionMap[parentUniqueId].push(uniqueId);
+				}
+
+				if (opt.Childs && opt.Childs.length > 0) {
+					processOptions(opt.Childs, tabId, categoryId, opt.Id);
+				}
+			}
+			return optionIds;
+		};
+
+		for (const tab of data) {
+			exrOptionMetaData.tabInfo[tab.Id] = tab.Name;
+			exrOptionMetaData.categoryIdMap[tab.Id] = tab.Categories.map((c) => c.Id);
+			for (const category of tab.Categories) {
+				exrOptionMetaData.categoryInfo[category.Id] = category.Name;
+				exrOptionMetaData.optionIdMap[category.Id] = processOptions(
+					category.Options,
+					tab.Id,
+					category.Id,
+					null,
+				);
+			}
+		}
+
+		useStore.getState().setExROptions(valueData, isOptionActive);
 	})();
 
-	return exrOptionsPromise;
+	return initialLoadPromise;
 }
 
 /**
@@ -93,6 +158,6 @@ export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
 /**
  * 両方のオプションをまとめて取得する
  */
-export function getAllOptions(): Promise<[ExRTabDto[], AuOptionCategoryDto[]]> {
-	return Promise.all([getExrOptions(), getAuOptions()]);
+export function getAllOptions(): Promise<[void, AuOptionCategoryDto[]]> {
+	return Promise.all([getInitialLoadPromise(), getAuOptions()]);
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -1,4 +1,3 @@
-import { useStore } from "../useStore";
 import type {
 	AuOptionCategoryDto,
 	ExROptionDto,
@@ -7,6 +6,7 @@ import type {
 	ExRTabDto,
 	OptionTab,
 } from "../type";
+import { useStore } from "../useStore";
 import { getUniqueOptionId } from "./optionUtils";
 
 /**
@@ -158,6 +158,6 @@ export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
 /**
  * 両方のオプションをまとめて取得する
  */
-export function getAllOptions(): Promise<[void, AuOptionCategoryDto[]]> {
+export function getAllOptions(): Promise<[undefined, AuOptionCategoryDto[]]> {
 	return Promise.all([getInitialLoadPromise(), getAuOptions()]);
 }

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -13,6 +13,13 @@ export function getUniqueOptionId(
 }
 
 /**
+ * 一意な数値IDから元のオプションIDを抽出します。
+ */
+export function getOptionIdFromUniqueId(uniqueId: number): number {
+	return uniqueId % 10_000;
+}
+
+/**
  * 指定されたカテゴリIDとオプションIDがプリセット設定（Category 0, Option 0）であるか判定します。
  */
 export function isPresetOption(categoryId: number, optionId: number): boolean {

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -21,7 +21,10 @@ export interface OptionViewerSlice {
 	setIsTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: number) => void;
-	updateExROptionSelection: (uniqueOptionId: number, selection: number) => void;
+	TEMP_updateExROptionSelection: (
+		uniqueOptionId: number,
+		selection: number,
+	) => void;
 	setExROptions: (
 		valueData: Record<number, ExROptionValueData>,
 		isOptionActive: Record<number, boolean>,
@@ -83,7 +86,10 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				};
 			});
 		},
-		updateExROptionSelection: (uniqueOptionId: number, selection: number) => {
+		TEMP_updateExROptionSelection: (
+			uniqueOptionId: number,
+			selection: number,
+		) => {
 			set((state) => {
 				const current = state.valueData[uniqueOptionId];
 				if (!current) {

--- a/src/slices/optionViewerSlice.ts
+++ b/src/slices/optionViewerSlice.ts
@@ -3,7 +3,7 @@ import {
 	loadPresetNamesFromCookie,
 	savePresetNamesToCookie,
 } from "../logics/cookieUtils";
-import type { OptionTab } from "../type";
+import type { ExROptionValueData, OptionTab } from "../type";
 
 /**
  * オプション表示エリア（ExR オプションのタブなど）の状態を管理するスライスのインターフェース
@@ -13,16 +13,18 @@ export interface OptionViewerSlice {
 	isTabPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<number, boolean>;
-	effectiveSelections: Record<number, number>;
+	valueData: Record<number, ExROptionValueData>;
+	isOptionActive: Record<number, boolean>;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
 	setSelectedExRTabId: (id: OptionTab) => void;
 	setIsTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: number) => void;
-	TEMP_updateExROptionSelection: (
-		uniqueOptionId: number,
-		selection: number,
+	updateExROptionSelection: (uniqueOptionId: number, selection: number) => void;
+	setExROptions: (
+		valueData: Record<number, ExROptionValueData>,
+		isOptionActive: Record<number, boolean>,
 	) => void;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
@@ -40,7 +42,8 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 		isTabPending: false,
 		openedExRCategoryIds: {},
 		openedExROptionIds: {},
-		effectiveSelections: {},
+		valueData: {},
+		isOptionActive: {},
 		presetNames: loadPresetNamesFromCookie(),
 		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: OptionTab) => {
@@ -55,7 +58,8 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				isTabPending: false,
 				openedExRCategoryIds: {},
 				openedExROptionIds: {},
-				effectiveSelections: {},
+				valueData: {},
+				isOptionActive: {},
 				isPresetDropdownOpen: false,
 			});
 		},
@@ -79,18 +83,25 @@ export const createOptionViewerSlice: StateCreator<OptionViewerSlice> = (
 				};
 			});
 		},
-		TEMP_updateExROptionSelection: (
-			uniqueOptionId: number,
-			selection: number,
-		) => {
+		updateExROptionSelection: (uniqueOptionId: number, selection: number) => {
 			set((state) => {
+				const current = state.valueData[uniqueOptionId];
+				if (!current) {
+					return state;
+				}
 				return {
-					effectiveSelections: {
-						...state.effectiveSelections,
-						[uniqueOptionId]: selection,
+					valueData: {
+						...state.valueData,
+						[uniqueOptionId]: {
+							...current,
+							selection,
+						},
 					},
 				};
 			});
+		},
+		setExROptions: (valueData, isOptionActive) => {
+			set({ valueData, isOptionActive });
 		},
 		updatePresetName: (presetIndex: number, name: string) => {
 			set((state) => {

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRCategoryList } from "../src/feature/ExRCategoryList";
+import { getInitialLoadPromise, resetApiCache } from "../src/logics/api";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
 import {
 	type ExRTabDto,
@@ -74,13 +75,26 @@ describe("ExRCategoryList Component Selection", () => {
 		},
 	];
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		resetApiCache();
 		useStore.getState().resetViewer();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve(mockTabs),
+				}),
+			),
+		);
+		await act(async () => {
+			await getInitialLoadPromise();
+		});
 	});
 
 	it("renders ExRStandardCategoryItem for General Tab", () => {
 		useStore.getState().setSelectedExRTabId(OptionTab.GeneralTab);
-		render(<ExRCategoryList tabs={mockTabs} />);
+		render(<ExRCategoryList />);
 
 		// General Tab: Should render standard category
 		expect(screen.getByText("General Category")).toBeInTheDocument();
@@ -91,7 +105,7 @@ describe("ExRCategoryList Component Selection", () => {
 
 	it("renders ExRRoleCategoryItem for Role Tab", () => {
 		useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
-		render(<ExRCategoryList tabs={mockTabs} />);
+		render(<ExRCategoryList />);
 
 		// Role Tab: Should render specialized category item
 		expect(screen.getByText("Sheriff")).toBeInTheDocument();
@@ -105,11 +119,11 @@ describe("ExRCategoryList Component Selection", () => {
 		// Set a non-zero spawn rate so the accordion is enabled
 		useStore
 			.getState()
-			.TEMP_updateExROptionSelection(
+			.updateExROptionSelection(
 				getUniqueOptionId(OptionTab.CrewmateTab, 2, SPAWN_RATE_OPTION_ID),
 				1,
 			); // Category 2, Option 50, Index 1 (Value 100)
-		render(<ExRCategoryList tabs={mockTabs} />);
+		render(<ExRCategoryList />);
 
 		// Open accordion - RoleCategoryItem uses a custom layout,
 		// we find the toggle button by role.

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, act } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRCategoryList } from "../src/feature/ExRCategoryList";
 import { getInitialLoadPromise, resetApiCache } from "../src/logics/api";
@@ -119,7 +119,7 @@ describe("ExRCategoryList Component Selection", () => {
 		// Set a non-zero spawn rate so the accordion is enabled
 		useStore
 			.getState()
-			.updateExROptionSelection(
+			.TEMP_updateExROptionSelection(
 				getUniqueOptionId(OptionTab.CrewmateTab, 2, SPAWN_RATE_OPTION_ID),
 				1,
 			); // Category 2, Option 50, Index 1 (Value 100)

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -1,31 +1,59 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, act } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
+import { getInitialLoadPromise, resetApiCache } from "../src/logics/api";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
-import type { ExROptionDto } from "../src/type";
+import type { ExRTabDto } from "../src/type";
 import { SPAWN_RATE_OPTION_ID } from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("ExRHeaderOptionControl", () => {
-	const mockOption: ExROptionDto = {
-		Id: SPAWN_RATE_OPTION_ID,
-		IsActive: true,
-		TranslatedName: "レート",
-		Selection: 0,
-		Format: "{0}%",
-		RangeMeta: { Type: "Int32", Values: [0, 50, 100] },
-		Childs: [],
-	};
+	const mockTabs: ExRTabDto[] = [
+		{
+			Id: 0,
+			Name: "General",
+			Categories: [
+				{
+					Id: 1,
+					Name: "Category 1",
+					Options: [
+						{
+							Id: SPAWN_RATE_OPTION_ID,
+							IsActive: true,
+							TranslatedName: "レート",
+							Selection: 0,
+							Format: "{0}%",
+							RangeMeta: { Type: "Int32", Values: [0, 50, 100] },
+							Childs: [],
+						},
+					],
+				},
+			],
+		},
+	];
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		resetApiCache();
 		useStore.getState().resetViewer();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve(mockTabs),
+				}),
+			),
+		);
+		await act(async () => {
+			await getInitialLoadPromise();
+		});
 	});
 
 	it("renders correctly with given label and value", () => {
 		render(
 			<ExRHeaderOptionControl
 				categoryId={1}
-				option={mockOption}
+				optionId={SPAWN_RATE_OPTION_ID}
 				label="Rate"
 			/>,
 		);
@@ -44,7 +72,7 @@ describe("ExRHeaderOptionControl", () => {
 		render(
 			<ExRHeaderOptionControl
 				categoryId={1}
-				option={mockOption}
+				optionId={SPAWN_RATE_OPTION_ID}
 				label="Rate"
 			/>,
 		);
@@ -56,9 +84,7 @@ describe("ExRHeaderOptionControl", () => {
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
 		expect(
-			state.effectiveSelections[
-				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)
-			],
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)].selection,
 		).toBe(1);
 	});
 
@@ -66,7 +92,7 @@ describe("ExRHeaderOptionControl", () => {
 		render(
 			<ExRHeaderOptionControl
 				categoryId={1}
-				option={mockOption}
+				optionId={SPAWN_RATE_OPTION_ID}
 				label="Rate"
 			/>,
 		);
@@ -84,9 +110,7 @@ describe("ExRHeaderOptionControl", () => {
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
 		expect(
-			state.effectiveSelections[
-				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)
-			],
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)].selection,
 		).toBe(2); // 100 is at index 2
 	});
 
@@ -101,7 +125,7 @@ describe("ExRHeaderOptionControl", () => {
 			>
 				<ExRHeaderOptionControl
 					categoryId={1}
-					option={mockOption}
+					optionId={SPAWN_RATE_OPTION_ID}
 					label="Rate"
 				/>
 			</button>,

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, act } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
 import { getInitialLoadPromise, resetApiCache } from "../src/logics/api";
@@ -84,7 +84,8 @@ describe("ExRHeaderOptionControl", () => {
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
 		expect(
-			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)].selection,
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)]
+				.selection,
 		).toBe(1);
 	});
 
@@ -110,7 +111,8 @@ describe("ExRHeaderOptionControl", () => {
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
 		expect(
-			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)].selection,
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)]
+				.selection,
 		).toBe(2); // 100 is at index 2
 	});
 

--- a/tests/ExROptionEditor.test.tsx
+++ b/tests/ExROptionEditor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, act } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExROptionEditor } from "../src/feature/ExROptionEditor";
 import { getInitialLoadPromise, resetApiCache } from "../src/logics/api";

--- a/tests/ExROptionEditor.test.tsx
+++ b/tests/ExROptionEditor.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExROptionEditor } from "../src/feature/ExROptionEditor";
+import { getInitialLoadPromise, resetApiCache } from "../src/logics/api";
 import type { ExRTabDto } from "../src/type";
 import { useStore } from "../src/useStore";
 
@@ -85,12 +86,25 @@ describe("ExROptionEditor", () => {
 		},
 	];
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		resetApiCache();
 		useStore.getState().resetViewer();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve(mockData),
+				}),
+			),
+		);
+		await act(async () => {
+			await getInitialLoadPromise();
+		});
 	});
 
 	it("should only show visible categories (not empty, at least one active option) and hide preset", () => {
-		render(<ExROptionEditor data={mockData} />);
+		render(<ExROptionEditor />);
 
 		expect(screen.getByText("Category 1")).toBeInTheDocument();
 		expect(screen.queryByText("Empty Category")).not.toBeInTheDocument();
@@ -101,7 +115,7 @@ describe("ExROptionEditor", () => {
 	});
 
 	it("should switch tabs and show correct categories", () => {
-		const { unmount } = render(<ExROptionEditor data={mockData} />);
+		const { unmount } = render(<ExROptionEditor />);
 
 		expect(screen.getByText("Category 1")).toBeInTheDocument();
 
@@ -114,7 +128,7 @@ describe("ExROptionEditor", () => {
 	});
 
 	it("should toggle accordion and show options UI", () => {
-		const { unmount } = render(<ExROptionEditor data={mockData} />);
+		const { unmount } = render(<ExROptionEditor />);
 
 		const categoryButton = screen.getByText("Category 1");
 

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,57 +1,72 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
+import { getInitialLoadPromise, resetApiCache } from "../src/logics/api";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
-import type { ExROptionDto } from "../src/type";
+import type { ExRTabDto } from "../src/type";
 import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("ExRRoleSpawnControls", () => {
-	const spawnRateOption: ExROptionDto = {
-		Id: SPAWN_RATE_OPTION_ID,
-		IsActive: true,
-		TranslatedName: "レート",
-		Selection: 0,
-		Format: "{0}%",
-		RangeMeta: { Type: "Int32", Values: [0, 10, 20, 30] },
-		Childs: [],
-	};
+	const mockTabs: ExRTabDto[] = [
+		{
+			Id: 0,
+			Name: "General",
+			Categories: [
+				{
+					Id: 1,
+					Name: "Sheriff",
+					Options: [
+						{
+							Id: SPAWN_RATE_OPTION_ID,
+							IsActive: true,
+							TranslatedName: "レート",
+							Selection: 0,
+							Format: "{0}%",
+							RangeMeta: { Type: "Int32", Values: [0, 10, 20, 30] },
+							Childs: [],
+						},
+						{
+							Id: SPAWN_COUNT_OPTION_ID,
+							IsActive: true,
+							TranslatedName: "数",
+							Selection: 0,
+							Format: "",
+							RangeMeta: { Type: "Int32", Values: [1, 2, 3] },
+							Childs: [],
+						},
+					],
+				},
+			],
+		},
+	];
 
-	const spawnCountOption: ExROptionDto = {
-		Id: SPAWN_COUNT_OPTION_ID,
-		IsActive: true,
-		TranslatedName: "数",
-		Selection: 0,
-		Format: "",
-		RangeMeta: { Type: "Int32", Values: [1, 2, 3] },
-		Childs: [],
-	};
-
-	beforeEach(() => {
+	beforeEach(async () => {
+		resetApiCache();
 		useStore.getState().resetViewer();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve(mockTabs),
+				}),
+			),
+		);
+		await act(async () => {
+			await getInitialLoadPromise();
+		});
 	});
 
 	it("renders both controls", () => {
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
+		render(<ExRRoleSpawnControls categoryId={1} />);
 
 		expect(screen.getByTestId("spawn-rate-control")).toBeInTheDocument();
 		expect(screen.getByTestId("spawn-count-control")).toBeInTheDocument();
 	});
 
 	it("handles virtual 0 for spawn count", () => {
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
+		render(<ExRRoleSpawnControls categoryId={1} />);
 
 		const countControl = screen.getByTestId("spawn-count-control");
 		const slider = countControl.querySelector(
@@ -67,18 +82,12 @@ describe("ExRRoleSpawnControls", () => {
 		const tabId = useStore.getState().selectedExRTabId;
 		useStore
 			.getState()
-			.TEMP_updateExROptionSelection(
+			.updateExROptionSelection(
 				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID),
 				1,
 			);
 
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
+		render(<ExRRoleSpawnControls categoryId={1} />);
 
 		const countControl = screen.getByTestId("spawn-count-control");
 		const slider = countControl.querySelector(
@@ -89,20 +98,12 @@ describe("ExRRoleSpawnControls", () => {
 
 		const state = useStore.getState();
 		expect(
-			state.effectiveSelections[
-				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)
-			],
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)].selection,
 		).toBe(0); // Rate 0%
 	});
 
 	it("syncs rate to 10% when count is set to non-zero from zero rate", () => {
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
+		render(<ExRRoleSpawnControls categoryId={1} />);
 
 		const countControl = screen.getByTestId("spawn-count-control");
 		const slider = countControl.querySelector(
@@ -114,9 +115,7 @@ describe("ExRRoleSpawnControls", () => {
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
 		expect(
-			state.effectiveSelections[
-				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)
-			],
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)].selection,
 		).toBe(1); // Rate index 1 is 10%
 	});
 
@@ -125,24 +124,18 @@ describe("ExRRoleSpawnControls", () => {
 		const tabId = useStore.getState().selectedExRTabId;
 		useStore
 			.getState()
-			.TEMP_updateExROptionSelection(
+			.updateExROptionSelection(
 				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID),
 				1,
 			);
 		useStore
 			.getState()
-			.TEMP_updateExROptionSelection(
+			.updateExROptionSelection(
 				getUniqueOptionId(tabId, 1, SPAWN_COUNT_OPTION_ID),
 				1,
 			); // backend index 1 is value 2
 
-		render(
-			<ExRRoleSpawnControls
-				categoryId={1}
-				spawnRateOption={spawnRateOption}
-				spawnCountOption={spawnCountOption}
-			/>,
-		);
+		render(<ExRRoleSpawnControls categoryId={1} />);
 
 		const rateControl = screen.getByTestId("spawn-rate-control");
 		const slider = rateControl.querySelector(
@@ -153,9 +146,7 @@ describe("ExRRoleSpawnControls", () => {
 
 		const state = useStore.getState();
 		expect(
-			state.effectiveSelections[
-				getUniqueOptionId(tabId, 1, SPAWN_COUNT_OPTION_ID)
-			],
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_COUNT_OPTION_ID)].selection,
 		).toBe(0); // Count reset to index 0
 
 		// UI should show 0

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, act } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
 import { getInitialLoadPromise, resetApiCache } from "../src/logics/api";
@@ -82,7 +82,7 @@ describe("ExRRoleSpawnControls", () => {
 		const tabId = useStore.getState().selectedExRTabId;
 		useStore
 			.getState()
-			.updateExROptionSelection(
+			.TEMP_updateExROptionSelection(
 				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID),
 				1,
 			);
@@ -98,7 +98,8 @@ describe("ExRRoleSpawnControls", () => {
 
 		const state = useStore.getState();
 		expect(
-			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)].selection,
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)]
+				.selection,
 		).toBe(0); // Rate 0%
 	});
 
@@ -115,7 +116,8 @@ describe("ExRRoleSpawnControls", () => {
 		const state = useStore.getState();
 		const tabId = state.selectedExRTabId;
 		expect(
-			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)].selection,
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID)]
+				.selection,
 		).toBe(1); // Rate index 1 is 10%
 	});
 
@@ -124,13 +126,13 @@ describe("ExRRoleSpawnControls", () => {
 		const tabId = useStore.getState().selectedExRTabId;
 		useStore
 			.getState()
-			.updateExROptionSelection(
+			.TEMP_updateExROptionSelection(
 				getUniqueOptionId(tabId, 1, SPAWN_RATE_OPTION_ID),
 				1,
 			);
 		useStore
 			.getState()
-			.updateExROptionSelection(
+			.TEMP_updateExROptionSelection(
 				getUniqueOptionId(tabId, 1, SPAWN_COUNT_OPTION_ID),
 				1,
 			); // backend index 1 is value 2
@@ -146,7 +148,8 @@ describe("ExRRoleSpawnControls", () => {
 
 		const state = useStore.getState();
 		expect(
-			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_COUNT_OPTION_ID)].selection,
+			state.valueData[getUniqueOptionId(tabId, 1, SPAWN_COUNT_OPTION_ID)]
+				.selection,
 		).toBe(0); // Count reset to index 0
 
 		// UI should show 0

--- a/tests/optionViewerSlice.test.ts
+++ b/tests/optionViewerSlice.test.ts
@@ -70,9 +70,16 @@ describe("optionViewerSlice", () => {
 	});
 
 	it("should update effective selections with numeric ID", () => {
-		const { TEMP_updateExROptionSelection } = useStore.getState();
+		const { setExROptions, updateExROptionSelection } = useStore.getState();
 
-		TEMP_updateExROptionSelection(10001, 5);
-		expect(useStore.getState().effectiveSelections[10001]).toBe(5);
+		setExROptions(
+			{
+				10001: { selection: 0, values: [0, 1, 2, 3, 4, 5] },
+			},
+			{ 10001: true },
+		);
+
+		updateExROptionSelection(10001, 5);
+		expect(useStore.getState().valueData[10001].selection).toBe(5);
 	});
 });

--- a/tests/optionViewerSlice.test.ts
+++ b/tests/optionViewerSlice.test.ts
@@ -70,7 +70,8 @@ describe("optionViewerSlice", () => {
 	});
 
 	it("should update effective selections with numeric ID", () => {
-		const { setExROptions, updateExROptionSelection } = useStore.getState();
+		const { setExROptions, TEMP_updateExROptionSelection } =
+			useStore.getState();
 
 		setExROptions(
 			{
@@ -79,7 +80,7 @@ describe("optionViewerSlice", () => {
 			{ 10001: true },
 		);
 
-		updateExROptionSelection(10001, 5);
+		TEMP_updateExROptionSelection(10001, 5);
 		expect(useStore.getState().valueData[10001].selection).toBe(5);
 	});
 });


### PR DESCRIPTION
This PR refactors how ExR options data is handled in the frontend.
Previously, the entire DTO array was passed down via props, which led to unnecessary re-renders and complex data passing.
The new architecture splits the data into:
1. Static Metadata: Stored in a global `exrOptionMetaData` object.
2. Dynamic Values: Stored in the Zustand store (`valueData` and `isOptionActive`).

The loading is now managed by `getInitialLoadPromise()`, which is used with React 19's `use()` hook.
All ExR-related components have been updated to use this new data flow.
Additionally, `package-lock.json` was removed to align with the use of pnpm.

---
*PR created automatically by Jules for task [8286331470445311017](https://jules.google.com/task/8286331470445311017) started by @yukieiji*