### PR TITLE
シンクロボタンの追加と同期機能の実装

### DIFF
--- a/e2e/sync.spec.ts
+++ b/e2e/sync.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.request.post("/mock/reset");
+	await page.goto("/");
+	// wait for main content instead of just "Loading data..." absence
+	await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible({
+		timeout: 15000,
+	});
+});
+
+test("synchronization updates data and preserves UI state", async ({
+	page,
+}) => {
+	// 1. Initial state check
+	await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible();
+
+	// 2. Change tab to ExR and open a category
+	await page.getByRole("button", { name: "ExR Options" }).click();
+	await expect(
+		page.getByRole("heading", { name: "ExR Options" }),
+	).toBeVisible();
+
+	// Use test-id which seems more stable
+	const category = page.getByTestId("exr-category-1");
+	await expect(category).toBeVisible();
+	await category.click();
+
+	// Check if category content is visible
+	// Let's use a more robust check for content inside accordion
+	await expect(page.getByTestId("exr-category-list")).toContainText(
+		"乱数に関する設定",
+	);
+
+	// 3. Perform synchronization
+	// Set artificial delay for sync to see the loading overlay
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 1000;
+	});
+
+	const syncButton = page.getByLabel("データを同期");
+	await expect(syncButton).toBeVisible();
+	await syncButton.click();
+
+	// 4. Verify loading overlay
+	await expect(page.getByText("Synchronizing...")).toBeVisible();
+	await expect(page.getByText("Synchronizing...")).not.toBeVisible({
+		timeout: 10000,
+	});
+
+	// 5. Verify UI state is preserved
+	// Tab should still be ExR
+	await expect(
+		page.getByRole("heading", { name: "ExR Options" }),
+	).toBeVisible();
+
+	// Sidebar state check (open by default, let's close it and sync)
+	await page.getByRole("button", { name: "サイドバーを閉じる" }).click();
+	await expect(page.getByRole("navigation")).not.toBeAttached();
+
+	await syncButton.click();
+	await expect(page.getByText("Synchronizing...")).not.toBeVisible();
+
+	// Sidebar should still be closed (navigation not visible)
+	await expect(page.getByRole("navigation")).not.toBeAttached();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
-import { Suspense, use } from "react";
+import { Suspense, use, useTransition } from "react";
 import { LoadingView } from "./components/parts/LoadingView";
+import { SyncButton } from "./components/parts/SyncButton";
+import { SyncLoadingOverlay } from "./components/parts/SyncLoadingOverlay";
 import { AuOptionEditor } from "./feature/AuOptionEditor";
 import { ExROptionEditor } from "./feature/ExROptionEditor";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { PresetSelector } from "./feature/PresetSelector";
