### PR TITLE
createAuOptionMetaData の実装と関連型の更新

### DIFF
--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -1,7 +1,7 @@
 import type { AuOptionCategoryDto } from "../type";
 
 import { useStore } from "../useStore";
-import { AU_OPTION_URL, createAuOptionMetaData, createExROptionMetaData } from "./api";
+import { createAuOptionMetaData, createExROptionMetaData } from "./api";
 
 /**
  * APIからデータを取得するPromiseをキャッシュするためのグローバル変数
@@ -46,10 +46,13 @@ export function getExrOptions(): Promise<void> {
 	return exrOptionsPromise;
 }
 
-async function createAuOptionMetaDataWithStore(delay: number): Promise<void> {
+async function createAuOptionMetaDataWithStore(
+	delay: number,
+): Promise<AuOptionCategoryDto[]> {
 	await waitDelay(delay);
-	const auValue = await createAuOptionMetaData();
-	useStore.getState().setAuValue(auValue);
+	const { initialValueData, rawData } = await createAuOptionMetaData();
+	useStore.getState().setAuValue(initialValueData);
+	return rawData as AuOptionCategoryDto[];
 }
 
 /**
@@ -63,18 +66,6 @@ export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
 	// @ts-expect-error - テスト用
 	const delay = typeof window !== "undefined" ? window.__API_DELAY__ || 0 : 0;
 
-	auOptionsPromise = (async () => {
-		if (delay > 0) {
-			await new Promise((resolve) => {
-				return setTimeout(resolve, delay);
-			});
-		}
-		const res = await fetch(AU_OPTION_URL);
-		if (!res.ok) {
-			throw new Error(`Failed to fetch Au options: ${res.statusText}`);
-		}
-		return res.json();
-	})();
-
+	auOptionsPromise = createAuOptionMetaDataWithStore(delay);
 	return auOptionsPromise;
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -40,8 +40,7 @@ export const exrOptionMetaData: ExROptionMetaDataRecords = {
 export const auOptionMetaData: AuOptionMetaDataRecords = {
 	tabNames: [],
 	tabCategoryMap: {},
-	categoryInfo: {},
-	categoryOptionMap: {},
+	categoryMetaData: {},
 	options: {},
 };
 
@@ -64,8 +63,7 @@ export function resetExrOptionMetaData() {
 export function resetAuOptionMetaData() {
 	auOptionMetaData.tabNames = [];
 	auOptionMetaData.tabCategoryMap = {};
-	auOptionMetaData.categoryInfo = {};
-	auOptionMetaData.categoryOptionMap = {};
+	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};
 }
 
@@ -158,8 +156,7 @@ export async function createAuOptionMetaData(): Promise<{
 	const initialValueData: Record<number, number> = {};
 	auOptionMetaData.tabNames = ["0", "1", "2"];
 	auOptionMetaData.tabCategoryMap = { 0: [], 1: [], 2: [] };
-	auOptionMetaData.categoryInfo = {};
-	auOptionMetaData.categoryOptionMap = {};
+	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};
 
 	let currentTab = 0;
@@ -182,8 +179,10 @@ export async function createAuOptionMetaData(): Promise<{
 		}
 
 		auOptionMetaData.tabCategoryMap[currentTab].push(categoryId);
-		auOptionMetaData.categoryInfo[categoryId] = category.TranslatedTitle;
-		auOptionMetaData.categoryOptionMap[categoryId] = [];
+		auOptionMetaData.categoryMetaData[categoryId] = {
+			name: category.TranslatedTitle,
+			options: [],
+		};
 
 		for (const opt of category.Options) {
 			const valueType = opt.Info.ValueType;
@@ -198,7 +197,7 @@ export async function createAuOptionMetaData(): Promise<{
 					valueType,
 					AU_PREFIX.MAX_COUNT,
 				);
-				auOptionMetaData.categoryOptionMap[categoryId].push(maxCountId);
+				auOptionMetaData.categoryMetaData[categoryId].options.push(maxCountId);
 				auOptionMetaData.options[maxCountId] = {
 					title: opt.TranslatedTitle,
 					format: opt.TranslatedFormat,
@@ -212,7 +211,7 @@ export async function createAuOptionMetaData(): Promise<{
 					valueType,
 					AU_PREFIX.CHANCE,
 				);
-				auOptionMetaData.categoryOptionMap[categoryId].push(chanceId);
+				auOptionMetaData.categoryMetaData[categoryId].options.push(chanceId);
 				auOptionMetaData.options[chanceId] = {
 					title: opt.TranslatedTitle,
 					format: opt.TranslatedFormat,
@@ -221,7 +220,7 @@ export async function createAuOptionMetaData(): Promise<{
 				initialValueData[chanceId] = Math.floor(roleValue.Chance / 10);
 			} else {
 				const auOptionId = getAuOptionId(optionName, valueType);
-				auOptionMetaData.categoryOptionMap[categoryId].push(auOptionId);
+				auOptionMetaData.categoryMetaData[categoryId].options.push(auOptionId);
 
 				let range = opt.Range || [];
 				let index = 0;

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -1,14 +1,24 @@
 import type {
+	AuOptionCategoryDto,
+	AuOptionId,
 	AuOptionMetaDataRecords,
+	AuRoleOption,
 	ExROptionDto,
 	ExROptionMetaDataRecords,
 	ExROptionValueData,
 	UniqueOptionId,
 	UpdatedOptions,
 } from "../type";
-import { AuOptionCategoryDtoArraySchema, ExRTabDtoArraySchema, OptionTab, UpdatedOptionsSchema } from "../type";
+import {
+	AU_PREFIX,
+	AuOptionCategoryDtoArraySchema,
+	ExRTabDtoArraySchema,
+	OptionTab,
+	OptionValueType,
+	UpdatedOptionsSchema,
+} from "../type";
 
-import { getUniqueOptionId } from "./optionUtils";
+import { getAuOptionId, getUniqueOptionId } from "./optionUtils";
 
 /**
  * API エンドポイントの定数定義
@@ -30,9 +40,10 @@ export const exrOptionMetaData: ExROptionMetaDataRecords = {
 export const auOptionMetaData: AuOptionMetaDataRecords = {
 	tabNames: [],
 	tabCategoryMap: {},
+	categoryInfo: {},
 	categoryOptionMap: {},
-	options: {}
-}
+	options: {},
+};
 
 /**
  * ExRオプションのメタデータをリセットする（テスト用）
@@ -41,9 +52,21 @@ export function resetExrOptionMetaData() {
 	exrOptionMetaData.tabInfo = {} as Record<OptionTab, string>;
 	exrOptionMetaData.tabIdMap = {} as Record<OptionTab, number[]>;
 	exrOptionMetaData.categoryInfo = {};
+	exrOptionMetaData.categoryTabMap = {} as Record<number, OptionTab>;
 	exrOptionMetaData.globalCategoryIdTopLevelMap = {};
 	exrOptionMetaData.optionMetaData = {};
 	exrOptionMetaData.childOptionMap = {};
+}
+
+/**
+ * Auオプションのメタデータをリセットする（テスト用）
+ */
+export function resetAuOptionMetaData() {
+	auOptionMetaData.tabNames = [];
+	auOptionMetaData.tabCategoryMap = {};
+	auOptionMetaData.categoryInfo = {};
+	auOptionMetaData.categoryOptionMap = {};
+	auOptionMetaData.options = {};
 }
 
 interface ExRinitializeData {
@@ -120,14 +143,111 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 	return { valueData, isOptionActive };
 }
 
