### PR TITLE
Refactor AuOptionEditor to use accordion interface

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -22,7 +22,7 @@ test.beforeEach(async ({ page }) => {
 	});
 });
 
-test("has sidebar and json viewer", async ({ page }) => {
+test("has sidebar and au option editor", async ({ page }) => {
 	const sidebar = page.getByLabel("オプションサイドバー");
 
 	// サイドバー内のボタンを明示的に指定
@@ -35,10 +35,9 @@ test("has sidebar and json viewer", async ({ page }) => {
 
 	// Au Options が初期で表示されることを確認する
 	await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible();
-	// 以前のデータには "ゲーム設定" があったが、新しいデータには "インポスター" などがある
-	await expect(page.getByTestId("au-json-pre")).toContainText(
-		'"TranslatedTitle": "インポスター"',
-	);
+
+	// アコーディオンが表示されていることを確認 (JSON preはなくなった)
+	await expect(page.getByTestId("au-category-list")).toBeVisible();
 
 	// ExR Options に切り替え
 	await sidebar.getByRole("button", { name: "ExR Options" }).click();

--- a/e2e/au-options.spec.ts
+++ b/e2e/au-options.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 0;
+	});
+	await page.goto("/");
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+
+	// Au Options タブに切り替え
+	await page.getByRole("button", { name: "Au Options" }).click();
+	await page.waitForSelector('[data-testid="au-category-list"]');
+});
+
+test.describe("Au Option Interactions", () => {
+	test("should display accordion for general tab categories", async ({
+		page,
+	}) => {
+		// Tab 0 (General)
+		await page.getByRole("button", { name: "0", exact: true }).click();
+
+		const category = page.getByTestId("au-category-0");
+		await expect(category.getByText("map")).toBeVisible();
+
+		// Initially closed
+		// AuOptionControl uses OptionDropdownControl which has a role of "combobox" when using StringSelector
+		// But map category first option is a string selector
+		await expect(category.getByRole("button", { name: "map" })).toBeVisible();
+
+		// Open it
+		await category.getByRole("button", { name: "map" }).click();
+		// In Accordion.tsx, the content is inside a div with data-testid="accordion-content"
+		const content = category.getByTestId("accordion-content");
+		await expect(content).toBeVisible();
+		// map category has a numeric range [0, 1, 2, 4, 5], so it uses OptionSliderControl
+		await expect(content.locator('input[type="range"]')).toBeVisible();
+		await expect(content.locator('input[type="text"]')).toBeVisible();
+	});
+
+	test("should display role controls in header for role tabs", async ({
+		page,
+	}) => {
+		// Tab 1
+		await page.getByRole("button", { name: "1", exact: true }).click();
+
+		// Initially chance is probably 0, so it's disabled
+		const category = page
+			.getByTestId("au-category-list")
+			.locator("> div")
+			.first();
+		await expect(category.getByTestId("au-chance-control")).toBeVisible();
+		await expect(category.getByTestId("au-max-count-control")).toBeVisible();
+
+		// Accordion button should be disabled when chance is 0
+		const toggleButton = category.locator("button").first();
+		await expect(toggleButton).toBeDisabled();
+	});
+
+	test("should synchronize chance and max count in Au roles", async ({
+		page,
+	}) => {
+		await page.getByRole("button", { name: "1", exact: true }).click();
+
+		const category = page
+			.getByTestId("au-category-list")
+			.locator("> div")
+			.first();
+		const chanceControl = category.getByTestId("au-chance-control");
+		const countControl = category.getByTestId("au-max-count-control");
+
+		const chanceInput = chanceControl.locator('input[type="text"]');
+		const countInput = countControl.locator('input[type="text"]');
+		const chanceSlider = chanceControl.locator('input[type="range"]');
+		const countSlider = countControl.locator('input[type="range"]');
+
+		// 1. Set count to 1, should set chance to 10%
+		await countSlider.fill("1");
+		await expect(countInput).toHaveValue("1");
+		await expect(chanceInput).toHaveValue("10");
+
+		// 2. Set chance to 0, should set count to 0 (Wait, in AuRoleSpawnControls.tsx handleChanceChange doesn't zero count)
+		// Actually, in handleMaxCountChange(0), it zeros chance. But in handleChanceChange(0), it only closes accordion.
+		// Let's re-verify the requirement. "ExRと同じように"
+		// In ExRRoleSpawnControls.tsx, handleRateChange(0) does NOT zero count.
+		// But handleCountUIChange(0) DOES zero rate.
+		// So my test #2 was wrong if it's mirroring ExR exactly.
+		await chanceSlider.fill("0");
+		await expect(chanceInput).toHaveValue("0");
+		// Count stays 1 in ExR logic if only rate is zeroed
+		await expect(countInput).toHaveValue("1");
+
+		// 3. Set count to 0, should set chance to 0%
+		await countSlider.fill("0");
+		await expect(countInput).toHaveValue("0");
+		await expect(chanceInput).toHaveValue("0");
+	});
+
+	test("expanding role accordion should show other options", async ({
+		page,
+	}) => {
+		await page.getByRole("button", { name: "1", exact: true }).click();
+
+		const category = page
+			.getByTestId("au-category-list")
+			.locator("> div")
+			.first();
+		const toggleButton = category.locator("button").first();
+
+		// Set chance to 100% to enable accordion
+		await category
+			.getByTestId("au-chance-control")
+			.locator('input[type="range"]')
+			.fill("10");
+
+		await expect(toggleButton).not.toBeDisabled();
+		await toggleButton.click();
+
+		// Should show additional options inside
+		// Since I don't know the exact options in mock data, I'll just check if the content area appears
+		await expect(category.locator(".bg-gray-900")).toBeVisible();
+	});
+});

--- a/e2e/au-options.spec.ts
+++ b/e2e/au-options.spec.ts
@@ -82,18 +82,17 @@ test.describe("Au Option Interactions", () => {
 		await expect(countInput).toHaveValue("1");
 		await expect(chanceInput).toHaveValue("10");
 
-		// 2. Set chance to 0, should set count to 0 (Wait, in AuRoleSpawnControls.tsx handleChanceChange doesn't zero count)
-		// Actually, in handleMaxCountChange(0), it zeros chance. But in handleChanceChange(0), it only closes accordion.
-		// Let's re-verify the requirement. "ExRと同じように"
-		// In ExRRoleSpawnControls.tsx, handleRateChange(0) does NOT zero count.
-		// But handleCountUIChange(0) DOES zero rate.
-		// So my test #2 was wrong if it's mirroring ExR exactly.
+		// 2. Set chance to 0, should set count to 0
 		await chanceSlider.fill("0");
 		await expect(chanceInput).toHaveValue("0");
-		// Count stays 1 in ExR logic if only rate is zeroed
-		await expect(countInput).toHaveValue("1");
+		await expect(countInput).toHaveValue("0");
 
-		// 3. Set count to 0, should set chance to 0%
+		// 3. Set count to 1, should set chance to 10%
+		await countSlider.fill("1");
+		await expect(countInput).toHaveValue("1");
+		await expect(chanceInput).toHaveValue("10");
+
+		// 4. Set count to 0, should set chance to 0%
 		await countSlider.fill("0");
 		await expect(countInput).toHaveValue("0");
 		await expect(chanceInput).toHaveValue("0");

--- a/src/feature/AuCategoryList.tsx
+++ b/src/feature/AuCategoryList.tsx
@@ -1,0 +1,35 @@
+import { useStore } from "../useStore";
+import { auOptionMetaData } from "../logics/api";
+import { AuRoleCategoryItem } from "./AuRoleCategoryItem";
+import { AuStandardCategoryItem } from "./AuStandardCategoryItem";
+
+/**
+ * Auの選択されたタブのカテゴリ一覧を表示するコンポーネント
+ */
+export function AuCategoryList() {
+	const selectedAuTabId = useStore((state) => state.selectedAuTabId);
+	const isTabPending = useStore((state) => state.isAuTabPending);
+
+	const tabCategoryIds = auOptionMetaData.tabCategoryMap[selectedAuTabId] || [];
+	const isRoleTab = selectedAuTabId === 1 || selectedAuTabId === 2;
+
+	return (
+		<div
+			data-testid="au-category-list"
+			className={`flex flex-col relative transition-opacity duration-200 ${isTabPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
+		>
+			{isTabPending && (
+				<div className="absolute inset-0 flex items-center justify-center z-10">
+					<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+				</div>
+			)}
+			{tabCategoryIds.map((categoryId) => (
+				isRoleTab ? (
+					<AuRoleCategoryItem key={categoryId} categoryId={categoryId} />
+				) : (
+					<AuStandardCategoryItem key={categoryId} categoryId={categoryId} />
+				)
+			))}
+		</div>
+	);
+}

--- a/src/feature/AuCategoryList.tsx
+++ b/src/feature/AuCategoryList.tsx
@@ -1,5 +1,5 @@
-import { useStore } from "../useStore";
 import { auOptionMetaData } from "../logics/api";
+import { useStore } from "../useStore";
 import { AuRoleCategoryItem } from "./AuRoleCategoryItem";
 import { AuStandardCategoryItem } from "./AuStandardCategoryItem";
 
@@ -23,13 +23,13 @@ export function AuCategoryList() {
 					<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
 				</div>
 			)}
-			{tabCategoryIds.map((categoryId) => (
+			{tabCategoryIds.map((categoryId) =>
 				isRoleTab ? (
 					<AuRoleCategoryItem key={categoryId} categoryId={categoryId} />
 				) : (
 					<AuStandardCategoryItem key={categoryId} categoryId={categoryId} />
-				)
-			))}
+				),
+			)}
 		</div>
 	);
 }

--- a/src/feature/AuCategoryOptionList.tsx
+++ b/src/feature/AuCategoryOptionList.tsx
@@ -1,0 +1,19 @@
+import type { AuOptionId } from "../type";
+import { AuOptionRow } from "./AuOptionRow";
+
+interface AuCategoryOptionListProps {
+	optionIds: AuOptionId[];
+}
+
+/**
+ * Auのカテゴリ内オプション一覧を表示するコンポーネント
+ */
+export function AuCategoryOptionList({ optionIds }: AuCategoryOptionListProps) {
+	return (
+		<div className="flex flex-col gap-2">
+			{optionIds.map((optionId) => (
+				<AuOptionRow key={optionId} optionId={optionId} />
+			))}
+		</div>
+	);
+}

--- a/src/feature/AuOptionControl.tsx
+++ b/src/feature/AuOptionControl.tsx
@@ -1,0 +1,53 @@
+import { OptionToggleControl } from "../components/blocks/OptionToggleControl";
+import { OptionDropdownControl } from "../components/parts/OptionDropdownControl";
+import { OptionSliderControl } from "../components/parts/OptionSliderControl";
+import type { AuOptionMeta } from "../type";
+
+interface AuOptionControlProps {
+	optionMeta: AuOptionMeta;
+	selection: number;
+	onSelectionChange: (selection: number) => void;
+}
+
+/**
+ * Auのオプション値を変更するためのコントロール
+ */
+export function AuOptionControl({
+	optionMeta,
+	selection,
+	onSelectionChange,
+}: AuOptionControlProps) {
+	const range = optionMeta.range;
+
+	// Boolean型の判定
+	if (range.length === 2 && typeof range[0] === "boolean") {
+		return (
+			<OptionToggleControl
+				selection={selection}
+				values={["<color=#ff0000>OFF</color>", "<color=#00ff00>ON</color>"]}
+				onChange={onSelectionChange}
+			/>
+		);
+	}
+
+	// 数値(Slider)か文字列(Selector)かの判定
+	if (typeof range[0] === "number") {
+		const numRange = range as number[];
+		return (
+			<OptionSliderControl
+				values={numRange}
+				selection={selection}
+				format={optionMeta.format}
+				onChange={onSelectionChange}
+			/>
+		);
+	}
+
+	return (
+		<OptionDropdownControl
+			values={range as string[]}
+			selection={selection}
+			onChange={onSelectionChange}
+		/>
+	);
+}

--- a/src/feature/AuOptionEditor.tsx
+++ b/src/feature/AuOptionEditor.tsx
@@ -1,53 +1,14 @@
-import { auOptionMetaData } from "../logics/api";
-import { useStore } from "../useStore";
+import { AuCategoryList } from "./AuCategoryList";
 import { AuTabSelector } from "./AuTabSelector";
 
 /**
  * Auオプションを表示するコンポーネント
  */
 export function AuOptionEditor() {
-	const selectedAuTabId = useStore((state) => {
-		return state.selectedAuTabId;
-	});
-	const isAuTabPending = useStore((state) => {
-		return state.isAuTabPending;
-	});
-
-	const categoryIds = auOptionMetaData.tabCategoryMap[selectedAuTabId] || [];
-	const filteredData = categoryIds.map((id) => {
-		const categoryMeta = auOptionMetaData.categoryMetaData[id];
-		return {
-			categoryName: categoryMeta.name,
-			options: categoryMeta.options.map((optId) => {
-				const optMeta = auOptionMetaData.options[optId];
-				return {
-					id: optId,
-					title: optMeta.title,
-					format: optMeta.format,
-					range: optMeta.range,
-				};
-			}),
-		};
-	});
-
 	return (
 		<div className="flex flex-col gap-4">
 			<AuTabSelector />
-			<div
-				className={`bg-gray-800 text-green-400 p-6 rounded-lg shadow-lg overflow-auto max-h-[80vh] relative transition-opacity duration-200 ${isAuTabPending ? "opacity-50 pointer-events-none" : "opacity-100"}`}
-			>
-				{isAuTabPending && (
-					<div className="absolute inset-0 flex items-center justify-center z-10">
-						<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
-					</div>
-				)}
-				<pre
-					data-testid="au-json-pre"
-					className="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed"
-				>
-					{JSON.stringify(filteredData, null, 2)}
-				</pre>
-			</div>
+			<AuCategoryList />
 		</div>
 	);
 }

--- a/src/feature/AuOptionRow.tsx
+++ b/src/feature/AuOptionRow.tsx
@@ -17,7 +17,9 @@ export function AuOptionRow({ optionId }: AuOptionRowProps) {
 		(state) => state.updateAuOptionSelection,
 	);
 
-	if (!optionMeta) return null;
+	if (!optionMeta) {
+		return null;
+	}
 
 	return (
 		<div className="flex items-center justify-between py-2 border-b border-gray-800 last:border-0 hover:bg-gray-800/50 transition-colors px-2 rounded">

--- a/src/feature/AuOptionRow.tsx
+++ b/src/feature/AuOptionRow.tsx
@@ -13,7 +13,9 @@ interface AuOptionRowProps {
 export function AuOptionRow({ optionId }: AuOptionRowProps) {
 	const optionMeta = auOptionMetaData.options[optionId];
 	const selection = useStore((state) => state.auValue[optionId] ?? 0);
-	const updateAuOptionSelection = useStore((state) => state.updateAuOptionSelection);
+	const updateAuOptionSelection = useStore(
+		(state) => state.updateAuOptionSelection,
+	);
 
 	if (!optionMeta) return null;
 
@@ -29,7 +31,10 @@ export function AuOptionRow({ optionId }: AuOptionRowProps) {
 					optionMeta={optionMeta}
 					selection={selection}
 					onSelectionChange={(newSelection) => {
-						updateAuOptionSelection({ auOptionId: optionId, selection: newSelection });
+						updateAuOptionSelection({
+							auOptionId: optionId,
+							selection: newSelection,
+						});
 					}}
 				/>
 			</div>

--- a/src/feature/AuOptionRow.tsx
+++ b/src/feature/AuOptionRow.tsx
@@ -1,0 +1,38 @@
+import { auOptionMetaData } from "../logics/api";
+import type { AuOptionId } from "../type";
+import { useStore } from "../useStore";
+import { AuOptionControl } from "./AuOptionControl";
+
+interface AuOptionRowProps {
+	optionId: AuOptionId;
+}
+
+/**
+ * Auの各オプション行を表示するコンポーネント
+ */
+export function AuOptionRow({ optionId }: AuOptionRowProps) {
+	const optionMeta = auOptionMetaData.options[optionId];
+	const selection = useStore((state) => state.auValue[optionId] ?? 0);
+	const updateAuOptionSelection = useStore((state) => state.updateAuOptionSelection);
+
+	if (!optionMeta) return null;
+
+	return (
+		<div className="flex items-center justify-between py-2 border-b border-gray-800 last:border-0 hover:bg-gray-800/50 transition-colors px-2 rounded">
+			<div className="flex flex-col flex-1 min-w-0 mr-4">
+				<span className="text-gray-200 text-sm font-medium truncate">
+					{optionMeta.title}
+				</span>
+			</div>
+			<div className="flex-shrink-0">
+				<AuOptionControl
+					optionMeta={optionMeta}
+					selection={selection}
+					onSelectionChange={(newSelection) => {
+						updateAuOptionSelection({ auOptionId: optionId, selection: newSelection });
+					}}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/feature/AuRoleCategoryItem.tsx
+++ b/src/feature/AuRoleCategoryItem.tsx
@@ -1,0 +1,102 @@
+import { useStore } from "../useStore";
+import { auOptionMetaData } from "../logics/api";
+import { AuRoleSpawnControls } from "./AuRoleSpawnControls";
+import { AuCategoryOptionList } from "./AuCategoryOptionList";
+
+interface AuRoleCategoryItemProps {
+	categoryId: number;
+}
+
+/**
+ * Auの役職タブ（Tab 1, 2）で使用される、スポーン設定をヘッダーに持つカテゴリ表示コンポーネント
+ */
+export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
+	const isOpen = useStore((state) => state.openedAuCategoryIds[categoryId] ?? false);
+	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
+	const auValue = useStore((state) => state.auValue);
+
+	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
+	if (!categoryMeta) return null;
+
+	// 各カテゴリの最初(0)がChance、次(1)がMaxCount
+	const chanceOptionId = categoryMeta.options[0];
+	const chanceValueIndex = auValue[chanceOptionId] ?? 0;
+	const chanceOptionMeta = auOptionMetaData.options[chanceOptionId];
+
+	// Chanceの実際の値（%）を取得
+	const chanceActualValue = chanceOptionMeta?.range[chanceValueIndex];
+	const isChanceZero = chanceActualValue === 0;
+
+	const isOpenFinal = !isChanceZero && isOpen;
+
+	// 残りのオプション
+	const otherOptionIds = categoryMeta.options.slice(2);
+
+	return (
+		<div
+			className="border border-gray-700 rounded-lg overflow-hidden mb-2"
+			data-testid={`au-category-${categoryId}`}
+		>
+			<div
+				className={`flex items-center bg-gray-800 ${!isChanceZero ? "hover:bg-gray-700 transition-colors" : ""}`}
+			>
+				<button
+					type="button"
+					onClick={() => {
+						if (!isChanceZero) {
+							toggleAuCategory(categoryId);
+						}
+					}}
+					className={`flex-1 flex items-center gap-3 p-4 text-left ${isChanceZero ? "cursor-default" : ""}`}
+					aria-expanded={isOpenFinal}
+					disabled={isChanceZero}
+				>
+					{isChanceZero ? (
+						<div className="w-5 h-5 flex items-center justify-center text-gray-500 font-bold">
+							・
+						</div>
+					) : (
+						<svg
+							className={`w-5 h-5 transition-transform duration-200 text-gray-400 ${isOpenFinal ? "rotate-180" : ""}`}
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<title>{isOpenFinal ? "Collapse" : "Expand"}</title>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M19 9l-7 7-7-7"
+							/>
+						</svg>
+					)}
+					<span className="font-semibold text-gray-200">
+						{categoryMeta.name}
+					</span>
+				</button>
+
+				<div className="flex items-center px-4">
+					<AuRoleSpawnControls categoryId={categoryId} />
+				</div>
+			</div>
+
+			<div
+				className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
+					isOpenFinal ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+				}`}
+			>
+				<div className="min-h-0">
+					{isOpenFinal && otherOptionIds.length > 0 && (
+						<div className="p-4 bg-gray-900 border-t border-gray-700">
+							<AuCategoryOptionList
+								categoryId={categoryId}
+								optionIds={otherOptionIds}
+							/>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/feature/AuRoleCategoryItem.tsx
+++ b/src/feature/AuRoleCategoryItem.tsx
@@ -26,7 +26,7 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 	const chanceOptionMeta = auOptionMetaData.options[chanceOptionId];
 
 	// Chanceの実際の値（%）を取得
-	const chanceActualValue = chanceOptionMeta?.range[chanceValueIndex];
+	const chanceActualValue = chanceOptionMeta?.range?.[chanceValueIndex] ?? 0;
 	const isChanceZero = chanceActualValue === 0;
 
 	const isOpenFinal = !isChanceZero && isOpen;

--- a/src/feature/AuRoleCategoryItem.tsx
+++ b/src/feature/AuRoleCategoryItem.tsx
@@ -1,7 +1,7 @@
-import { useStore } from "../useStore";
 import { auOptionMetaData } from "../logics/api";
-import { AuRoleSpawnControls } from "./AuRoleSpawnControls";
+import { useStore } from "../useStore";
 import { AuCategoryOptionList } from "./AuCategoryOptionList";
+import { AuRoleSpawnControls } from "./AuRoleSpawnControls";
 
 interface AuRoleCategoryItemProps {
 	categoryId: number;
@@ -11,7 +11,9 @@ interface AuRoleCategoryItemProps {
  * Auの役職タブ（Tab 1, 2）で使用される、スポーン設定をヘッダーに持つカテゴリ表示コンポーネント
  */
 export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
-	const isOpen = useStore((state) => state.openedAuCategoryIds[categoryId] ?? false);
+	const isOpen = useStore(
+		(state) => state.openedAuCategoryIds[categoryId] ?? false,
+	);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
 	const auValue = useStore((state) => state.auValue);
 
@@ -89,10 +91,7 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 				<div className="min-h-0">
 					{isOpenFinal && otherOptionIds.length > 0 && (
 						<div className="p-4 bg-gray-900 border-t border-gray-700">
-							<AuCategoryOptionList
-								categoryId={categoryId}
-								optionIds={otherOptionIds}
-							/>
+							<AuCategoryOptionList optionIds={otherOptionIds} />
 						</div>
 					)}
 				</div>

--- a/src/feature/AuRoleCategoryItem.tsx
+++ b/src/feature/AuRoleCategoryItem.tsx
@@ -18,7 +18,9 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 	const auValue = useStore((state) => state.auValue);
 
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
-	if (!categoryMeta) return null;
+	if (!categoryMeta) {
+		return null;
+	}
 
 	// 各カテゴリの最初(0)がChance、次(1)がMaxCount
 	const chanceOptionId = categoryMeta.options[0];

--- a/src/feature/AuRoleSpawnControls.tsx
+++ b/src/feature/AuRoleSpawnControls.tsx
@@ -43,28 +43,31 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	const maxCountValues = (maxCountMeta?.range as number[]) ?? [];
 
 	const isChanceZero = (chanceValues[chanceSelection] ?? 0) === 0;
+	const isMaxCountZero = (maxCountValues[maxCountSelection] ?? 0) === 0;
 
 	const handleChanceChange = (newSelection: number) => {
-		// Chanceが0%になったら、スポーン数も0にしてアコーディオンを閉じる
-		if (chanceValues[newSelection] === 0) {
-			updateAuOptionSelection(
-				{
-					auOptionId: chanceOptionId,
-					selection: newSelection,
-				},
-				{
-					auOptionId: maxCountOptionId,
-					selection: 0,
-				},
-			);
+		const chanceOptionUpdate = {
+			auOptionId: chanceOptionId,
+			selection: newSelection,
+		};
+
+		// Chanceが0%以外に変更されたとき、数が0なら1にあげる
+		if (isMaxCountZero && (chanceValues[newSelection] ?? 0) > 0) {
+			updateAuOptionSelection(chanceOptionUpdate, {
+				auOptionId: maxCountOptionId,
+				selection: findClosestIndex(maxCountValues, 1),
+			});
+		} else if (chanceValues[newSelection] === 0) {
+			// Chanceが0%になったら、スポーン数も0にしてアコーディオンを閉じる
+			updateAuOptionSelection(chanceOptionUpdate, {
+				auOptionId: maxCountOptionId,
+				selection: 0,
+			});
 			if (isOpenedCategory) {
 				toggleAuCategory(categoryId);
 			}
 		} else {
-			updateAuOptionSelection({
-				auOptionId: chanceOptionId,
-				selection: newSelection,
-			});
+			updateAuOptionSelection(chanceOptionUpdate);
 		}
 	};
 
@@ -73,17 +76,19 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	};
 
 	const handleMaxCountChange = (newSelection: number) => {
+		const countOptionUpdate = {
+			auOptionId: maxCountOptionId,
+			selection: newSelection,
+		};
+
 		// 数が0以外に変更されたとき、現在Chanceが0%なら10%に上げる
-		if ((maxCountValues[newSelection] ?? 0) > 0 && isChanceZero) {
+		if (isChanceZero && (maxCountValues[newSelection] ?? 0) > 0) {
 			updateAuOptionSelection(
 				{
 					auOptionId: chanceOptionId,
 					selection: findClosestIndex(chanceValues, 10),
 				},
-				{
-					auOptionId: maxCountOptionId,
-					selection: newSelection,
-				},
+				countOptionUpdate,
 			);
 		} else if ((maxCountValues[newSelection] ?? 0) === 0) {
 			// 数を0にすると、Chanceも0%にする
@@ -92,19 +97,13 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 					auOptionId: chanceOptionId,
 					selection: findClosestIndex(chanceValues, 0),
 				},
-				{
-					auOptionId: maxCountOptionId,
-					selection: newSelection,
-				},
+				countOptionUpdate,
 			);
 			if (isOpenedCategory) {
 				toggleAuCategory(categoryId);
 			}
 		} else {
-			updateAuOptionSelection({
-				auOptionId: maxCountOptionId,
-				selection: newSelection,
-			});
+			updateAuOptionSelection(countOptionUpdate);
 		}
 	};
 

--- a/src/feature/AuRoleSpawnControls.tsx
+++ b/src/feature/AuRoleSpawnControls.tsx
@@ -45,16 +45,26 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	const isChanceZero = (chanceValues[chanceSelection] ?? 0) === 0;
 
 	const handleChanceChange = (newSelection: number) => {
-		updateAuOptionSelection({
-			auOptionId: chanceOptionId,
-			selection: newSelection,
-		});
-
-		// Chanceが0%になったら、アコーディオンを閉じる
+		// Chanceが0%になったら、スポーン数も0にしてアコーディオンを閉じる
 		if (chanceValues[newSelection] === 0) {
+			updateAuOptionSelection(
+				{
+					auOptionId: chanceOptionId,
+					selection: newSelection,
+				},
+				{
+					auOptionId: maxCountOptionId,
+					selection: 0,
+				},
+			);
 			if (isOpenedCategory) {
 				toggleAuCategory(categoryId);
 			}
+		} else {
+			updateAuOptionSelection({
+				auOptionId: chanceOptionId,
+				selection: newSelection,
+			});
 		}
 	};
 

--- a/src/feature/AuRoleSpawnControls.tsx
+++ b/src/feature/AuRoleSpawnControls.tsx
@@ -29,8 +29,9 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 		!categoryMeta ||
 		chanceOptionId === undefined ||
 		maxCountOptionId === undefined
-	)
+	) {
 		return null;
+	}
 
 	const chanceSelection = auValue[chanceOptionId] ?? 0;
 	const maxCountSelection = auValue[maxCountOptionId] ?? 0;

--- a/src/feature/AuRoleSpawnControls.tsx
+++ b/src/feature/AuRoleSpawnControls.tsx
@@ -12,8 +12,9 @@ interface AuRoleSpawnControlsProps {
  */
 export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
-	const chanceOptionId = categoryMeta.options[0];
-	const maxCountOptionId = categoryMeta.options[1];
+
+	const chanceOptionId = categoryMeta?.options[0];
+	const maxCountOptionId = categoryMeta?.options[1];
 
 	const auValue = useStore((state) => state.auValue);
 	const updateAuOptionSelection = useStore(
@@ -24,6 +25,13 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 		(state) => state.openedAuCategoryIds[categoryId] ?? false,
 	);
 
+	if (
+		!categoryMeta ||
+		chanceOptionId === undefined ||
+		maxCountOptionId === undefined
+	)
+		return null;
+
 	const chanceSelection = auValue[chanceOptionId] ?? 0;
 	const maxCountSelection = auValue[maxCountOptionId] ?? 0;
 
@@ -33,7 +41,7 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	const chanceValues = (chanceMeta?.range as number[]) ?? [];
 	const maxCountValues = (maxCountMeta?.range as number[]) ?? [];
 
-	const isChanceZero = chanceValues[chanceSelection] === 0;
+	const isChanceZero = (chanceValues[chanceSelection] ?? 0) === 0;
 
 	const handleChanceChange = (newSelection: number) => {
 		updateAuOptionSelection({
@@ -55,7 +63,7 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 
 	const handleMaxCountChange = (newSelection: number) => {
 		// 数が0以外に変更されたとき、現在Chanceが0%なら10%に上げる
-		if (maxCountValues[newSelection] > 0 && isChanceZero) {
+		if ((maxCountValues[newSelection] ?? 0) > 0 && isChanceZero) {
 			updateAuOptionSelection(
 				{
 					auOptionId: chanceOptionId,
@@ -66,7 +74,7 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 					selection: newSelection,
 				},
 			);
-		} else if (maxCountValues[newSelection] === 0) {
+		} else if ((maxCountValues[newSelection] ?? 0) === 0) {
 			// 数を0にすると、Chanceも0%にする
 			updateAuOptionSelection(
 				{

--- a/src/feature/AuRoleSpawnControls.tsx
+++ b/src/feature/AuRoleSpawnControls.tsx
@@ -16,9 +16,13 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	const maxCountOptionId = categoryMeta.options[1];
 
 	const auValue = useStore((state) => state.auValue);
-	const updateAuOptionSelection = useStore((state) => state.updateAuOptionSelection);
+	const updateAuOptionSelection = useStore(
+		(state) => state.updateAuOptionSelection,
+	);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
-	const isOpenedCategory = useStore((state) => state.openedAuCategoryIds[categoryId] ?? false);
+	const isOpenedCategory = useStore(
+		(state) => state.openedAuCategoryIds[categoryId] ?? false,
+	);
 
 	const chanceSelection = auValue[chanceOptionId] ?? 0;
 	const maxCountSelection = auValue[maxCountOptionId] ?? 0;
@@ -60,7 +64,7 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 				{
 					auOptionId: maxCountOptionId,
 					selection: newSelection,
-				}
+				},
 			);
 		} else if (maxCountValues[newSelection] === 0) {
 			// 数を0にすると、Chanceも0%にする
@@ -72,7 +76,7 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 				{
 					auOptionId: maxCountOptionId,
 					selection: newSelection,
-				}
+				},
 			);
 			if (isOpenedCategory) {
 				toggleAuCategory(categoryId);

--- a/src/feature/AuRoleSpawnControls.tsx
+++ b/src/feature/AuRoleSpawnControls.tsx
@@ -1,0 +1,112 @@
+import { CompactSlider } from "../components/parts/CompactSlider";
+import { auOptionMetaData } from "../logics/api";
+import { findClosestIndex } from "../logics/optionUtils";
+import { useStore } from "../useStore";
+
+interface AuRoleSpawnControlsProps {
+	categoryId: number;
+}
+
+/**
+ * Auの役職のChanceとMaxCountをセットで管理するコンポーネント
+ */
+export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
+	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
+	const chanceOptionId = categoryMeta.options[0];
+	const maxCountOptionId = categoryMeta.options[1];
+
+	const auValue = useStore((state) => state.auValue);
+	const updateAuOptionSelection = useStore((state) => state.updateAuOptionSelection);
+	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
+	const isOpenedCategory = useStore((state) => state.openedAuCategoryIds[categoryId] ?? false);
+
+	const chanceSelection = auValue[chanceOptionId] ?? 0;
+	const maxCountSelection = auValue[maxCountOptionId] ?? 0;
+
+	const chanceMeta = auOptionMetaData.options[chanceOptionId];
+	const maxCountMeta = auOptionMetaData.options[maxCountOptionId];
+
+	const chanceValues = (chanceMeta?.range as number[]) ?? [];
+	const maxCountValues = (maxCountMeta?.range as number[]) ?? [];
+
+	const isChanceZero = chanceValues[chanceSelection] === 0;
+
+	const handleChanceChange = (newSelection: number) => {
+		updateAuOptionSelection({
+			auOptionId: chanceOptionId,
+			selection: newSelection,
+		});
+
+		// Chanceが0%になったら、アコーディオンを閉じる
+		if (chanceValues[newSelection] === 0) {
+			if (isOpenedCategory) {
+				toggleAuCategory(categoryId);
+			}
+		}
+	};
+
+	const handleChanceInputChange = (val: number) => {
+		handleChanceChange(findClosestIndex(chanceValues, val));
+	};
+
+	const handleMaxCountChange = (newSelection: number) => {
+		// 数が0以外に変更されたとき、現在Chanceが0%なら10%に上げる
+		if (maxCountValues[newSelection] > 0 && isChanceZero) {
+			updateAuOptionSelection(
+				{
+					auOptionId: chanceOptionId,
+					selection: findClosestIndex(chanceValues, 10),
+				},
+				{
+					auOptionId: maxCountOptionId,
+					selection: newSelection,
+				}
+			);
+		} else if (maxCountValues[newSelection] === 0) {
+			// 数を0にすると、Chanceも0%にする
+			updateAuOptionSelection(
+				{
+					auOptionId: chanceOptionId,
+					selection: findClosestIndex(chanceValues, 0),
+				},
+				{
+					auOptionId: maxCountOptionId,
+					selection: newSelection,
+				}
+			);
+			if (isOpenedCategory) {
+				toggleAuCategory(categoryId);
+			}
+		} else {
+			updateAuOptionSelection({
+				auOptionId: maxCountOptionId,
+				selection: newSelection,
+			});
+		}
+	};
+
+	const handleMaxCountInputChange = (val: number) => {
+		handleMaxCountChange(findClosestIndex(maxCountValues, val));
+	};
+
+	return (
+		<div className="flex items-center gap-4">
+			<CompactSlider
+				label="レート"
+				values={chanceValues}
+				currentSelection={chanceSelection}
+				onSelectionChange={handleChanceChange}
+				onInputChange={handleChanceInputChange}
+				testId="au-chance-control"
+			/>
+			<CompactSlider
+				label="数"
+				values={maxCountValues}
+				currentSelection={maxCountSelection}
+				onSelectionChange={handleMaxCountChange}
+				onInputChange={handleMaxCountInputChange}
+				testId="au-max-count-control"
+			/>
+		</div>
+	);
+}

--- a/src/feature/AuStandardCategoryItem.tsx
+++ b/src/feature/AuStandardCategoryItem.tsx
@@ -1,0 +1,33 @@
+import { Accordion } from "../components/parts/Accordion";
+import { auOptionMetaData } from "../logics/api";
+import { useStore } from "../useStore";
+import { AuCategoryOptionList } from "./AuCategoryOptionList";
+
+interface AuStandardCategoryItemProps {
+	categoryId: number;
+}
+
+/**
+ * Auの一般タブ（Tab 0）で使用される標準的なカテゴリ表示コンポーネント
+ */
+export function AuStandardCategoryItem({ categoryId }: AuStandardCategoryItemProps) {
+	const isOpen = useStore((state) => state.openedAuCategoryIds[categoryId] ?? false);
+	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
+
+	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
+	if (!categoryMeta) return null;
+
+	return (
+		<div data-testid={`au-category-${categoryId}`}>
+			<Accordion
+				title={categoryMeta.name}
+				isOpen={isOpen}
+				onToggle={() => toggleAuCategory(categoryId)}
+			>
+				<AuCategoryOptionList
+					optionIds={categoryMeta.options}
+				/>
+			</Accordion>
+		</div>
+	);
+}

--- a/src/feature/AuStandardCategoryItem.tsx
+++ b/src/feature/AuStandardCategoryItem.tsx
@@ -10,8 +10,12 @@ interface AuStandardCategoryItemProps {
 /**
  * Auの一般タブ（Tab 0）で使用される標準的なカテゴリ表示コンポーネント
  */
-export function AuStandardCategoryItem({ categoryId }: AuStandardCategoryItemProps) {
-	const isOpen = useStore((state) => state.openedAuCategoryIds[categoryId] ?? false);
+export function AuStandardCategoryItem({
+	categoryId,
+}: AuStandardCategoryItemProps) {
+	const isOpen = useStore(
+		(state) => state.openedAuCategoryIds[categoryId] ?? false,
+	);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
 
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
@@ -24,9 +28,7 @@ export function AuStandardCategoryItem({ categoryId }: AuStandardCategoryItemPro
 				isOpen={isOpen}
 				onToggle={() => toggleAuCategory(categoryId)}
 			>
-				<AuCategoryOptionList
-					optionIds={categoryMeta.options}
-				/>
+				<AuCategoryOptionList optionIds={categoryMeta.options} />
 			</Accordion>
 		</div>
 	);

--- a/src/feature/AuStandardCategoryItem.tsx
+++ b/src/feature/AuStandardCategoryItem.tsx
@@ -19,7 +19,9 @@ export function AuStandardCategoryItem({
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
 
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
-	if (!categoryMeta) return null;
+	if (!categoryMeta) {
+		return null;
+	}
 
 	return (
 		<div data-testid={`au-category-${categoryId}`}>

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -12,6 +12,8 @@ export interface AuOptionViewerSlice {
 	setSelectedAuTabId: (id: number) => void;
 	setIsAuTabPending: (isPending: boolean) => void;
 	setAuValue: (value: Record<AuOptionId, number>) => void;
+	toggleAuCategory: (categoryId: number) => void;
+	updateAuOptionSelection: (...args: { auOptionId: AuOptionId; selection: number }[]) => void;
 }
 
 /**
@@ -33,6 +35,22 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 		},
 		setAuValue(value) {
 			set({ auValue: value });
+		},
+		toggleAuCategory: (categoryId) => {
+			set((state) => {
+				const next = { ...state.openedAuCategoryIds };
+				next[categoryId] = !next[categoryId];
+				return { openedAuCategoryIds: next };
+			});
+		},
+		updateAuOptionSelection: (...args) => {
+			set((state) => {
+				const nextAuValue = { ...state.auValue };
+				for (const arg of args) {
+					nextAuValue[arg.auOptionId] = arg.selection;
+				}
+				return { auValue: nextAuValue };
+			});
 		},
 	};
 };

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -13,7 +13,9 @@ export interface AuOptionViewerSlice {
 	setIsAuTabPending: (isPending: boolean) => void;
 	setAuValue: (value: Record<AuOptionId, number>) => void;
 	toggleAuCategory: (categoryId: number) => void;
-	updateAuOptionSelection: (...args: { auOptionId: AuOptionId; selection: number }[]) => void;
+	updateAuOptionSelection: (
+		...args: { auOptionId: AuOptionId; selection: number }[]
+	) => void;
 }
 
 /**

--- a/tests/AuCategoryList.test.tsx
+++ b/tests/AuCategoryList.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { AuCategoryList } from "../src/feature/AuCategoryList";
+import { auOptionMetaData, resetAuOptionMetaData } from "../src/logics/api";
+import type { AuOptionId } from "../src/type";
+import { useStore } from "../src/useStore";
+
+describe("AuCategoryList", () => {
+	beforeEach(() => {
+		resetAuOptionMetaData();
+		useStore.getState().resetViewer();
+	});
+
+	it("renders standard category items for Tab 0", () => {
+		auOptionMetaData.tabCategoryMap = { 0: [1], 1: [], 2: [] };
+		auOptionMetaData.categoryMetaData = {
+			1: { name: "General Settings", options: [] },
+		};
+		useStore.getState().setSelectedAuTabId(0);
+
+		render(<AuCategoryList />);
+
+		expect(screen.getByText("General Settings")).toBeInTheDocument();
+		expect(screen.getByTestId("au-category-1")).toBeInTheDocument();
+	});
+
+	it("renders role category items for Tab 1", () => {
+		const chanceId = 101 as unknown as AuOptionId;
+		const countId = 102 as unknown as AuOptionId;
+		auOptionMetaData.tabCategoryMap = { 0: [], 1: [2], 2: [] };
+		auOptionMetaData.categoryMetaData = {
+			2: { name: "Scientist", options: [chanceId, countId] },
+		};
+		auOptionMetaData.options[chanceId] = {
+			title: "C",
+			format: "",
+			range: [0, 100],
+		};
+		auOptionMetaData.options[countId] = {
+			title: "M",
+			format: "",
+			range: [0, 1],
+		};
+
+		useStore.getState().setSelectedAuTabId(1);
+		useStore.getState().setAuValue({ [chanceId]: 1, [countId]: 1 });
+
+		render(<AuCategoryList />);
+
+		expect(screen.getByText("Scientist")).toBeInTheDocument();
+		expect(screen.getByTestId("au-chance-control")).toBeInTheDocument();
+		expect(screen.getByTestId("au-max-count-control")).toBeInTheDocument();
+	});
+
+	it("disables accordion button when chance is 0", () => {
+		const chanceId = 101 as unknown as AuOptionId;
+		const countId = 102 as unknown as AuOptionId;
+		auOptionMetaData.tabCategoryMap = { 1: [2] };
+		auOptionMetaData.categoryMetaData = {
+			2: { name: "Scientist", options: [chanceId, countId] },
+		};
+		auOptionMetaData.options[chanceId] = {
+			title: "C",
+			format: "",
+			range: [0, 100],
+		};
+		auOptionMetaData.options[countId] = {
+			title: "M",
+			format: "",
+			range: [0, 1],
+		};
+
+		useStore.getState().setSelectedAuTabId(1);
+		useStore.getState().setAuValue({ [chanceId]: 0, [countId]: 0 });
+
+		render(<AuCategoryList />);
+
+		const button = screen.getByRole("button", { name: /Scientist/ });
+		expect(button).toBeDisabled();
+	});
+
+	it("filters out first two options from role category body", async () => {
+		const chanceId = 101 as unknown as AuOptionId;
+		const countId = 102 as unknown as AuOptionId;
+		const otherId = 103 as unknown as AuOptionId;
+
+		auOptionMetaData.tabCategoryMap = { 1: [2] };
+		auOptionMetaData.categoryMetaData = {
+			2: { name: "Scientist", options: [chanceId, countId, otherId] },
+		};
+		auOptionMetaData.options[chanceId] = {
+			title: "Chance",
+			format: "",
+			range: [0, 100],
+		};
+		auOptionMetaData.options[countId] = {
+			title: "MaxCount",
+			format: "",
+			range: [0, 1],
+		};
+		auOptionMetaData.options[otherId] = {
+			title: "Other Option",
+			format: "",
+			range: [0, 1],
+		};
+
+		useStore.getState().setSelectedAuTabId(1);
+		useStore
+			.getState()
+			.setAuValue({ [chanceId]: 1, [countId]: 1, [otherId]: 0 });
+
+		render(<AuCategoryList />);
+
+		const toggleButton = screen.getByRole("button", { name: /Scientist/ });
+		fireEvent.click(toggleButton);
+
+		expect(screen.getByText("Other Option")).toBeInTheDocument();
+		expect(screen.queryByText("Chance")).not.toBeInTheDocument();
+		expect(screen.queryByText("MaxCount")).not.toBeInTheDocument();
+	});
+});

--- a/tests/AuRoleSpawnControls.test.tsx
+++ b/tests/AuRoleSpawnControls.test.tsx
@@ -79,6 +79,27 @@ describe("AuRoleSpawnControls", () => {
 		expect(state.auValue[maxCountId]).toBe(0);
 	});
 
+	it("syncs max count to 0 when chance is set to 0%", () => {
+		// Initial state: Chance 50% (index 5), Max Count 2 (index 2)
+		useStore.getState().setAuValue({
+			[chanceId]: 5,
+			[maxCountId]: 2,
+		});
+
+		render(<AuRoleSpawnControls categoryId={categoryId} />);
+
+		const chanceControl = screen.getByTestId("au-chance-control");
+		const slider = chanceControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+
+		fireEvent.change(slider, { target: { value: "0" } });
+
+		const state = useStore.getState();
+		expect(state.auValue[chanceId]).toBe(0);
+		expect(state.auValue[maxCountId]).toBe(0);
+	});
+
 	it("closes accordion when chance becomes 0%", () => {
 		// Initial state: Open and Chance 10%
 		useStore.getState().setAuValue({ [chanceId]: 1, [maxCountId]: 1 });

--- a/tests/AuRoleSpawnControls.test.tsx
+++ b/tests/AuRoleSpawnControls.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { AuRoleSpawnControls } from "../src/feature/AuRoleSpawnControls";
+import { auOptionMetaData, resetAuOptionMetaData } from "../src/logics/api";
+import { useStore } from "../src/useStore";
+
+describe("AuRoleSpawnControls", () => {
+	const categoryId = 10;
+	const chanceId = 100 as unknown as AuOptionId;
+	const maxCountId = 200 as unknown as AuOptionId;
+
+	beforeEach(() => {
+		resetAuOptionMetaData();
+		useStore.getState().resetViewer();
+
+		auOptionMetaData.categoryMetaData[categoryId] = {
+			name: "Test Role",
+			options: [chanceId, maxCountId],
+		};
+
+		auOptionMetaData.options[chanceId] = {
+			title: "Chance",
+			format: "{0}%",
+			range: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+		};
+
+		auOptionMetaData.options[maxCountId] = {
+			title: "Max Count",
+			format: "{0}",
+			range: [0, 1, 2, 3, 4, 5],
+		};
+
+		useStore.getState().setAuValue({
+			[chanceId]: 0,
+			[maxCountId]: 0,
+		});
+	});
+
+	it("renders both controls", () => {
+		render(<AuRoleSpawnControls categoryId={categoryId} />);
+
+		expect(screen.getByTestId("au-chance-control")).toBeInTheDocument();
+		expect(screen.getByTestId("au-max-count-control")).toBeInTheDocument();
+	});
+
+	it("syncs chance to 10% when max count is set to non-zero from zero", () => {
+		render(<AuRoleSpawnControls categoryId={categoryId} />);
+
+		const countControl = screen.getByTestId("au-max-count-control");
+		const slider = countControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+
+		fireEvent.change(slider, { target: { value: "1" } }); // Select 1
+
+		const state = useStore.getState();
+		expect(state.auValue[chanceId]).toBe(1); // Index 1 is 10%
+		expect(state.auValue[maxCountId]).toBe(1); // Index 1 is 1
+	});
+
+	it("syncs chance to 0% when max count is set to 0", () => {
+		// Initial state: Chance 50% (index 5), Max Count 2 (index 2)
+		useStore.getState().setAuValue({
+			[chanceId]: 5,
+			[maxCountId]: 2,
+		});
+
+		render(<AuRoleSpawnControls categoryId={categoryId} />);
+
+		const countControl = screen.getByTestId("au-max-count-control");
+		const slider = countControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+
+		fireEvent.change(slider, { target: { value: "0" } });
+
+		const state = useStore.getState();
+		expect(state.auValue[chanceId]).toBe(0); // Index 0 is 0%
+		expect(state.auValue[maxCountId]).toBe(0);
+	});
+
+	it("closes accordion when chance becomes 0%", () => {
+		// Initial state: Open and Chance 10%
+		useStore.getState().setAuValue({ [chanceId]: 1, [maxCountId]: 1 });
+		useStore.getState().toggleAuCategory(categoryId);
+		expect(useStore.getState().openedAuCategoryIds[categoryId]).toBe(true);
+
+		render(<AuRoleSpawnControls categoryId={categoryId} />);
+
+		const chanceControl = screen.getByTestId("au-chance-control");
+		const slider = chanceControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+
+		fireEvent.change(slider, { target: { value: "0" } });
+
+		expect(useStore.getState().openedAuCategoryIds[categoryId]).toBe(false);
+	});
+});

--- a/tests/OptionEditor.test.tsx
+++ b/tests/OptionEditor.test.tsx
@@ -19,9 +19,7 @@ describe("OptionEditor Components", () => {
 
 		render(<AuOptionEditor />);
 
-		const pre = screen.getByText((content) => {
-			return content.includes('"categoryName": "Test Category"');
-		});
-		expect(pre).toBeTruthy();
+		const category = screen.getByText("Test Category");
+		expect(category).toBeTruthy();
 	});
 });


### PR DESCRIPTION
Refactored the AuOptionEditor to match the ExR option editor's accordion-style interface. Key changes include:
1. Created new UI components (`AuCategoryList`, `AuRoleCategoryItem`, etc.) to support the accordion layout.
2. Implemented specialized logic for role-based tabs where 'Chance' and 'MaxCount' are managed together in the accordion header.
3. Updated the Zustand store to handle Au option category toggling and value updates.
4. Ensured visual consistency and interactive behavior (e.g., disabling accordions when the spawn rate is zero) similar to the ExR implementation.
5. Updated existing tests to verify the new component-based structure.

---
*PR created automatically by Jules for task [11503565037267755686](https://jules.google.com/task/11503565037267755686) started by @yukieiji*