### PR TITLE
プリセット切り替え機能の実装と同期処理の共通化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, use, useTransition } from "react";
+import { Suspense, use } from "react";
 import { LoadingView } from "./components/parts/LoadingView";
 import { SyncButton } from "./components/parts/SyncButton";
 import { SyncLoadingOverlay } from "./components/parts/SyncLoadingOverlay";
@@ -6,7 +6,7 @@ import { AuOptionEditor } from "./feature/AuOptionEditor";
 import { ExROptionEditor } from "./feature/ExROptionEditor";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { PresetSelector } from "./feature/PresetSelector";
-import { getAuOptions, getExrOptions, resetApiCache } from "./logics/api.store";
+import { getAuOptions, getExrOptions, syncOptions } from "./logics/api.store";
 import { useStore } from "./useStore";
 
 /**
@@ -49,18 +49,20 @@ function MainContent() {
 	const isSidebarPending = useStore((state) => {
 		return state.isSidebarPending;
 	});
-	const validateOpenedIds = useStore((state) => {
-		return state.validateOpenedIds;
+	const isSyncPending = useStore((state) => {
+		return state.isSyncPending;
+	});
+	const setIsSyncPending = useStore((state) => {
+		return state.setIsSyncPending;
 	});
 
-	const [isSyncPending, startSyncTransition] = useTransition();
-
-	const handleSync = () => {
-		startSyncTransition(async () => {
-			resetApiCache();
-			await Promise.all([getExrOptions(), getAuOptions()]);
-			validateOpenedIds();
-		});
+	const handleSync = async () => {
+		setIsSyncPending(true);
+		try {
+			await syncOptions();
+		} finally {
+			setIsSyncPending(false);
+		}
 	};
 
 	return (

--- a/src/feature/PresetSelector.tsx
+++ b/src/feature/PresetSelector.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useOptionData } from "../hooks/useOptionData";
+import { syncOptions } from "../logics/api.store";
 import { PRESET_OPTION_UNIQUE_ID } from "../logics/optionUtils";
 import { useStore } from "../useStore";
 
@@ -32,6 +33,9 @@ export function PresetSelector() {
 	const setPresetDropdownOpen = useStore((state) => {
 		return state.setPresetDropdownOpen;
 	});
+	const setIsSyncPending = useStore((state) => {
+		return state.setIsSyncPending;
+	});
 
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -63,11 +67,25 @@ export function PresetSelector() {
 		presetNames[currentSelection] ?? String(currentPresetValue);
 
 	const handlePresetSelect = async (index: number) => {
-		await updateExROptionSelection({
-			uniqueOptionId: PRESET_OPTION_UNIQUE_ID,
-			selection: index,
-		});
 		setPresetDropdownOpen(false);
+
+		const name =
+			presetNames[index] ?? String((presetOption.values as number[])[index]);
+
+		if (!window.confirm(`プリセットを「${name}」に切り替えますか？`)) {
+			return;
+		}
+
+		setIsSyncPending(true);
+		try {
+			await updateExROptionSelection({
+				uniqueOptionId: PRESET_OPTION_UNIQUE_ID,
+				selection: index,
+			});
+			await syncOptions();
+		} finally {
+			setIsSyncPending(false);
+		}
 	};
 
 	/**

--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -67,3 +67,12 @@ export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
 
 	return auOptionsPromise;
 }
+
+/**
+ * データを再取得して同期する
+ */
+export async function syncOptions(): Promise<void> {
+	resetApiCache();
+	await Promise.all([getExrOptions(), getAuOptions()]);
+	useStore.getState().validateOpenedIds();
+}

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -117,7 +117,7 @@ export async function updateExrOption(
 	categoryId: number,
 	optionId: number,
 	selection: number,
-): Promise<UpdatedOptions> {
+): Promise<UpdatedOptions | null> {
 	const request = {
 		TabId: tabId,
 		CategoryId: categoryId,
@@ -134,6 +134,10 @@ export async function updateExrOption(
 
 	if (!res.ok) {
 		throw new Error(`Failed to update ExR option: ${res.statusText}`);
+	}
+
+	if (res.status === 202) {
+		return null;
 	}
 
 	const jsonData = await res.json();

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -20,6 +20,7 @@ import type {
 export interface ExROptionViewerSlice {
 	selectedExRTabId: OptionTab;
 	isExRTabPending: boolean;
+	isSyncPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<number, boolean>;
 	presetNames: Record<number, string>;
@@ -28,6 +29,7 @@ export interface ExROptionViewerSlice {
 	isExROptionActive: Record<UniqueOptionId, boolean>;
 	setSelectedExRTabId: (id: OptionTab) => void;
 	setIsExRTabPending: (isPending: boolean) => void;
+	setIsSyncPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: UniqueOptionId) => void;
 	updateExROptionSelection: (...updateInfos: UpdateExRArg[]) => Promise<void>;
@@ -50,6 +52,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 	return {
 		selectedExRTabId: 0,
 		isExRTabPending: false,
+		isSyncPending: false,
 		openedExRCategoryIds: {},
 		openedExROptionIds: {},
 		exrValue: {},
@@ -62,10 +65,14 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		setIsExRTabPending: (isPending: boolean) => {
 			set({ isExRTabPending: isPending });
 		},
+		setIsSyncPending: (isPending: boolean) => {
+			set({ isSyncPending: isPending });
+		},
 		resetViewer: () => {
 			set({
 				selectedExRTabId: 0,
 				isExRTabPending: false,
+				isSyncPending: false,
 				openedExRCategoryIds: {},
 				openedExROptionIds: {},
 				isPresetDropdownOpen: false,
@@ -166,6 +173,10 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 					};
 
 					updateResult.forEach((x) => {
+						if (x === null) {
+							return;
+						}
+
 						if (x.UpdatedCategory) {
 							processCategory(x.UpdatedCategory);
 						}


### PR DESCRIPTION
プリセット切り替え機能を追加しました。
主な変更内容：
1. APIが202を返した場合にnullを返すように変更し、ストア側でnullチェックを行うようにしました。
2. グローバルな `isSyncPending` 状態を導入し、プリセット切り替え中も同期中と同じローディング画面が表示されるようにしました。
3. `syncOptions` 処理を共通化し、プリセット切り替え成功時（202返却時）に自動的に呼び出されるようにしました。
4. `PresetSelector` において、切り替え前に確認ダイアログを表示し、OKが押された場合のみ重たい切り替え処理と再構築（同期）を行うようにしました。
5. `App.tsx` の既存の同期ボタンも、新しく共通化した `syncOptions` とグローバルな `isSyncPending` を使うようにリファクタリングしました。
全てのユニットテストおよび関連するE2Eテストがパスすることを確認済みです。

---
*PR created automatically by Jules for task [16540084402675043940](https://jules.google.com/task/16540084402675043940) started by @yukieiji*