### PR TITLE
Fix unit test errors

### DIFF
--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -124,10 +124,9 @@ describe("ExRCategoryList Component Selection", () => {
 						}
 						if (
 							opt.Id !== SPAWN_RATE_OPTION_ID &&
-							!exrOptionMetaData.childOptionMap[rateUniqueId].includes(opt.Id)
+							!exrOptionMetaData.childOptionMap[rateUniqueId].includes(uniqueId)
 						) {
-							// バグ回避用の optionId での登録
-							exrOptionMetaData.childOptionMap[rateUniqueId].push(opt.Id);
+							exrOptionMetaData.childOptionMap[rateUniqueId].push(uniqueId);
 						}
 					}
 				}

--- a/tests/optionUtils.test.ts
+++ b/tests/optionUtils.test.ts
@@ -124,8 +124,12 @@ describe("optionUtils", () => {
 			setupMockMeta(tabId, categoryId, 2, "A 最大");
 			setupMockMeta(tabId, categoryId, 3, "B");
 
-			const options = [1, 2, 3];
-			const grouped = groupOptionPairs(tabId, categoryId, options);
+			const options = [
+				getUniqueOptionId(tabId, categoryId, 1),
+				getUniqueOptionId(tabId, categoryId, 2),
+				getUniqueOptionId(tabId, categoryId, 3),
+			];
+			const grouped = groupOptionPairs(options);
 			expect(grouped).toHaveLength(2);
 			expect(grouped[0]).toEqual({
 				type: "pair",
@@ -147,7 +151,7 @@ describe("optionUtils", () => {
 					label: "最大",
 				},
 			});
-			expect(grouped[1]).toBe(3);
+			expect(grouped[1]).toBe(getUniqueOptionId(tabId, categoryId, 3));
 		});
 
 		it("should not group non-consecutive pairs", () => {
@@ -157,11 +161,15 @@ describe("optionUtils", () => {
 			setupMockMeta(tabId, categoryId, 3, "B");
 			setupMockMeta(tabId, categoryId, 2, "A 最大");
 
-			const options = [1, 3, 2];
-			const grouped = groupOptionPairs(tabId, categoryId, options);
+			const options = [
+				getUniqueOptionId(tabId, categoryId, 1),
+				getUniqueOptionId(tabId, categoryId, 3),
+				getUniqueOptionId(tabId, categoryId, 2),
+			];
+			const grouped = groupOptionPairs(options);
 			// 仕様により、連続しないペアやその間の要素は除外される（最後の一つを除く）
 			expect(grouped).toHaveLength(1);
-			expect(grouped[0]).toBe(2);
+			expect(grouped[0]).toBe(getUniqueOptionId(tabId, categoryId, 2));
 		});
 	});
 });


### PR DESCRIPTION
Unit test failures were caused by mismatches between the test code and the current implementation of utility functions and data structures. This PR updates the test code to align with these changes without modifying the production logic.

Key changes:
- In `tests/optionUtils.test.ts`, `groupOptionPairs` calls were updated to provide only the required array of `UniqueOptionId`s. Assertions were also updated to expect `UniqueOptionId`s.
- In `tests/ExRCategoryList.test.tsx`, the setup logic was fixed to use `UniqueOptionId` instead of raw option IDs when populating `exrOptionMetaData.childOptionMap`, which is necessary for the filtering logic in `ExRRoleCategoryItem` to work correctly.
- All 106 tests across 23 files now pass.

---
*PR created automatically by Jules for task [17178914359757914778](https://jules.google.com/task/17178914359757914778) started by @yukieiji*