### PR TITLE
プリセット切り替え機能の追加と確認ダイアログの実装

### DIFF
--- a/e2e/preset_naming.spec.ts
+++ b/e2e/preset_naming.spec.ts
@@ -38,13 +38,22 @@ test("Preset naming and persistence behavior", async ({ page }) => {
 	await expect(selectButton).toBeVisible();
 	await selectButton.click();
 
-	// TODO: プリセットを切り替えた時にデータを再リロードする必要があるため追加の修正が必要になります
-	// 仕様: プリセット切り替え => 200番成功 => ExR側のデータ再取得をして再構築 => 再表示
-	/* 
 	// プリセット 2 (index 1) に切り替える
 	const preset2Button = page.getByRole("button", { name: "2", exact: true });
 	await expect(preset2Button).toBeVisible();
 	await preset2Button.click();
+
+	// 確認ダイアログが表示されることを確認
+	const dialog = page.getByRole("dialog");
+	await expect(dialog).toBeVisible();
+	await expect(dialog).toContainText("プリセットの切り替え");
+	await dialog.getByRole("button", { name: "OK" }).click();
+
+	// ローディング画面が表示され、その後消えることを確認
+	await expect(page.getByText("Synchronizing...")).toBeVisible();
+	await expect(page.getByText("Synchronizing...")).not.toBeVisible({
+		timeout: 30000,
+	});
 
 	// 入力欄が index 1 のデフォルト値 "2" になっていることを確認
 	await expect(presetInput).toHaveValue("2");
@@ -77,6 +86,14 @@ test("Preset naming and persistence behavior", async ({ page }) => {
 
 	// index 1 (Casual Fun) に切り替える
 	await casualFunButton.click();
+
+	// 再度ダイアログを確認してOK
+	await expect(dialog).toBeVisible();
+	await dialog.getByRole("button", { name: "OK" }).click();
+
+	await expect(page.getByText("Synchronizing...")).not.toBeVisible({
+		timeout: 30000,
+	});
+
 	await expect(presetInput).toHaveValue("Casual Fun");
-	*/
 });

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -73,6 +73,17 @@ export const handlers = [
 
     // CategoryIdとOptionIdが0のときは202を返す（ボディなし）
     if (CategoryId === 0 && OptionId === 0) {
+      // 実際にデータを更新する
+      const tab = curValidatedExRMockData.find(t => t.Id === TabId);
+      if (tab) {
+        const category = tab.Categories.find(c => c.Id === CategoryId);
+        if (category) {
+          const option = category.Options.find(o => o.Id === OptionId);
+          if (option) {
+            option.Selection = Selection;
+          }
+        }
+      }
       return new HttpResponse(null, { status: 202 });
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { AuOptionEditor } from "./feature/AuOptionEditor";
 import { ExROptionEditor } from "./feature/ExROptionEditor";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { PresetSelector } from "./feature/PresetSelector";
-import { getAuOptions, getExrOptions, resetApiCache } from "./logics/api.store";
+import { getAuOptions, getExrOptions, syncAllData } from "./logics/api.store";
 import { useStore } from "./useStore";
 
 /**
@@ -49,17 +49,23 @@ function MainContent() {
 	const isSidebarPending = useStore((state) => {
 		return state.isSidebarPending;
 	});
-	const validateOpenedIds = useStore((state) => {
-		return state.validateOpenedIds;
+	const isSyncPending = useStore((state) => {
+		return state.isSyncPending;
+	});
+	const setIsSyncPending = useStore((state) => {
+		return state.setIsSyncPending;
 	});
 
-	const [isSyncPending, startSyncTransition] = useTransition();
+	const [, startSyncTransition] = useTransition();
 
 	const handleSync = () => {
 		startSyncTransition(async () => {
-			resetApiCache();
-			await Promise.all([getExrOptions(), getAuOptions()]);
-			validateOpenedIds();
+			setIsSyncPending(true);
+			try {
+				await syncAllData();
+			} finally {
+				setIsSyncPending(false);
+			}
 		});
 	};
 

--- a/src/components/parts/ConfirmDialog.tsx
+++ b/src/components/parts/ConfirmDialog.tsx
@@ -1,0 +1,50 @@
+interface ConfirmDialogProps {
+	title: string;
+	message: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+/**
+ * 確認ダイアログコンポーネント
+ */
+export function ConfirmDialog({
+	title,
+	message,
+	onConfirm,
+	onCancel,
+}: ConfirmDialogProps) {
+	return (
+		<div
+			className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-[110]"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="dialog-title"
+		>
+			<div className="bg-white p-6 rounded-lg shadow-2xl flex flex-col gap-6 border border-gray-200 max-w-sm w-full mx-4">
+				<div className="flex flex-col gap-2">
+					<h3 id="dialog-title" className="text-xl font-bold text-gray-900">
+						{title}
+					</h3>
+					<p className="text-gray-600">{message}</p>
+				</div>
+				<div className="flex justify-end gap-3">
+					<button
+						type="button"
+						onClick={onCancel}
+						className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+					>
+						キャンセル
+					</button>
+					<button
+						type="button"
+						onClick={onConfirm}
+						className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+					>
+						OK
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { ConfirmDialog } from "../components/parts/ConfirmDialog";
 import { useOptionData } from "../hooks/useOptionData";
+import { syncAllData } from "../logics/api.store";
 import { PRESET_OPTION_UNIQUE_ID } from "../logics/optionUtils";
 import { useStore } from "../useStore";
 
@@ -32,6 +34,12 @@ export function PresetSelector() {
 	const setPresetDropdownOpen = useStore((state) => {
 		return state.setPresetDropdownOpen;
 	});
+	const setIsSyncPending = useStore((state) => {
+		return state.setIsSyncPending;
+	});
+
+	const [pendingSelection, setPendingSelection] = useState<number | null>(null);
+	const [, startTransition] = useTransition();
 
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -62,12 +70,36 @@ export function PresetSelector() {
 	const currentPresetName =
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
-	const handlePresetSelect = async (index: number) => {
-		await updateExROptionSelection({
-			uniqueOptionId: PRESET_OPTION_UNIQUE_ID,
-			selection: index,
-		});
+	const handlePresetSelect = (index: number) => {
+		if (index === currentSelection) {
+			setPresetDropdownOpen(false);
+			return;
+		}
+		setPendingSelection(index);
 		setPresetDropdownOpen(false);
+	};
+
+	const confirmPresetChange = () => {
+		if (pendingSelection === null) {
+			return;
+		}
+
+		const selectionToUpdate = pendingSelection;
+		setPendingSelection(null);
+
+		startTransition(async () => {
+			setIsSyncPending(true);
+			try {
+				await updateExROptionSelection({
+					uniqueOptionId: PRESET_OPTION_UNIQUE_ID,
+					selection: selectionToUpdate,
+				});
+				// プリセット切り替え成功時にデータを再取得して再構築
+				await syncAllData();
+			} finally {
+				setIsSyncPending(false);
+			}
+		});
 	};
 
 	/**
@@ -101,6 +133,16 @@ export function PresetSelector() {
 
 	return (
 		<div className="relative flex items-center gap-2" ref={dropdownRef}>
+			{pendingSelection !== null && (
+				<ConfirmDialog
+					title="プリセットの切り替え"
+					message={`プリセットを「${presetNames[pendingSelection] ?? String(presetValues[pendingSelection])}」に切り替えますか？`}
+					onConfirm={confirmPresetChange}
+					onCancel={() => {
+						setPendingSelection(null);
+					}}
+				/>
+			)}
 			<div className="relative flex items-center bg-gray-800 border border-gray-700 rounded overflow-hidden focus-within:border-blue-500">
 				<input
 					ref={inputRef}

--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -67,3 +67,12 @@ export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
 
 	return auOptionsPromise;
 }
+
+/**
+ * すべてのデータを同期し、バリデーションを行う
+ */
+export async function syncAllData(): Promise<void> {
+	resetApiCache();
+	await Promise.all([getExrOptions(), getAuOptions()]);
+	useStore.getState().validateOpenedIds();
+}

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -117,7 +117,7 @@ export async function updateExrOption(
 	categoryId: number,
 	optionId: number,
 	selection: number,
-): Promise<UpdatedOptions> {
+): Promise<UpdatedOptions | null> {
 	const request = {
 		TabId: tabId,
 		CategoryId: categoryId,
@@ -134,6 +134,10 @@ export async function updateExrOption(
 
 	if (!res.ok) {
 		throw new Error(`Failed to update ExR option: ${res.statusText}`);
+	}
+
+	if (res.status === 202) {
+		return null;
 	}
 
 	const jsonData = await res.json();

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -20,6 +20,7 @@ import type {
 export interface ExROptionViewerSlice {
 	selectedExRTabId: OptionTab;
 	isExRTabPending: boolean;
+	isSyncPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<number, boolean>;
 	presetNames: Record<number, string>;
@@ -28,6 +29,7 @@ export interface ExROptionViewerSlice {
 	isExROptionActive: Record<UniqueOptionId, boolean>;
 	setSelectedExRTabId: (id: OptionTab) => void;
 	setIsExRTabPending: (isPending: boolean) => void;
+	setIsSyncPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: UniqueOptionId) => void;
 	updateExROptionSelection: (...updateInfos: UpdateExRArg[]) => Promise<void>;
@@ -50,6 +52,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 	return {
 		selectedExRTabId: 0,
 		isExRTabPending: false,
+		isSyncPending: false,
 		openedExRCategoryIds: {},
 		openedExROptionIds: {},
 		exrValue: {},
@@ -62,10 +65,14 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		setIsExRTabPending: (isPending: boolean) => {
 			set({ isExRTabPending: isPending });
 		},
+		setIsSyncPending: (isPending: boolean) => {
+			set({ isSyncPending: isPending });
+		},
 		resetViewer: () => {
 			set({
 				selectedExRTabId: 0,
 				isExRTabPending: false,
+				isSyncPending: false,
 				openedExRCategoryIds: {},
 				openedExROptionIds: {},
 				isPresetDropdownOpen: false,
@@ -166,6 +173,10 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 					};
 
 					updateResult.forEach((x) => {
+						if (!x) {
+							return;
+						}
+
 						if (x.UpdatedCategory) {
 							processCategory(x.UpdatedCategory);
 						}


### PR DESCRIPTION
プリセット切り替え時に確認ダイアログを表示し、ユーザーがOKを押した場合に切り替え処理を実行する機能を実装しました。
切り替え中は同期処理と同じローディング画面を表示し、処理成功後（202 Accepted または 200 OK）に最新のデータを再取得して画面を再構築します。

主な変更点:
1. `ConfirmDialog` コンポーネントの作成
2. `isSyncPending` 状態を `exrOptionViewerSlice` へ移動し、コンポーネントを跨いでローディング表示を共有
3. `api.store.ts` にデータ再取得用の共通関数 `syncAllData` を定義
4. `updateExrOption` で 202 Accepted 時に `null` を返し、不要なパースをスキップするよう修正
5. モックサーバーでプリセット切り替え時に 202 を返し、データを更新するように修正
6. E2Eテスト (`preset_naming.spec.ts`) を新仕様に合わせて更新

---
*PR created automatically by Jules for task [14488336404775346594](https://jules.google.com/task/14488336404775346594) started by @yukieiji*