### PR TITLE
Fix Biome lint errors and test bugs

### DIFF
--- a/tests/ExROptionEditor.test.tsx
+++ b/tests/ExROptionEditor.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { Suspense } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExROptionEditor } from "../src/feature/ExROptionEditor";
-import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import { resetExrOptionMetaData } from "../src/logics/api";
 import { getExrOptions, resetApiCache } from "../src/logics/api.store";
 import type { ExRTabDto } from "../src/type";
 import { useStore } from "../src/useStore";
@@ -108,33 +108,10 @@ describe("ExROptionEditor", () => {
 			vi.fn().mockResolvedValue({
 				ok: true,
 				json: vi.fn().mockResolvedValue(mockData),
-			}),
+			} as Response),
 		);
 
 		await getExrOptions();
-
-		// プロダクトコードのバグ（uniqueId ではなく optionId でストアを参照している箇所など）を
-		// 回避するために、テストコード側でグローバル状態を調整する
-		const state = useStore.getState();
-
-		// 1. isOptionActive を optionId でも引けるようにする（ExRStandardCategoryList 用）
-		const newActive = { ...state.isExROptionActive };
-		for (const [uId, active] of Object.entries(state.isExROptionActive)) {
-			const oId = Number(uId) % 10000;
-			newActive[oId] = active;
-		}
-
-		// 2. childOptionIds を uniqueId ではなく optionId の配列にする（ExRRoleCategoryItem 用）
-		for (const uId in exrOptionMetaData.options) {
-			const option = exrOptionMetaData.options[Number(uId)];
-			if (option) {
-				option.childOptionIds = option.childOptionIds.map(
-					(cid) => (Number(cid) % 10000) as any,
-				);
-			}
-		}
-
-		useStore.setState({ isExROptionActive: newActive });
 	});
 
 	it("should only show visible categories (not empty, at least one active option) and hide preset", () => {

--- a/tests/auOptionMetaData.test.ts
+++ b/tests/auOptionMetaData.test.ts
@@ -4,7 +4,7 @@ import {
 	createAuOptionMetaData,
 	resetAuOptionMetaData,
 } from "../src/logics/api";
-import { OptionValueType } from "../src/type";
+import { type AuOptionId, OptionValueType } from "../src/type";
 
 // Mock global fetch
 global.fetch = vi.fn();
@@ -53,10 +53,10 @@ describe("createAuOptionMetaData", () => {
 			},
 		];
 
-		(fetch as any).mockResolvedValue({
+		vi.mocked(fetch).mockResolvedValue({
 			ok: true,
 			json: async () => mockData,
-		});
+		} as Response);
 
 		const result = await createAuOptionMetaData();
 
@@ -70,25 +70,25 @@ describe("createAuOptionMetaData", () => {
 
 		// Check options
 		// NormalOption: Name 1, Type 2 (Int), Prefix 0 => 10200
-		const id1 = 10200;
+		const id1 = 10200 as AuOptionId;
 		expect(auOptionMetaData.options[id1]).toBeDefined();
 		expect(auOptionMetaData.options[id1].title).toBe("NormalOption");
-		expect(result.initialValueData[id1]).toBe(1); // Index of 10 in [0, 10, 20]
+		expect(result[id1]).toBe(1); // Index of 10 in [0, 10, 20]
 
 		// BoolOption: Name 2, Type 0 (Bool), Prefix 0 => 20000
-		const id2 = 20000;
+		const id2 = 20000 as AuOptionId;
 		expect(auOptionMetaData.options[id2]).toBeDefined();
-		expect(result.initialValueData[id2]).toBe(1); // true => 1
+		expect(result[id2]).toBe(1); // true => 1
 
 		// RoleBase: Name 3, Type 5 (RoleBase)
 		// MaxCount: Name 3, Type 5, Prefix 1 => 30501
-		const id3Max = 30501;
+		const id3Max = 30501 as AuOptionId;
 		expect(auOptionMetaData.options[id3Max]).toBeDefined();
-		expect(result.initialValueData[id3Max]).toBe(1);
+		expect(result[id3Max]).toBe(1);
 
 		// Chance: Name 3, Type 5, Prefix 2 => 30502
-		const id3Chance = 30502;
+		const id3Chance = 30502 as AuOptionId;
 		expect(auOptionMetaData.options[id3Chance]).toBeDefined();
-		expect(result.initialValueData[id3Chance]).toBe(5); // 50 / 10 = 5
+		expect(result[id3Chance]).toBe(5); // 50 / 10 = 5
 	});
 });


### PR DESCRIPTION
Fixed Biome lint errors (suspicious/noExplicitAny) and addressed technical debt in test files. Removed "reasonless" mocking that manipulated global state with magic numbers, as confirmed by the user that it was a bug in the test code. Improved type safety by using `vi.mocked` and appropriate type casts instead of `any`. verified that all tests continue to pass after these cleanups.

---
*PR created automatically by Jules for task [12788511796036328690](https://jules.google.com/task/12788511796036328690) started by @yukieiji*