-import { getAuOptions, getExrOptions } from "./logics/api.store";
+import { getAuOptions, getExrOptions, resetApiCache } from "./logics/api.store";
 import { useStore } from "./useStore";
 
 /**
@@ -47,29 +49,46 @@ function MainContent() {
 	const isSidebarPending = useStore((state) => {
 		return state.isSidebarPending;
 	});
+	const validateOpenedIds = useStore((state) => {
+		return state.validateOpenedIds;
+	});
+
+	const [isSyncPending, startSyncTransition] = useTransition();
+
+	const handleSync = () => {
+		startSyncTransition(async () => {
+			resetApiCache();
+			await Promise.all([getExrOptions(), getAuOptions()]);
+			validateOpenedIds();
+		});
+	};
 
 	return (
 		<section
 			data-testid="main-content-section"
-			className={`flex flex-col gap-4 transition-opacity duration-200 ${isSidebarPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
-			data-is-pending={isSidebarPending ? "true" : "false"}
+			className={`flex flex-col gap-4 transition-opacity duration-200 ${isSidebarPending || isSyncPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
+			data-is-pending={isSidebarPending || isSyncPending ? "true" : "false"}
 		>
+			{isSyncPending && <SyncLoadingOverlay />}
 			<div className="flex items-center gap-4">
-				<h2 className="text-2xl font-bold whitespace-nowrap">
-					{selectedTab === "ExR" ? "ExR Options" : "Au Options"}
-				</h2>
-				{selectedTab === "ExR" && (
-					<Suspense
-						fallback={
-							<div className="w-48 h-8 bg-gray-700 animate-pulse rounded" />
-						}
-					>
-						<PresetSelectorContainer />
-					</Suspense>
-				)}
-				{isSidebarPending && (
-					<div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
-				)}
+				<div className="flex items-center gap-4 flex-1">
+					<h2 className="text-2xl font-bold whitespace-nowrap">
+						{selectedTab === "ExR" ? "ExR Options" : "Au Options"}
+					</h2>
+					{selectedTab === "ExR" && (
+						<Suspense
+							fallback={
+								<div className="w-48 h-8 bg-gray-700 animate-pulse rounded" />
+							}
+						>
+							<PresetSelectorContainer />
+						</Suspense>
+					)}
+					{isSidebarPending && (
+						<div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+					)}
+				</div>
+				<SyncButton onClick={handleSync} disabled={isSyncPending} />
 			</div>
 			<Suspense
 				fallback={

--- a/src/components/parts/SyncButton.tsx
+++ b/src/components/parts/SyncButton.tsx
@@ -1,0 +1,42 @@
+interface SyncButtonProps {
+	onClick: () => void;
+	disabled?: boolean;
+}
+
+/**
+ * 同期ボタンコンポーネント
+ * アイコンのみを表示します
+ */
+export function SyncButton({ onClick, disabled }: SyncButtonProps) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			disabled={disabled}
+			className={`
+        p-2 rounded-full transition-all duration-200
+        ${disabled ? "text-gray-400 cursor-not-allowed" : "text-blue-600 hover:bg-blue-50 active:bg-blue-100 shadow-sm border border-gray-200 bg-white"}
+      `}
+			title="同期"
+			aria-label="データを同期"
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="20"
+				height="20"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				aria-hidden="true"
+			>
+				<path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+				<path d="M3 3v5h5" />
+				<path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
+				<path d="M16 16h5v5" />
+			</svg>
+		</button>
+	);
+}

--- a/src/components/parts/SyncLoadingOverlay.tsx
+++ b/src/components/parts/SyncLoadingOverlay.tsx
@@ -1,0 +1,18 @@
+/**
+ * 同期中のオーバーレイコンポーネント
+ * UIを表示したまま、操作を無効化しローディングを表示します
+ */
+export function SyncLoadingOverlay() {
+	return (
+		<div
+			className="fixed inset-0 flex items-center justify-center bg-black/20 backdrop-blur-[1px] z-[100]"
+			aria-busy="true"
+			role="status"
+		>
+			<div className="bg-white p-6 rounded-lg shadow-xl flex flex-col items-center gap-4 border border-gray-200">
+				<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+				<p className="text-lg font-medium text-gray-700">Synchronizing...</p>
+			</div>
+		</div>
+	);
+}

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -38,6 +38,7 @@ export interface ExROptionViewerSlice {
 		valueData: Record<UniqueOptionId, ExROptionValueData>,
 		optionActiveData: Record<UniqueOptionId, boolean>,
 	) => void;
