### PR TITLE
ExROptionMetaDataRecordsのリファクタリングとインターフェース分割

### DIFF
--- a/src/feature/ExRCategoryList.tsx
+++ b/src/feature/ExRCategoryList.tsx
@@ -68,7 +68,7 @@ export function ExRCategoryList() {
 		return state.isExRTabPending;
 	});
 
-	const tabCategory = exrOptionMetaData.tabIdMap[selectedExRTabId];
+	const tabCategory = exrOptionMetaData.tabs[selectedExRTabId]?.categoryIds;
 	const isRoleTab = selectedExRTabId !== OptionTab.GeneralTab;
 
 	return (

--- a/src/feature/ExROptionItem.tsx
+++ b/src/feature/ExROptionItem.tsx
@@ -16,7 +16,7 @@ interface ExROptionItemProps {
 }
 
 function ExROptionItemInner({ uniqueOptionId, depth = 0 }: ExROptionItemProps) {
-	const childs = exrOptionMetaData.childOptionMap[uniqueOptionId];
+	const childs = exrOptionMetaData.options[uniqueOptionId]?.childOptionIds;
 	const hasActiveChildren = useStore(
 		useShallow((state) => {
 			if (!childs) {

--- a/src/feature/ExROptionRecursiveItem.tsx
+++ b/src/feature/ExROptionRecursiveItem.tsx
@@ -28,7 +28,7 @@ export function ExROptionRecursiveItem({
 		toggleExROption(uniqueOptionId);
 	};
 
-	const childs = exrOptionMetaData.childOptionMap[uniqueOptionId];
+	const childs = exrOptionMetaData.options[uniqueOptionId]?.childOptionIds;
 
 	return (
 		<OptionAccordion

--- a/src/feature/ExROptionRow.tsx
+++ b/src/feature/ExROptionRow.tsx
@@ -19,7 +19,7 @@ export function ExROptionRow({
 	depth = 0,
 	isLeaf = false,
 }: ExROptionRowProps) {
-	const optionData = exrOptionMetaData.optionMetaData[uniqueOptionId];
+	const optionData = exrOptionMetaData.options[uniqueOptionId]?.metaData;
 	if (!optionData) {
 		return null;
 	}

--- a/src/feature/ExRRoleCategoryItem.tsx
+++ b/src/feature/ExRRoleCategoryItem.tsx
@@ -38,7 +38,7 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 	);
 	const spawnRateOptionValue = useOptionData(uniqueRateId);
 
-	const category = exrOptionMetaData.categoryInfo[categoryId];
+	const category = exrOptionMetaData.categories[categoryId]?.name ?? "";
 
 	const spawnRateSelection = spawnRateOptionValue.selection ?? 0;
 	const isSpawnRateZero = spawnRateSelection === 0;
@@ -51,7 +51,7 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 	// └─ 4
 	// なので、スポーンレートのオプションIDの子要素を取れば、その役職の全オプションを取得できる
 	const childUniqueOptionIds =
-		exrOptionMetaData.childOptionMap[uniqueRateId] || [];
+		exrOptionMetaData.options[uniqueRateId]?.childOptionIds || [];
 	// スポーン数のオプションはスポーンレートの子であることが確定、孫とかにはない
 	const filteredChildOptionIds = childUniqueOptionIds.filter((optionId) => {
 		return optionId !== uniqueCountId;

--- a/src/feature/ExRStandardCategoryItem.tsx
+++ b/src/feature/ExRStandardCategoryItem.tsx
@@ -42,7 +42,9 @@ export function ExRStandardCategoryItem({
 		<div data-testid={`exr-category-${categoryId}`}>
 			<Accordion
 				title={
-					<ColoredText text={exrOptionMetaData.categoryInfo[categoryId]} />
+					<ColoredText
+						text={exrOptionMetaData.categories[categoryId]?.name ?? ""}
+					/>
 				}
 				isOpen={isOpen}
 				onToggle={() => {

--- a/src/feature/ExRTabSelector.tsx
+++ b/src/feature/ExRTabSelector.tsx
@@ -39,7 +39,7 @@ export function ExRTabSelector() {
 
 	return (
 		<div className="flex flex-wrap gap-2 border-b border-gray-200 pb-2">
-			{Object.keys(exrOptionMetaData.tabInfo).map((tabId) => {
+			{Object.keys(exrOptionMetaData.tabs).map((tabId) => {
 				const castedTabId = Number(tabId) as OptionTab;
 				return (
 					<button
@@ -53,7 +53,9 @@ export function ExRTabSelector() {
               ${selectedExRTabId === castedTabId ? "bg-blue-500 text-white" : "bg-gray-200 text-gray-700 hover:bg-gray-300"}
             `}
 					>
-						<ColoredText text={exrOptionMetaData.tabInfo[castedTabId]} />
+						<ColoredText
+							text={exrOptionMetaData.tabs[castedTabId]?.name ?? ""}
+						/>
 					</button>
 				);
 			})}

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -87,13 +87,13 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 		for (const opt of options) {
 			const uniqueId = getUniqueOptionId(tabId, categoryId, opt.Id);
 
-			exrOptionMetaData.options[uniqueId] = {
+exrOptionMetaData.options[uniqueId] = {
 				metaData: {
 					translatedName: opt.TranslatedName,
 					format: opt.Format,
 					type: opt.RangeMeta.Type,
 				},
-				childOptionIds: [],
+				childOptionIds: exrOptionMetaData.options[uniqueId]?.childOptionIds ?? [],
 			};
 
 			valueData[uniqueId] = {

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -28,13 +28,10 @@ export const AU_OPTION_URL = "/au/option/";
 
 export const exrOptionMetaData: ExROptionMetaDataRecords = {
 	// OptionTabはAPIから取得したデータに基づいて動的に構築され全てあることが保証されるため、初期値は空のオブジェクトで問題ありません
-	tabInfo: {} as Record<OptionTab, string>,
-	tabIdMap: {} as Record<OptionTab, number[]>,
-	categoryTabMap: {} as Record<number, OptionTab>,
-	categoryInfo: {},
+	tabs: {} as Record<OptionTab, ExRTabMetaData>,
+	categories: {},
+	options: {},
 	globalCategoryIdTopLevelMap: {},
-	optionMetaData: {},
-	childOptionMap: {},
 };
 
 export const auOptionMetaData: AuOptionMetaDataRecords = {
@@ -48,13 +45,10 @@ export const auOptionMetaData: AuOptionMetaDataRecords = {
  * ExRオプションのメタデータをリセットする（テスト用）
  */
 export function resetExrOptionMetaData() {
-	exrOptionMetaData.tabInfo = {} as Record<OptionTab, string>;
-	exrOptionMetaData.tabIdMap = {} as Record<OptionTab, number[]>;
-	exrOptionMetaData.categoryInfo = {};
-	exrOptionMetaData.categoryTabMap = {} as Record<number, OptionTab>;
+	exrOptionMetaData.tabs = {} as Record<OptionTab, ExRTabMetaData>;
+	exrOptionMetaData.categories = {};
+	exrOptionMetaData.options = {};
 	exrOptionMetaData.globalCategoryIdTopLevelMap = {};
-	exrOptionMetaData.optionMetaData = {};
-	exrOptionMetaData.childOptionMap = {};
 }
 
 /**
@@ -93,10 +87,13 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 		for (const opt of options) {
 			const uniqueId = getUniqueOptionId(tabId, categoryId, opt.Id);
 
-			exrOptionMetaData.optionMetaData[uniqueId] = {
-				translatedName: opt.TranslatedName,
-				format: opt.Format,
-				type: opt.RangeMeta.Type,
+			exrOptionMetaData.options[uniqueId] = {
+				metaData: {
+					translatedName: opt.TranslatedName,
+					format: opt.Format,
+					type: opt.RangeMeta.Type,
+				},
+				childOptionIds: [],
 			};
 
 			valueData[uniqueId] = {
@@ -110,10 +107,25 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 					categoryId,
 					parentOptionId,
 				);
-				if (!exrOptionMetaData.childOptionMap[parentUniqueId]) {
-					exrOptionMetaData.childOptionMap[parentUniqueId] = [];
+				if (!exrOptionMetaData.options[parentUniqueId]) {
+					exrOptionMetaData.options[parentUniqueId] = {
+						metaData: {
+							translatedName: "",
+							format: "",
+							type: "",
+						},
+						childOptionIds: [],
+					};
 				}
-				exrOptionMetaData.childOptionMap[parentUniqueId].push(uniqueId);
+				if (
+					!exrOptionMetaData.options[parentUniqueId].childOptionIds.includes(
+						uniqueId,
+					)
+				) {
+					exrOptionMetaData.options[parentUniqueId].childOptionIds.push(
+						uniqueId,
+					);
+				}
 			}
 
 			if (opt.Childs && opt.Childs.length > 0) {
@@ -123,11 +135,15 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 	};
 
 	for (const tab of data) {
-		exrOptionMetaData.tabInfo[tab.Id] = tab.Name;
-		exrOptionMetaData.tabIdMap[tab.Id] = tab.Categories.map((c) => c.Id);
+		exrOptionMetaData.tabs[tab.Id] = {
+			name: tab.Name,
+			categoryIds: tab.Categories.map((c) => c.Id),
+		};
 		for (const category of tab.Categories) {
-			exrOptionMetaData.categoryInfo[category.Id] = category.Name;
-			exrOptionMetaData.categoryTabMap[category.Id] = tab.Id;
+			exrOptionMetaData.categories[category.Id] = {
+				name: category.Name,
+				tabId: tab.Id,
+			};
 			if (tab.Id === OptionTab.GeneralTab) {
 				// 一般タブのカテゴリは、トップレベルオプションIDを直接カテゴリIDに紐づける
 				exrOptionMetaData.globalCategoryIdTopLevelMap[category.Id] =
@@ -165,10 +181,7 @@ export async function createAuOptionMetaData(): Promise<{
 		const category = data[i];
 		const categoryId = i;
 		const firstOption = category.Options[0];
-		if (
-			currentTab === 0 &&
-			firstOption?.TranslatedTitle === "DefaultOption"
-		) {
+		if (currentTab === 0 && firstOption?.TranslatedTitle === "DefaultOption") {
 			currentTab = 1;
 		} else if (
 			currentTab === 1 &&
@@ -206,11 +219,7 @@ export async function createAuOptionMetaData(): Promise<{
 				initialValueData[maxCountId] = roleValue.MaxCount;
 
 				// Chance
-				const chanceId = getAuOptionId(
-					optionName,
-					valueType,
-					AU_PREFIX.CHANCE,
-				);
+				const chanceId = getAuOptionId(optionName, valueType, AU_PREFIX.CHANCE);
 				auOptionMetaData.categoryMetaData[categoryId].options.push(chanceId);
 				auOptionMetaData.options[chanceId] = {
 					title: opt.TranslatedTitle,

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -173,7 +173,7 @@ export function groupOptionPairs(
 
 	for (let i = 0; i < uniqueOptionIds.length; i++) {
 		const currentUniqueId = uniqueOptionIds[i];
-		const currentMeta = exrOptionMetaData.optionMetaData[currentUniqueId];
+		const currentMeta = exrOptionMetaData.options[currentUniqueId]?.metaData;
 		if (!currentMeta) {
 			continue;
 		}
@@ -184,7 +184,7 @@ export function groupOptionPairs(
 			continue;
 		}
 
-		const nextMeta = exrOptionMetaData.optionMetaData[nextUniqueId];
+		const nextMeta = exrOptionMetaData.options[nextUniqueId]?.metaData;
 		if (!currentMeta || !nextMeta) {
 			result.push(currentUniqueId);
 			continue;

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -185,7 +185,7 @@ export function groupOptionPairs(
 		}
 
 		const nextMeta = exrOptionMetaData.options[nextUniqueId]?.metaData;
-		if (!currentMeta || !nextMeta) {
+if (!nextMeta) {
 			result.push(currentUniqueId);
 			continue;
 		}

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -9,7 +9,7 @@ export interface AuOptionViewerSlice {
 	isAuTabPending: boolean;
 	openedAuCategoryIds: Record<number, boolean>;
 	auValue: Record<AuOptionId, number>; // セレクション
-	setAuValue: (value: Record<AuOptionId, number>) => void
+	setAuValue: (value: Record<AuOptionId, number>) => void;
 }
 
 /**
@@ -24,7 +24,7 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 		openedAuCategoryIds: {},
 		auValue: {},
 		setAuValue(value) {
-			set({auValue: value})
+			set({ auValue: value });
 		},
 	};
 };

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -159,7 +159,10 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 					};
 
 					const processCategory = (cat: ExRCategoryDto) => {
-						const tId = exrOptionMetaData.categoryTabMap[cat.Id];
+						const tId = exrOptionMetaData.categories[cat.Id]?.tabId;
+						if (tId === undefined) {
+							return;
+						}
 						for (const opt of cat.Options) {
 							processOption(opt, cat.Id, tId);
 						}
@@ -174,7 +177,10 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 						}
 
 						for (const chain of x.ChainUpdatedOption) {
-							const tId = exrOptionMetaData.categoryTabMap[chain.Id];
+							const tId = exrOptionMetaData.categories[chain.Id]?.tabId;
+							if (tId === undefined) {
+								continue;
+							}
 							for (const opt of chain.Options) {
 								processOption(opt, chain.Id, tId);
 							}
@@ -234,7 +240,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 				let categoryChanged = false;
 				for (const id in nextOpenedExRCategoryIds) {
 					const categoryId = Number(id);
-					if (!exrOptionMetaData.categoryInfo[categoryId]) {
+					if (!exrOptionMetaData.categories[categoryId]) {
 						delete nextOpenedExRCategoryIds[categoryId];
 						categoryChanged = true;
 					}
@@ -244,7 +250,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 				let optionChanged = false;
 				for (const id in nextOpenedExROptionIds) {
 					const uniqueOptionId = Number(id) as UniqueOptionId;
-					if (!exrOptionMetaData.optionMetaData[uniqueOptionId]) {
+					if (!exrOptionMetaData.options[uniqueOptionId]) {
 						delete nextOpenedExROptionIds[uniqueOptionId];
 						optionChanged = true;
 					}

--- a/src/type.ts
+++ b/src/type.ts
@@ -27,14 +27,26 @@ export interface ExROptionValueData {
 	values: number[] | string[];
 }
 
+export interface ExRTabMetaData {
+	name: string;
+	categoryIds: number[];
+}
+
+export interface ExRCategoryMetaData {
+	name: string;
+	tabId: OptionTab;
+}
+
+export interface ExROptionMetaDataDetail {
+	metaData: ExROptionMetaData;
+	childOptionIds: UniqueOptionId[];
+}
+
 export interface ExROptionMetaDataRecords {
-	tabInfo: Record<OptionTab, string>; // タブIDとタブ名の対応
-	tabIdMap: Record<OptionTab, number[]>; // タブIDとそのタブに属するカテゴリIDの対応
-	categoryTabMap: Record<number, OptionTab>; // カテゴリIDとタブIDの対応
-	categoryInfo: Record<number, string>; // カテゴリIDとカテゴリ名の対応
-	globalCategoryIdTopLevelMap: Record<number, UniqueOptionId[]>; // グローバル設定のカテゴリIDとそのカテゴリに属するトップレベルオプションのユニークオプションIDの対応
-	optionMetaData: Record<UniqueOptionId, ExROptionMetaData>; // ユニークオプションIDとそのオプションメタデータの対応
-	childOptionMap: Record<UniqueOptionId, UniqueOptionId[]>; // 親ユニークオプションIDとその子ユニークオプションIDの対応
+	tabs: Record<OptionTab, ExRTabMetaData>;
+	categories: Record<number, ExRCategoryMetaData>;
+	options: Record<UniqueOptionId, ExROptionMetaDataDetail>;
+	globalCategoryIdTopLevelMap: Record<number, UniqueOptionId[]>;
 }
 
 /**

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -1,18 +1,21 @@
 import { create } from "zustand";
+import type { AuOptionViewerSlice } from "./slices/auOptionViewerSlice";
+import { createAuOptionViewerSlice } from "./slices/auOptionViewerSlice";
 import type { ExROptionViewerSlice } from "./slices/exrOptionViewerSlice";
 import { createExROptionViewerSlice } from "./slices/exrOptionViewerSlice";
 import type { GlobalUiSlice } from "./slices/globalUiSlice";
 import { createGlobalUiSlice } from "./slices/globalUiSlice";
 import type { OptionGroupToggleSidebarSlice } from "./slices/optionGroupToggleSidebarSlice";
 import { createOptionGroupToggleSidebarSlice } from "./slices/optionGroupToggleSidebarSlice";
-import type { AuOptionViewerSlice } from "./slices/auOptionViewerSlice";
-import { createAuOptionViewerSlice } from "./slices/auOptionViewerSlice";
 
 /**
  * Zustand ストアの作成
  */
 export const useStore = create<
-	GlobalUiSlice & OptionGroupToggleSidebarSlice & AuOptionViewerSlice & ExROptionViewerSlice
+	GlobalUiSlice &
+		OptionGroupToggleSidebarSlice &
+		AuOptionViewerSlice &
+		ExROptionViewerSlice
 >()((...a) => {
 	return {
 		...createGlobalUiSlice(...a),

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -81,9 +81,15 @@ describe("ExRCategoryList Component Selection", () => {
 
 		// exrOptionMetaData のセットアップ
 		for (const tab of mockTabs) {
-			exrOptionMetaData.tabIdMap[tab.Id] = tab.Categories.map((c) => c.Id);
+			exrOptionMetaData.tabs[tab.Id] = {
+				name: tab.Name,
+				categoryIds: tab.Categories.map((c) => c.Id),
+			};
 			for (const cat of tab.Categories) {
-				exrOptionMetaData.categoryInfo[cat.Id] = cat.Name;
+				exrOptionMetaData.categories[cat.Id] = {
+					name: cat.Name,
+					tabId: tab.Id,
+				};
 				if (tab.Id === OptionTab.GeneralTab) {
 					exrOptionMetaData.globalCategoryIdTopLevelMap[cat.Id] =
 						cat.Options.map((o) => getUniqueOptionId(tab.Id, cat.Id, o.Id));
@@ -91,10 +97,13 @@ describe("ExRCategoryList Component Selection", () => {
 
 				for (const opt of cat.Options) {
 					const uniqueId = getUniqueOptionId(tab.Id, cat.Id, opt.Id);
-					exrOptionMetaData.optionMetaData[uniqueId] = {
-						translatedName: opt.TranslatedName,
-						format: opt.Format,
-						type: opt.RangeMeta.Type,
+					exrOptionMetaData.options[uniqueId] = {
+						metaData: {
+							translatedName: opt.TranslatedName,
+							format: opt.Format,
+							type: opt.RangeMeta.Type,
+						},
+						childOptionIds: [],
 					};
 					useStore.getState().setExROptions(
 						{
@@ -119,14 +128,21 @@ describe("ExRCategoryList Component Selection", () => {
 							cat.Id,
 							SPAWN_RATE_OPTION_ID,
 						);
-						if (!exrOptionMetaData.childOptionMap[rateUniqueId]) {
-							exrOptionMetaData.childOptionMap[rateUniqueId] = [];
+						if (!exrOptionMetaData.options[rateUniqueId]) {
+							exrOptionMetaData.options[rateUniqueId] = {
+								metaData: { translatedName: "", format: "", type: "" },
+								childOptionIds: [],
+							};
 						}
 						if (
 							opt.Id !== SPAWN_RATE_OPTION_ID &&
-							!exrOptionMetaData.childOptionMap[rateUniqueId].includes(uniqueId)
+							!exrOptionMetaData.options[rateUniqueId].childOptionIds.includes(
+								uniqueId,
+							)
 						) {
-							exrOptionMetaData.childOptionMap[rateUniqueId].push(uniqueId);
+							exrOptionMetaData.options[rateUniqueId].childOptionIds.push(
+								uniqueId,
+							);
 						}
 					}
 				}

--- a/tests/ExROptionEditor.test.tsx
+++ b/tests/ExROptionEditor.test.tsx
@@ -124,14 +124,15 @@ describe("ExROptionEditor", () => {
 			newActive[oId] = active;
 		}
 
-		// 2. childOptionMap を uniqueId ではなく optionId の配列にする（ExRRoleCategoryItem 用）
-		const newChildMap: Record<number, number[]> = {};
-		for (const [uId, children] of Object.entries(
-			exrOptionMetaData.childOptionMap,
-		)) {
-			newChildMap[Number(uId)] = children.map((cid) => cid % 10000);
+		// 2. childOptionIds を uniqueId ではなく optionId の配列にする（ExRRoleCategoryItem 用）
+		for (const uId in exrOptionMetaData.options) {
+			const option = exrOptionMetaData.options[Number(uId)];
+			if (option) {
+				option.childOptionIds = option.childOptionIds.map(
+					(cid) => (Number(cid) % 10000) as any,
+				);
+			}
 		}
-		exrOptionMetaData.childOptionMap = newChildMap;
 
 		useStore.setState({ isExROptionActive: newActive });
 	});

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -43,15 +43,21 @@ describe("ExRRoleSpawnControls", () => {
 			SPAWN_COUNT_OPTION_ID,
 		);
 
-		exrOptionMetaData.optionMetaData[rateUniqueId] = {
-			translatedName: "レート",
-			format: "{0}%",
-			type: "Int32",
+		exrOptionMetaData.options[rateUniqueId] = {
+			metaData: {
+				translatedName: "レート",
+				format: "{0}%",
+				type: "Int32",
+			},
+			childOptionIds: [],
 		};
-		exrOptionMetaData.optionMetaData[countUniqueId] = {
-			translatedName: "数",
-			format: "{0}",
-			type: "Int32",
+		exrOptionMetaData.options[countUniqueId] = {
+			metaData: {
+				translatedName: "数",
+				format: "{0}",
+				type: "Int32",
+			},
+			childOptionIds: [],
 		};
 
 		useStore.getState().setExROptions(

--- a/tests/auOptionMetaData.test.ts
+++ b/tests/auOptionMetaData.test.ts
@@ -1,90 +1,95 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createAuOptionMetaData, auOptionMetaData, AU_OPTION_URL, resetAuOptionMetaData } from '../src/logics/api';
-import { OptionValueType } from '../src/type';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	AU_OPTION_URL,
+	auOptionMetaData,
+	createAuOptionMetaData,
+	resetAuOptionMetaData,
+} from "../src/logics/api";
+import { OptionValueType } from "../src/type";
 
 // Mock global fetch
 global.fetch = vi.fn();
 
-describe('createAuOptionMetaData', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-        resetAuOptionMetaData();
-    });
+describe("createAuOptionMetaData", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetAuOptionMetaData();
+	});
 
-    it('should correctly process options and tabs', async () => {
-        const mockData = [
-            {
-                TranslatedTitle: "Tab0Category",
-                Options: [
-                    {
-                        TranslatedTitle: "NormalOption",
-                        TranslatedFormat: "Format",
-                        Value: 10,
-                        Info: { ValueType: OptionValueType.Int, OptionName: 1 },
-                        Range: [0, 10, 20]
-                    }
-                ]
-            },
-            {
-                TranslatedTitle: "Tab1CategoryStart",
-                Options: [
-                    {
-                        TranslatedTitle: "DefaultOption",
-                        TranslatedFormat: "Something",
-                        Value: true,
-                        Info: { ValueType: OptionValueType.Bool, OptionName: 2 }
-                    }
-                ]
-            },
-            {
-                TranslatedTitle: "Tab2CategoryStart",
-                Options: [
-                    {
-                        TranslatedTitle: "DefaultOption",
-                        TranslatedFormat: "Shapeshifter",
-                        Value: { MaxCount: 1, Chance: 50 },
-                        Info: { ValueType: OptionValueType.RoleBase, OptionName: 3 }
-                    }
-                ]
-            }
-        ];
+	it("should correctly process options and tabs", async () => {
+		const mockData = [
+			{
+				TranslatedTitle: "Tab0Category",
+				Options: [
+					{
+						TranslatedTitle: "NormalOption",
+						TranslatedFormat: "Format",
+						Value: 10,
+						Info: { ValueType: OptionValueType.Int, OptionName: 1 },
+						Range: [0, 10, 20],
+					},
+				],
+			},
+			{
+				TranslatedTitle: "Tab1CategoryStart",
+				Options: [
+					{
+						TranslatedTitle: "DefaultOption",
+						TranslatedFormat: "Something",
+						Value: true,
+						Info: { ValueType: OptionValueType.Bool, OptionName: 2 },
+					},
+				],
+			},
+			{
+				TranslatedTitle: "Tab2CategoryStart",
+				Options: [
+					{
+						TranslatedTitle: "DefaultOption",
+						TranslatedFormat: "Shapeshifter",
+						Value: { MaxCount: 1, Chance: 50 },
+						Info: { ValueType: OptionValueType.RoleBase, OptionName: 3 },
+					},
+				],
+			},
+		];
 
-        (fetch as any).mockResolvedValue({
-            ok: true,
-            json: async () => mockData,
-        });
+		(fetch as any).mockResolvedValue({
+			ok: true,
+			json: async () => mockData,
+		});
 
-        const result = await createAuOptionMetaData();
+		const result = await createAuOptionMetaData();
 
-        // Check tabs
-        expect(auOptionMetaData.tabCategoryMap[0]).toContain(0);
-        expect(auOptionMetaData.tabCategoryMap[1]).toContain(1);
-        expect(auOptionMetaData.tabCategoryMap[2]).toContain(2);
+		// Check tabs
+		expect(auOptionMetaData.tabCategoryMap[0]).toContain(0);
+		expect(auOptionMetaData.tabCategoryMap[1]).toContain(1);
+		expect(auOptionMetaData.tabCategoryMap[2]).toContain(2);
 
-        // Check category info
-        expect(auOptionMetaData.categoryMetaData[0].name).toBe("Tab0Category");
+		// Check category info
+		expect(auOptionMetaData.categoryMetaData[0].name).toBe("Tab0Category");
 
-        // Check options
-        // NormalOption: Name 1, Type 2 (Int), Prefix 0 => 10200
-        const id1 = 10200;
-        expect(auOptionMetaData.options[id1]).toBeDefined();
-        expect(auOptionMetaData.options[id1].title).toBe("NormalOption");
-        expect(result.initialValueData[id1]).toBe(1); // Index of 10 in [0, 10, 20]
+		// Check options
+		// NormalOption: Name 1, Type 2 (Int), Prefix 0 => 10200
+		const id1 = 10200;
+		expect(auOptionMetaData.options[id1]).toBeDefined();
+		expect(auOptionMetaData.options[id1].title).toBe("NormalOption");
+		expect(result.initialValueData[id1]).toBe(1); // Index of 10 in [0, 10, 20]
 
-        // BoolOption: Name 2, Type 0 (Bool), Prefix 0 => 20000
-        const id2 = 20000;
-        expect(auOptionMetaData.options[id2]).toBeDefined();
-        expect(result.initialValueData[id2]).toBe(1); // true => 1
+		// BoolOption: Name 2, Type 0 (Bool), Prefix 0 => 20000
+		const id2 = 20000;
+		expect(auOptionMetaData.options[id2]).toBeDefined();
+		expect(result.initialValueData[id2]).toBe(1); // true => 1
 
-        // RoleBase: Name 3, Type 5 (RoleBase)
-        // MaxCount: Name 3, Type 5, Prefix 1 => 30501
-        const id3Max = 30501;
-        expect(auOptionMetaData.options[id3Max]).toBeDefined();
-        expect(result.initialValueData[id3Max]).toBe(1);
+		// RoleBase: Name 3, Type 5 (RoleBase)
+		// MaxCount: Name 3, Type 5, Prefix 1 => 30501
+		const id3Max = 30501;
+		expect(auOptionMetaData.options[id3Max]).toBeDefined();
+		expect(result.initialValueData[id3Max]).toBe(1);
 
-        // Chance: Name 3, Type 5, Prefix 2 => 30502
-        const id3Chance = 30502;
-        expect(auOptionMetaData.options[id3Chance]).toBeDefined();
-        expect(result.initialValueData[id3Chance]).toBe(5); // 50 / 10 = 5
-    });
+		// Chance: Name 3, Type 5, Prefix 2 => 30502
+		const id3Chance = 30502;
+		expect(auOptionMetaData.options[id3Chance]).toBeDefined();
+		expect(result.initialValueData[id3Chance]).toBe(5); // 50 / 10 = 5
+	});
 });

--- a/tests/optionUtils.test.ts
+++ b/tests/optionUtils.test.ts
@@ -110,10 +110,13 @@ describe("optionUtils", () => {
 			name: string,
 		) => {
 			const uniqueId = getUniqueOptionId(tabId, categoryId, id);
-			exrOptionMetaData.optionMetaData[uniqueId] = {
-				translatedName: name,
-				format: "",
-				type: "Int32",
+			exrOptionMetaData.options[uniqueId] = {
+				metaData: {
+					translatedName: name,
+					format: "",
+					type: "Int32",
+				},
+				childOptionIds: [],
 			};
 		};
 
@@ -137,17 +140,15 @@ describe("optionUtils", () => {
 				minData: {
 					uniqueOptionId: getUniqueOptionId(tabId, categoryId, 1),
 					metaData:
-						exrOptionMetaData.optionMetaData[
-							getUniqueOptionId(tabId, categoryId, 1)
-						],
+						exrOptionMetaData.options[getUniqueOptionId(tabId, categoryId, 1)]
+							?.metaData,
 					label: "最小",
 				},
 				maxData: {
 					uniqueOptionId: getUniqueOptionId(tabId, categoryId, 2),
 					metaData:
-						exrOptionMetaData.optionMetaData[
-							getUniqueOptionId(tabId, categoryId, 2)
-						],
+						exrOptionMetaData.options[getUniqueOptionId(tabId, categoryId, 2)]
+							?.metaData,
 					label: "最大",
 				},
 			});

--- a/tests/validateOpenedIds.test.ts
+++ b/tests/validateOpenedIds.test.ts
@@ -20,9 +20,9 @@ describe("validateOpenedIds", () => {
 
 	it("should remove non-existent category IDs", () => {
 		// Mock metadata
-		exrOptionMetaData.categoryInfo = {
-			1: "Category 1",
-			2: "Category 2",
+		exrOptionMetaData.categories = {
+			1: { name: "Category 1", tabId: 0 },
+			2: { name: "Category 2", tabId: 0 },
 		};
 
 		// Set initial state
@@ -46,8 +46,11 @@ describe("validateOpenedIds", () => {
 		// Mock metadata
 		const uId1 = 101 as UniqueOptionId;
 		const uId2 = 102 as UniqueOptionId;
-		exrOptionMetaData.optionMetaData = {
-			[uId1]: { translatedName: "Opt 1", format: "", type: "Single" },
+		exrOptionMetaData.options = {
+			[uId1]: {
+				metaData: { translatedName: "Opt 1", format: "", type: "Single" },
+				childOptionIds: [],
+			},
 		};
 
 		// Set initial state
@@ -68,10 +71,13 @@ describe("validateOpenedIds", () => {
 	});
 
 	it("should do nothing if all IDs are valid", () => {
-		exrOptionMetaData.categoryInfo = { 1: "Cat 1" };
+		exrOptionMetaData.categories = { 1: { name: "Cat 1", tabId: 0 } };
 		const uId = 101 as UniqueOptionId;
-		exrOptionMetaData.optionMetaData = {
-			[uId]: { translatedName: "Opt 1", format: "", type: "Single" },
+		exrOptionMetaData.options = {
+			[uId]: {
+				metaData: { translatedName: "Opt 1", format: "", type: "Single" },
+				childOptionIds: [],
+			},
 		};
 
 		const initialState = {


### PR DESCRIPTION
ExROptionMetaDataRecordsのデータ構造を、タブ、カテゴリ、オプションの単位でインターフェースを分割し、それぞれのIDをキーとするネストされたRecord構造にリファクタリングしました。

主な変更点:
1. `src/type.ts`: `ExRTabMetaData`, `ExRCategoryMetaData`, `ExROptionMetaDataDetail` インターフェースを新設し、`ExROptionMetaDataRecords` の各プロパティをこれらの Record 型に変更。
2. `src/logics/api.ts`: `exrOptionMetaData` の初期化処理および `createExROptionMetaData` でのデータ構築ロジックを新構造に合わせて更新。
3. コードベース全体: `exrOptionMetaData.tabs[tabId].name` や `exrOptionMetaData.options[uniqueId].childOptionIds` のような新しいアクセス方式にすべての参照を修正。
4. テストコード: すべての単体テストを新構造に合わせて更新し、`pnpm run test` で全テストがパスすることを確認。
5. コード品質: Biome によるチェックを実行し、コードスタイルを修正。

このリファクタリングにより、各データの責務が明確になり、メタデータへのアクセスが型安全かつ直感的になりました。

---
*PR created automatically by Jules for task [5504692951830843428](https://jules.google.com/task/5504692951830843428) started by @yukieiji*