-export async function createAuOptionMetaData(): Record<AuOptionId, number> {
-	const res = await fetch(EXR_OPTION_URL);
+export async function createAuOptionMetaData(): Promise<{
+	initialValueData: Record<AuOptionId, number>;
+	rawData: AuOptionCategoryDto[];
+}> {
+	const res = await fetch(AU_OPTION_URL);
 	if (!res.ok) {
-		throw new Error(`Failed to fetch ExR options: ${res.statusText}`);
+		throw new Error(`Failed to fetch Au options: ${res.statusText}`);
 	}
 
 	const jsonData = await res.json();
 	const data = await AuOptionCategoryDtoArraySchema.parseAsync(jsonData);
+
+	const initialValueData: Record<number, number> = {};
+	auOptionMetaData.tabNames = ["0", "1", "2"];
+	auOptionMetaData.tabCategoryMap = { 0: [], 1: [], 2: [] };
+	auOptionMetaData.categoryInfo = {};
+	auOptionMetaData.categoryOptionMap = {};
+	auOptionMetaData.options = {};
+
+	let currentTab = 0;
+
+	for (let i = 0; i < data.length; i++) {
+		const category = data[i];
+		const categoryId = i;
+		const firstOption = category.Options[0];
+		if (
+			currentTab === 0 &&
+			firstOption?.TranslatedTitle === "DefaultOption"
+		) {
+			currentTab = 1;
+		} else if (
+			currentTab === 1 &&
+			firstOption?.TranslatedTitle === "DefaultOption" &&
+			firstOption?.TranslatedFormat === "Shapeshifter"
+		) {
+			currentTab = 2;
+		}
+
+		auOptionMetaData.tabCategoryMap[currentTab].push(categoryId);
+		auOptionMetaData.categoryInfo[categoryId] = category.TranslatedTitle;
+		auOptionMetaData.categoryOptionMap[categoryId] = [];
+
+		for (const opt of category.Options) {
+			const valueType = opt.Info.ValueType;
+			const optionName = opt.Info.OptionName;
+
+			if (valueType === OptionValueType.RoleBase) {
+				const roleValue = opt.Value as AuRoleOption;
+
+				// MaxCount
+				const maxCountId = getAuOptionId(
+					optionName,
+					valueType,
+					AU_PREFIX.MAX_COUNT,
+				);
+				auOptionMetaData.categoryOptionMap[categoryId].push(maxCountId);
+				auOptionMetaData.options[maxCountId] = {
+					title: opt.TranslatedTitle,
+					format: opt.TranslatedFormat,
+					range: Array.from({ length: 16 }, (_, i) => i),
+				};
+				initialValueData[maxCountId] = roleValue.MaxCount;
+
+				// Chance
+				const chanceId = getAuOptionId(
+					optionName,
+					valueType,
+					AU_PREFIX.CHANCE,
+				);
+				auOptionMetaData.categoryOptionMap[categoryId].push(chanceId);
+				auOptionMetaData.options[chanceId] = {
+					title: opt.TranslatedTitle,
+					format: opt.TranslatedFormat,
+					range: Array.from({ length: 11 }, (_, i) => i * 10),
+				};
+				initialValueData[chanceId] = Math.floor(roleValue.Chance / 10);
+			} else {
+				const auOptionId = getAuOptionId(optionName, valueType);
+				auOptionMetaData.categoryOptionMap[categoryId].push(auOptionId);
+
+				let range = opt.Range || [];
+				let index = 0;
+
+				if (valueType === OptionValueType.Bool) {
+					range = [0, 1]; // number[] として扱う
+					index = opt.Value ? 1 : 0;
+				} else if (range.length > 0) {
+					index = range.indexOf(opt.Value as string | number);
+					if (index === -1) index = 0;
+				}
+
+				auOptionMetaData.options[auOptionId] = {
+					title: opt.TranslatedTitle,
+					format: opt.TranslatedFormat,
+					range: range as (string | number)[],
+				};
+				initialValueData[auOptionId] = index;
+			}
+		}
+	}
+
+	return {
+		initialValueData: initialValueData as unknown as Record<AuOptionId, number>,
+		rawData: data,
+	};
 }
 
 export async function updateExrOption(

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -1,4 +1,4 @@
-import type { OptionData, UniqueOptionId } from "../type";
+import type { AuOptionId, OptionData, UniqueOptionId } from "../type";
 import { exrOptionMetaData } from "./api";
 
 const TAB_ID_MULTIPLIER = 1_000_000_000_000;
@@ -16,6 +16,20 @@ export function getUniqueOptionId(
 	const uniqueId =
 		tabId * TAB_ID_MULTIPLIER + categoryId * CATEGORY_ID_MULTIPLIER + optionId;
 	return uniqueId as UniqueOptionId;
+}
+
+/**
+ * Au系のオプションIDを生成します。
+ * 1～2桁: 予備用プレフィックスコード
+ * 3～4桁: OptionValueType
+ * 5桁より上: OptionName
+ */
+export function getAuOptionId(
+	optionName: number,
+	valueType: number,
+	prefix = 0,
+): AuOptionId {
+	return (optionName * 10000 + valueType * 100 + prefix) as AuOptionId;
 }
 
 export function parseUniqueOptionId(uniqueOptionId: UniqueOptionId): {

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -1,13 +1,5 @@
 import type { StateCreator } from "zustand";
-import { exrOptionMetaData, updateExrOption } from "../logics/api";
-import {
-	loadPresetNamesFromCookie,
-	savePresetNamesToCookie,
-} from "../logics/cookieUtils";
-import { getUniqueOptionId, parseUniqueOptionId } from "../logics/optionUtils";
-import type {
-	AuOptionId
-} from "../type";
+import type { AuOptionId } from "../type";
 
 /**
  * ExR オプションの状態を管理するスライスのインターフェース

--- a/src/type.ts
+++ b/src/type.ts
@@ -159,8 +159,9 @@ export interface AuOptionMeta {
 
 export interface AuOptionMetaDataRecords {
 	tabNames: string[]; // タブの名前
-	tabCategoryMap: Record<number, string[]>; // 1タブにしてゲーム設定はそれぞれでカテゴリ、役職は陣営毎に1タブ役職ごとのカテゴリとして保存
-	categoryOptionMap: Record<string, AuOptionId>; // カテゴリーとオプションの紐づけ
+	tabCategoryMap: Record<number, number[]>; // タブIDとそのタブに属するカテゴリIDの対応
+	categoryInfo: Record<number, string>; // カテゴリIDとカテゴリ名の対応
+	categoryOptionMap: Record<number, AuOptionId[]>; // カテゴリIDとそのカテゴリに属するオプションIDの対応
 	options: Record<AuOptionId, AuOptionMeta>; // 全オプションのメタデータ
 }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -157,11 +157,15 @@ export interface AuOptionMeta {
 	range: (number | string)[];
 }
 
+export interface AuOptionCategoryMetaData {
+	name: string;
+	options: AuOptionId[];
+}
+
 export interface AuOptionMetaDataRecords {
 	tabNames: string[]; // タブの名前
 	tabCategoryMap: Record<number, number[]>; // タブIDとそのタブに属するカテゴリIDの対応
-	categoryInfo: Record<number, string>; // カテゴリIDとカテゴリ名の対応
-	categoryOptionMap: Record<number, AuOptionId[]>; // カテゴリIDとそのカテゴリに属するオプションIDの対応
+	categoryMetaData: Record<number, AuOptionCategoryMetaData>; // カテゴリIDとカテゴリメタデータの対応
 	options: Record<AuOptionId, AuOptionMeta>; // 全オプションのメタデータ
 }
 

--- a/tests/auOptionMetaData.test.ts
+++ b/tests/auOptionMetaData.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createAuOptionMetaData, auOptionMetaData, AU_OPTION_URL } from '../src/logics/api';
+import { createAuOptionMetaData, auOptionMetaData, AU_OPTION_URL, resetAuOptionMetaData } from '../src/logics/api';
 import { OptionValueType } from '../src/type';
 
 // Mock global fetch
@@ -8,7 +8,7 @@ global.fetch = vi.fn();
 describe('createAuOptionMetaData', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        // Reset auOptionMetaData manually if needed, or let the function overwrite it
+        resetAuOptionMetaData();
     });
 
     it('should correctly process options and tabs', async () => {

--- a/tests/auOptionMetaData.test.ts
+++ b/tests/auOptionMetaData.test.ts
@@ -62,7 +62,7 @@ describe('createAuOptionMetaData', () => {
         expect(auOptionMetaData.tabCategoryMap[2]).toContain(2);
 
         // Check category info
-        expect(auOptionMetaData.categoryInfo[0]).toBe("Tab0Category");
+        expect(auOptionMetaData.categoryMetaData[0].name).toBe("Tab0Category");
 
         // Check options
         // NormalOption: Name 1, Type 2 (Int), Prefix 0 => 10200

--- a/tests/auOptionMetaData.test.ts
+++ b/tests/auOptionMetaData.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createAuOptionMetaData, auOptionMetaData, AU_OPTION_URL } from '../src/logics/api';
+import { OptionValueType } from '../src/type';
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe('createAuOptionMetaData', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Reset auOptionMetaData manually if needed, or let the function overwrite it
+    });
+
+    it('should correctly process options and tabs', async () => {
+        const mockData = [
+            {
+                TranslatedTitle: "Tab0Category",
+                Options: [
+                    {
+                        TranslatedTitle: "NormalOption",
+                        TranslatedFormat: "Format",
+                        Value: 10,
+                        Info: { ValueType: OptionValueType.Int, OptionName: 1 },
+                        Range: [0, 10, 20]
+                    }
+                ]
+            },
+            {
+                TranslatedTitle: "Tab1CategoryStart",
+                Options: [
+                    {
+                        TranslatedTitle: "DefaultOption",
+                        TranslatedFormat: "Something",
+                        Value: true,
+                        Info: { ValueType: OptionValueType.Bool, OptionName: 2 }
+                    }
+                ]
+            },
+            {
+                TranslatedTitle: "Tab2CategoryStart",
+                Options: [
+                    {
+                        TranslatedTitle: "DefaultOption",
+                        TranslatedFormat: "Shapeshifter",
+                        Value: { MaxCount: 1, Chance: 50 },
+                        Info: { ValueType: OptionValueType.RoleBase, OptionName: 3 }
+                    }
+                ]
+            }
+        ];
+
+        (fetch as any).mockResolvedValue({
+            ok: true,
+            json: async () => mockData,
+        });
+
+        const result = await createAuOptionMetaData();
+
+        // Check tabs
+        expect(auOptionMetaData.tabCategoryMap[0]).toContain(0);
+        expect(auOptionMetaData.tabCategoryMap[1]).toContain(1);
+        expect(auOptionMetaData.tabCategoryMap[2]).toContain(2);
+
+        // Check category info
+        expect(auOptionMetaData.categoryInfo[0]).toBe("Tab0Category");
+
+        // Check options
+        // NormalOption: Name 1, Type 2 (Int), Prefix 0 => 10200
+        const id1 = 10200;
+        expect(auOptionMetaData.options[id1]).toBeDefined();
+        expect(auOptionMetaData.options[id1].title).toBe("NormalOption");
+        expect(result.initialValueData[id1]).toBe(1); // Index of 10 in [0, 10, 20]
+
+        // BoolOption: Name 2, Type 0 (Bool), Prefix 0 => 20000
+        const id2 = 20000;
+        expect(auOptionMetaData.options[id2]).toBeDefined();
+        expect(result.initialValueData[id2]).toBe(1); // true => 1
+
+        // RoleBase: Name 3, Type 5 (RoleBase)
+        // MaxCount: Name 3, Type 5, Prefix 1 => 30501
+        const id3Max = 30501;
+        expect(auOptionMetaData.options[id3Max]).toBeDefined();
+        expect(result.initialValueData[id3Max]).toBe(1);
+
+        // Chance: Name 3, Type 5, Prefix 2 => 30502
+        const id3Chance = 30502;
+        expect(auOptionMetaData.options[id3Chance]).toBeDefined();
+        expect(result.initialValueData[id3Chance]).toBe(5); // 50 / 10 = 5
+    });
+});


### PR DESCRIPTION
`api.ts` の `createAuOptionMetaData` を実装しました。以下の仕様に基づいています：

- **タブ管理**: 
  - 0: カテゴリ内の最初のオプションの TranslatedTitle が "DefaultOption" になるまで。
  - 1: 最初の "DefaultOption" が出てから、TranslatedTitle が "DefaultOption" かつフォーマットが "Shapeshifter" になるまで。
  - 2: それ以降。
- **ID生成**: `getAuOptionId` を追加し、`(OptionName * 10000 + ValueType * 100 + Prefix)` の式を使用。
- **RoleBase 分割**: `RoleBase` (ValueType 5) のオプションを `MaxCount` (プレフィックス 1) と `Chance` (プレフィックス 2) に分割して登録。
- **データ構造**: `categoryId` を配列のインデックス順とし、`categoryInfo` で表示名を管理するように改善。
- **動作確認**: ビルドが通ること、および新規追加したユニットテストが全てパスすることを確認済みです。

---
*PR created automatically by Jules for task [18404380877839791078](https://jules.google.com/task/18404380877839791078) started by @yukieiji*