+	validateOpenedIds: () => void;
 }
 
 /**
@@ -222,6 +223,38 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 			set({
 				exrValue: valueData,
 				isExROptionActive: optionActiveData,
+			});
+		},
+		validateOpenedIds: () => {
+			set((state) => {
+				const nextOpenedExRCategoryIds = { ...state.openedExRCategoryIds };
+				let categoryChanged = false;
+				for (const id in nextOpenedExRCategoryIds) {
+					const categoryId = Number(id);
+					if (!exrOptionMetaData.categoryInfo[categoryId]) {
+						delete nextOpenedExRCategoryIds[categoryId];
+						categoryChanged = true;
+					}
+				}
+
+				const nextOpenedExROptionIds = { ...state.openedExROptionIds };
+				let optionChanged = false;
+				for (const id in nextOpenedExROptionIds) {
+					const uniqueOptionId = Number(id) as UniqueOptionId;
+					if (!exrOptionMetaData.optionMetaData[uniqueOptionId]) {
+						delete nextOpenedExROptionIds[uniqueOptionId];
+						optionChanged = true;
+					}
+				}
+
+				if (!categoryChanged && !optionChanged) {
+					return state;
+				}
+
+				return {
+					openedExRCategoryIds: nextOpenedExRCategoryIds,
+					openedExROptionIds: nextOpenedExROptionIds,
+				};
 			});
 		},
 	};

--- a/tests/validateOpenedIds.test.ts
+++ b/tests/validateOpenedIds.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { create } from "zustand";
+import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import type { ExROptionViewerSlice } from "../src/slices/exrOptionViewerSlice";
+import { createExROptionViewerSlice } from "../src/slices/exrOptionViewerSlice";
+import type { UniqueOptionId } from "../src/type";
+
+describe("validateOpenedIds", () => {
+	const useStore = create<ExROptionViewerSlice>()((...a) => ({
+		...createExROptionViewerSlice(...a),
+	}));
+
+	beforeEach(() => {
+		resetExrOptionMetaData();
+		useStore.setState({
+			openedExRCategoryIds: {},
+			openedExROptionIds: {},
+		});
+	});
+
+	it("should remove non-existent category IDs", () => {
+		// Mock metadata
+		exrOptionMetaData.categoryInfo = {
+			1: "Category 1",
+			2: "Category 2",
+		};
+
+		// Set initial state
+		useStore.setState({
+			openedExRCategoryIds: {
+				1: true,
+				3: true, // Non-existent
+			},
+		});
+
+		const { validateOpenedIds } = useStore.getState();
+		validateOpenedIds();
+
+		const state = useStore.getState();
+		expect(state.openedExRCategoryIds).toEqual({
+			1: true,
+		});
+	});
+
+	it("should remove non-existent option IDs", () => {
+		// Mock metadata
+		const uId1 = 101 as UniqueOptionId;
+		const uId2 = 102 as UniqueOptionId;
+		exrOptionMetaData.optionMetaData = {
+			[uId1]: { translatedName: "Opt 1", format: "", type: "Single" },
+		};
+
+		// Set initial state
+		useStore.setState({
+			openedExROptionIds: {
+				[uId1]: true,
+				[uId2]: true, // Non-existent
+			},
+		});
+
+		const { validateOpenedIds } = useStore.getState();
+		validateOpenedIds();
+
+		const state = useStore.getState();
+		expect(state.openedExROptionIds).toEqual({
+			[uId1]: true,
+		});
+	});
+
+	it("should do nothing if all IDs are valid", () => {
+		exrOptionMetaData.categoryInfo = { 1: "Cat 1" };
+		const uId = 101 as UniqueOptionId;
+		exrOptionMetaData.optionMetaData = {
+			[uId]: { translatedName: "Opt 1", format: "", type: "Single" },
+		};
+
+		const initialState = {
+			openedExRCategoryIds: { 1: true },
+			openedExROptionIds: { [uId]: true },
+		};
+		useStore.setState(initialState);
+
+		const { validateOpenedIds } = useStore.getState();
+		validateOpenedIds();
+
+		const state = useStore.getState();
+		expect(state.openedExRCategoryIds).toEqual(
+			initialState.openedExRCategoryIds,
+		);
+		expect(state.openedExROptionIds).toEqual(initialState.openedExROptionIds);
+	});
+});


### PR DESCRIPTION
UIにシンクロボタンを追加しました。
ボタンが押されるとバックエンドから最新データを再取得し、フロントエンドの状態を更新します。
更新中は、既存のUIを表示したまま操作のみを制限する専用のローディングダイアログが表示されます。
現在のタブ選択状態、サイドバーの開閉状態、および展開されているカテゴリやオプションの状態は同期後も保持されます。
ただし、同期後に存在しなくなったカテゴリやオプションのIDは自動的にクリーンアップされます。

---
*PR created automatically by Jules for task [11051930472282876010](https://jules.google.com/task/11051930472282876010) started by @yukieiji*