### PR TITLE
Refactor Au options initialization and implement tab-based selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,13 +31,13 @@ function EditorContainer() {
 
 	// React 19 の use() フックを使用してデータを取得
 	use(getExrOptions());
-	const auData = use(getAuOptions());
+	use(getAuOptions());
 
 	if (selectedTab === "ExR") {
 		return <ExROptionEditor />;
 	}
 
-	return <AuOptionEditor data={auData} />;
+	return <AuOptionEditor />;
 }
 
 /**

--- a/src/feature/AuOptionEditor.tsx
+++ b/src/feature/AuOptionEditor.tsx
@@ -1,21 +1,53 @@
-import type { AuOptionCategoryDto } from "../type";
-
-interface AuOptionEditorProps {
-	data: AuOptionCategoryDto[];
-}
+import { auOptionMetaData } from "../logics/api";
+import { useStore } from "../useStore";
+import { AuTabSelector } from "./AuTabSelector";
 
 /**
  * Auオプションを表示するコンポーネント
  */
-export function AuOptionEditor({ data }: AuOptionEditorProps) {
+export function AuOptionEditor() {
+	const selectedAuTabId = useStore((state) => {
+		return state.selectedAuTabId;
+	});
+	const isAuTabPending = useStore((state) => {
+		return state.isAuTabPending;
+	});
+
+	const categoryIds = auOptionMetaData.tabCategoryMap[selectedAuTabId] || [];
+	const filteredData = categoryIds.map((id) => {
+		const categoryMeta = auOptionMetaData.categoryMetaData[id];
+		return {
+			categoryName: categoryMeta.name,
+			options: categoryMeta.options.map((optId) => {
+				const optMeta = auOptionMetaData.options[optId];
+				return {
+					id: optId,
+					title: optMeta.title,
+					format: optMeta.format,
+					range: optMeta.range,
+				};
+			}),
+		};
+	});
+
 	return (
-		<div className="bg-gray-800 text-green-400 p-6 rounded-lg shadow-lg overflow-auto max-h-[80vh]">
-			<pre
-				data-testid="au-json-pre"
-				className="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed"
+		<div className="flex flex-col gap-4">
+			<AuTabSelector />
+			<div
+				className={`bg-gray-800 text-green-400 p-6 rounded-lg shadow-lg overflow-auto max-h-[80vh] relative transition-opacity duration-200 ${isAuTabPending ? "opacity-50 pointer-events-none" : "opacity-100"}`}
 			>
-				{JSON.stringify(data, null, 2)}
-			</pre>
+				{isAuTabPending && (
+					<div className="absolute inset-0 flex items-center justify-center z-10">
+						<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+					</div>
+				)}
+				<pre
+					data-testid="au-json-pre"
+					className="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed"
+				>
+					{JSON.stringify(filteredData, null, 2)}
+				</pre>
+			</div>
 		</div>
 	);
 }

--- a/src/feature/AuTabSelector.tsx
+++ b/src/feature/AuTabSelector.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useTransition } from "react";
+import { auOptionMetaData } from "../logics/api";
+import { useStore } from "../useStore";
+
+/**
+ * Auオプションのタブ選択コンポーネント
+ */
+export function AuTabSelector() {
+	const selectedAuTabId = useStore((state) => {
+		return state.selectedAuTabId;
+	});
+	const setSelectedAuTabId = useStore((state) => {
+		return state.setSelectedAuTabId;
+	});
+	const setIsTabPending = useStore((state) => {
+		return state.setIsAuTabPending;
+	});
+	const [isPending, startTransition] = useTransition();
+
+	useEffect(() => {
+		// トランジションが完了したらペンディング状態を解除する
+		if (!isPending) {
+			setIsTabPending(false);
+		}
+	}, [isPending, setIsTabPending]);
+
+	const handleClick = (id: number) => {
+		if (id === selectedAuTabId) {
+			return;
+		}
+		// トランジション開始前に即座にペンディング状態にする
+		setIsTabPending(true);
+		startTransition(() => {
+			setSelectedAuTabId(id);
+		});
+	};
+
+	return (
+		<div className="flex flex-wrap gap-2 border-b border-gray-200 pb-2">
+			{auOptionMetaData.tabNames.map((name, index) => {
+				return (
+					<button
+						key={name}
+						type="button"
+						onClick={() => {
+							handleClick(index);
+						}}
+						className={`
+              px-4 py-2 rounded-t-lg transition-colors font-medium
+              ${selectedAuTabId === index ? "bg-blue-500 text-white" : "bg-gray-200 text-gray-700 hover:bg-gray-300"}
+            `}
+					>
+						{name}
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -1,5 +1,3 @@
-import type { AuOptionCategoryDto } from "../type";
-
 import { useStore } from "../useStore";
 import { createAuOptionMetaData, createExROptionMetaData } from "./api";
 
@@ -7,7 +5,7 @@ import { createAuOptionMetaData, createExROptionMetaData } from "./api";
  * APIからデータを取得するPromiseをキャッシュするためのグローバル変数
  * React 19 の use() で扱うためにリクエストを一度だけ実行するようにします
  */
-let auOptionsPromise: Promise<AuOptionCategoryDto[]> | null = null;
+let auOptionsPromise: Promise<void> | null = null;
 let exrOptionsPromise: Promise<void> | null = null;
 
 /**
@@ -48,17 +46,16 @@ export function getExrOptions(): Promise<void> {
 
 async function createAuOptionMetaDataWithStore(
 	delay: number,
-): Promise<AuOptionCategoryDto[]> {
+): Promise<void> {
 	await waitDelay(delay);
-	const { initialValueData, rawData } = await createAuOptionMetaData();
+	const { initialValueData } = await createAuOptionMetaData();
 	useStore.getState().setAuValue(initialValueData);
-	return rawData as AuOptionCategoryDto[];
 }
 
 /**
  * Auオプションを取得する
  */
-export function getAuOptions(): Promise<AuOptionCategoryDto[]> {
+export function getAuOptions(): Promise<void> {
 	if (auOptionsPromise) {
 		return auOptionsPromise;
 	}

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -254,7 +254,6 @@ export async function createAuOptionMetaData(): Promise<{
 
 	return {
 		initialValueData: initialValueData as unknown as Record<AuOptionId, number>,
-		rawData: data,
 	};
 }
 

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -9,6 +9,8 @@ export interface AuOptionViewerSlice {
 	isAuTabPending: boolean;
 	openedAuCategoryIds: Record<number, boolean>;
 	auValue: Record<AuOptionId, number>; // セレクション
+	setSelectedAuTabId: (id: number) => void;
+	setIsAuTabPending: (isPending: boolean) => void;
 	setAuValue: (value: Record<AuOptionId, number>) => void;
 }
 
@@ -23,6 +25,12 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 		isAuTabPending: false,
 		openedAuCategoryIds: {},
 		auValue: {},
+		setSelectedAuTabId: (id: number) => {
+			set({ selectedAuTabId: id });
+		},
+		setIsAuTabPending: (isPending: boolean) => {
+			set({ isAuTabPending: isPending });
+		},
 		setAuValue(value) {
 			set({ auValue: value });
 		},

--- a/tests/OptionEditor.test.tsx
+++ b/tests/OptionEditor.test.tsx
@@ -1,21 +1,22 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { AuOptionEditor } from "../src/feature/AuOptionEditor";
-import type { AuOptionCategoryDto } from "../src/type";
+import { auOptionMetaData } from "../src/logics/api";
 
 describe("OptionEditor Components", () => {
 	it("AuOptionEditor がデータを正しく表示すること", () => {
-		const mockData: AuOptionCategoryDto[] = [
-			{
-				TranslatedTitle: "Test Category",
-				Options: [],
+		auOptionMetaData.categoryMetaData = {
+			0: {
+				name: "Test Category",
+				options: [],
 			},
-		];
+		};
+		auOptionMetaData.tabCategoryMap = { 0: [0] };
 
-		render(<AuOptionEditor data={mockData} />);
+		render(<AuOptionEditor />);
 
 		const pre = screen.getByText((content) => {
-			return content.includes('"TranslatedTitle": "Test Category"');
+			return content.includes('"categoryName": "Test Category"');
 		});
 		expect(pre).toBeTruthy();
 	});

--- a/tests/OptionEditor.test.tsx
+++ b/tests/OptionEditor.test.tsx
@@ -1,9 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { AuOptionEditor } from "../src/feature/AuOptionEditor";
-import { auOptionMetaData } from "../src/logics/api";
+import { auOptionMetaData, resetAuOptionMetaData } from "../src/logics/api";
 
 describe("OptionEditor Components", () => {
+	beforeEach(() => {
+		resetAuOptionMetaData();
+	});
+
 	it("AuOptionEditor がデータを正しく表示すること", () => {
 		auOptionMetaData.categoryMetaData = {
 			0: {


### PR DESCRIPTION
This PR refactors the Au options system to mirror the ExR options' initialization and tab selection logic. Key changes include:
- `getAuOptions` now returns `Promise<void>`, updating the store and global metadata internally.
- `AuTabSelector` provides a tabbed UI for Au options, using `useTransition` for smooth state updates.
- `AuOptionEditor` displays only the categories and options belonging to the currently selected tab, formatted as JSON as per current requirements.
- Store slices and metadata records have been updated to support these changes and maintain consistency across the application.

---
*PR created automatically by Jules for task [8371314342781132426](https://jules.google.com/task/8371314342781132426) started by @yukieiji*