### PR TITLE
AUオプションの更新処理の実装

### DIFF
--- a/src/feature/AuOptionRow.tsx
+++ b/src/feature/AuOptionRow.tsx
@@ -13,9 +13,7 @@ interface AuOptionRowProps {
 export function AuOptionRow({ optionId }: AuOptionRowProps) {
 	const optionMeta = auOptionMetaData.options[optionId];
 	const selection = useStore((state) => state.auValue[optionId] ?? 0);
-	const updateAuOptionSelection = useStore(
-		(state) => state.updateAuOptionSelection,
-	);
+	const updateAuOption = useStore((state) => state.updateAuOption);
 
 	if (!optionMeta) {
 		return null;
@@ -33,10 +31,7 @@ export function AuOptionRow({ optionId }: AuOptionRowProps) {
 					optionMeta={optionMeta}
 					selection={selection}
 					onSelectionChange={(newSelection) => {
-						updateAuOptionSelection({
-							auOptionId: optionId,
-							selection: newSelection,
-						});
+						updateAuOption(optionId, newSelection);
 					}}
 				/>
 			</div>

--- a/src/feature/AuRoleSpawnControls.tsx
+++ b/src/feature/AuRoleSpawnControls.tsx
@@ -17,9 +17,7 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	const maxCountOptionId = categoryMeta?.options[1];
 
 	const auValue = useStore((state) => state.auValue);
-	const updateAuOptionSelection = useStore(
-		(state) => state.updateAuOptionSelection,
-	);
+	const updateAuRoleOption = useStore((state) => state.updateAuRoleOption);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
 	const isOpenedCategory = useStore(
 		(state) => state.openedAuCategoryIds[categoryId] ?? false,
@@ -46,28 +44,27 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	const isMaxCountZero = (maxCountValues[maxCountSelection] ?? 0) === 0;
 
 	const handleChanceChange = (newSelection: number) => {
-		const chanceOptionUpdate = {
-			auOptionId: chanceOptionId,
-			selection: newSelection,
-		};
-
 		// Chanceが0%以外に変更されたとき、数が0なら1にあげる
 		if (isMaxCountZero && (chanceValues[newSelection] ?? 0) > 0) {
-			updateAuOptionSelection(chanceOptionUpdate, {
-				auOptionId: maxCountOptionId,
-				selection: findClosestIndex(maxCountValues, 1),
-			});
+			updateAuRoleOption(
+				chanceOptionId,
+				newSelection,
+				maxCountOptionId,
+				findClosestIndex(maxCountValues, 1),
+			);
 		} else if (chanceValues[newSelection] === 0) {
 			// Chanceが0%になったら、スポーン数も0にしてアコーディオンを閉じる
-			updateAuOptionSelection(chanceOptionUpdate, {
-				auOptionId: maxCountOptionId,
-				selection: 0,
-			});
+			updateAuRoleOption(chanceOptionId, newSelection, maxCountOptionId, 0);
 			if (isOpenedCategory) {
 				toggleAuCategory(categoryId);
 			}
 		} else {
-			updateAuOptionSelection(chanceOptionUpdate);
+			updateAuRoleOption(
+				chanceOptionId,
+				newSelection,
+				maxCountOptionId,
+				maxCountSelection,
+			);
 		}
 	};
 
@@ -76,34 +73,32 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	};
 
 	const handleMaxCountChange = (newSelection: number) => {
-		const countOptionUpdate = {
-			auOptionId: maxCountOptionId,
-			selection: newSelection,
-		};
-
 		// 数が0以外に変更されたとき、現在Chanceが0%なら10%に上げる
 		if (isChanceZero && (maxCountValues[newSelection] ?? 0) > 0) {
-			updateAuOptionSelection(
-				{
-					auOptionId: chanceOptionId,
-					selection: findClosestIndex(chanceValues, 10),
-				},
-				countOptionUpdate,
+			updateAuRoleOption(
+				chanceOptionId,
+				findClosestIndex(chanceValues, 10),
+				maxCountOptionId,
+				newSelection,
 			);
 		} else if ((maxCountValues[newSelection] ?? 0) === 0) {
 			// 数を0にすると、Chanceも0%にする
-			updateAuOptionSelection(
-				{
-					auOptionId: chanceOptionId,
-					selection: findClosestIndex(chanceValues, 0),
-				},
-				countOptionUpdate,
+			updateAuRoleOption(
+				chanceOptionId,
+				findClosestIndex(chanceValues, 0),
+				maxCountOptionId,
+				newSelection,
 			);
 			if (isOpenedCategory) {
 				toggleAuCategory(categoryId);
 			}
 		} else {
-			updateAuOptionSelection(countOptionUpdate);
+			updateAuRoleOption(
+				chanceOptionId,
+				chanceSelection,
+				maxCountOptionId,
+				newSelection,
+			);
 		}
 	};
 

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -290,3 +290,26 @@ export async function updateExrOption(
 	const jsonData = await res.json();
 	return await UpdatedOptionsSchema.parseAsync(jsonData);
 }
+
+export async function updateAuOption(
+	request: VanillaOptionPutRequest,
+): Promise<UpdatedOptions | null> {
+	const res = await fetch(AU_OPTION_URL, {
+		method: "PUT",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(request),
+	});
+
+	if (res.status === 202) {
+		return null;
+	}
+
+	if (!res.ok) {
+		throw new Error(`Failed to update AU option: ${res.statusText}`);
+	}
+
+	const jsonData = await res.json();
+	return await UpdatedOptionsSchema.parseAsync(jsonData);
+}

--- a/src/logics/exrStateLogic.ts
+++ b/src/logics/exrStateLogic.ts
@@ -95,3 +95,43 @@ export function getUpdatedExRState(
 		isOptionActiveChanged,
 	};
 }
+
+/**
+ * APIの戻り値を元にExRの状態を更新するパッチを生成します。
+ * 変更がない場合はnullを返します。
+ */
+export function applyUpdatedOptions(
+	updateResults: (UpdatedOptions | null)[],
+	currentExrValue: Record<UniqueOptionId, ExROptionValueData>,
+	currentIsExROptionActive: Record<UniqueOptionId, boolean>,
+): {
+	exrValue?: Record<UniqueOptionId, ExROptionValueData>;
+	isExROptionActive?: Record<UniqueOptionId, boolean>;
+} | null {
+	const {
+		nextValueData,
+		nextIsOptionActive,
+		valueDataChanged,
+		isOptionActiveChanged,
+	} = getUpdatedExRState(
+		updateResults,
+		currentExrValue,
+		currentIsExROptionActive,
+	);
+
+	if (!valueDataChanged && !isOptionActiveChanged) {
+		return null;
+	}
+
+	const patch: {
+		exrValue?: Record<UniqueOptionId, ExROptionValueData>;
+		isExROptionActive?: Record<UniqueOptionId, boolean>;
+	} = {};
+	if (valueDataChanged) {
+		patch.exrValue = nextValueData;
+	}
+	if (isOptionActiveChanged) {
+		patch.isExROptionActive = nextIsOptionActive;
+	}
+	return patch;
+}

--- a/src/logics/exrStateLogic.ts
+++ b/src/logics/exrStateLogic.ts
@@ -1,5 +1,3 @@
-import { exrOptionMetaData } from "./api";
-import { getUniqueOptionId } from "./optionUtils";
 import type {
 	ExRCategoryDto,
 	ExROptionDto,
@@ -7,6 +5,8 @@ import type {
 	UniqueOptionId,
 	UpdatedOptions,
 } from "../type";
+import { exrOptionMetaData } from "./api";
+import { getUniqueOptionId } from "./optionUtils";
 
 /**
  * UpdatedOptionsの情報を元に、ExRのオプション状態を更新するための情報を生成します

--- a/src/logics/exrStateLogic.ts
+++ b/src/logics/exrStateLogic.ts
@@ -1,0 +1,97 @@
+import { exrOptionMetaData } from "./api";
+import { getUniqueOptionId } from "./optionUtils";
+import type {
+	ExRCategoryDto,
+	ExROptionDto,
+	ExROptionValueData,
+	UniqueOptionId,
+	UpdatedOptions,
+} from "../type";
+
+/**
+ * UpdatedOptionsの情報を元に、ExRのオプション状態を更新するための情報を生成します
+ */
+export function getUpdatedExRState(
+	updateResults: (UpdatedOptions | null)[],
+	currentExrValue: Record<UniqueOptionId, ExROptionValueData>,
+	currentIsExROptionActive: Record<UniqueOptionId, boolean>,
+) {
+	let nextValueData = currentExrValue;
+	let nextIsOptionActive = currentIsExROptionActive;
+
+	let valueDataChanged = false;
+	let isOptionActiveChanged = false;
+
+	const processOption = (opt: ExROptionDto, catId: number, tId: number) => {
+		const uId = getUniqueOptionId(tId, catId, opt.Id);
+
+		// values
+		const currentValData = nextValueData[uId];
+		if (
+			!currentValData ||
+			currentValData.selection !== opt.Selection ||
+			currentValData.values.length !== opt.RangeMeta.Values.length ||
+			currentValData.values.some((v, i) => v !== opt.RangeMeta.Values[i])
+		) {
+			if (!valueDataChanged) {
+				nextValueData = { ...nextValueData };
+				valueDataChanged = true;
+			}
+			nextValueData[uId] = {
+				selection: opt.Selection,
+				values: opt.RangeMeta.Values,
+			};
+		}
+
+		// isOptionActive
+		if (nextIsOptionActive[uId] !== opt.IsActive) {
+			if (!isOptionActiveChanged) {
+				nextIsOptionActive = { ...nextIsOptionActive };
+				isOptionActiveChanged = true;
+			}
+			nextIsOptionActive[uId] = opt.IsActive;
+		}
+
+		if (opt.Childs) {
+			for (const child of opt.Childs) {
+				processOption(child, catId, tId);
+			}
+		}
+	};
+
+	const processCategory = (cat: ExRCategoryDto) => {
+		const tId = exrOptionMetaData.categories[cat.Id]?.tabId;
+		if (tId === undefined) {
+			return;
+		}
+		for (const opt of cat.Options) {
+			processOption(opt, cat.Id, tId);
+		}
+	};
+
+	for (const x of updateResults) {
+		if (!x) {
+			continue;
+		}
+		if (x.UpdatedCategory) {
+			processCategory(x.UpdatedCategory);
+		}
+
+		for (const chain of x.ChainUpdatedOption) {
+			const tId = exrOptionMetaData.categories[chain.Id]?.tabId;
+			if (tId === undefined) {
+				continue;
+			}
+			for (const opt of chain.Options) {
+				processOption(opt, chain.Id, tId);
+			}
+		}
+	}
+
+	return {
+		nextValueData,
+		nextIsOptionActive,
+		valueDataChanged,
+		isOptionActiveChanged,
+	};
+}

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -32,6 +32,13 @@ export function getAuOptionId(
 	return (optionName * 10000 + valueType * 100 + prefix) as AuOptionId;
 }
 
+export function parseAuOptionId(id: number) {
+	const prefix = id % 100;
+	const valueType = Math.floor(id / 100) % 100;
+	const optionName = Math.floor(id / 10000);
+	return { optionName, valueType, prefix };
+}
+
 export function parseUniqueOptionId(uniqueOptionId: UniqueOptionId): {
 	tabId: number;
 	categoryId: number;

--- a/src/logics/syncLogic.ts
+++ b/src/logics/syncLogic.ts
@@ -1,14 +1,5 @@
-import type {
-	ExRCategoryDto,
-	ExROptionDto,
-	ExROptionValueData,
-	UniqueOptionId,
-	UpdatedOptions,
-} from "../type";
 import { useStore } from "../useStore";
-import { exrOptionMetaData } from "./api";
 import { getAuOptions, getExrOptions, resetApiCache } from "./api.store";
-import { getUniqueOptionId } from "./optionUtils";
 
 /**
  * 全データの再取得と同期を行う
@@ -20,92 +11,4 @@ export async function performGlobalSync() {
 	resetApiCache();
 	await Promise.all([getExrOptions(), getAuOptions()]);
 	validateOpenedIds();
-}
-
-/**
- * UpdatedOptionsの情報を元に、ExRのオプション状態を更新するための情報を生成します
- */
-export function getUpdatedExRState(
-	updateResults: (UpdatedOptions | null)[],
-	currentExrValue: Record<UniqueOptionId, ExROptionValueData>,
-	currentIsExROptionActive: Record<UniqueOptionId, boolean>,
-) {
-	let nextValueData = currentExrValue;
-	let nextIsOptionActive = currentIsExROptionActive;
-
-	let valueDataChanged = false;
-	let isOptionActiveChanged = false;
-
-	const processOption = (opt: ExROptionDto, catId: number, tId: number) => {
-		const uId = getUniqueOptionId(tId, catId, opt.Id);
-
-		// values
-		const currentValData = nextValueData[uId];
-		if (
-			!currentValData ||
-			currentValData.selection !== opt.Selection ||
-			currentValData.values.length !== opt.RangeMeta.Values.length ||
-			currentValData.values.some((v, i) => v !== opt.RangeMeta.Values[i])
-		) {
-			if (!valueDataChanged) {
-				nextValueData = { ...nextValueData };
-				valueDataChanged = true;
-			}
-			nextValueData[uId] = {
-				selection: opt.Selection,
-				values: opt.RangeMeta.Values,
-			};
-		}
-
-		// isOptionActive
-		if (nextIsOptionActive[uId] !== opt.IsActive) {
-			if (!isOptionActiveChanged) {
-				nextIsOptionActive = { ...nextIsOptionActive };
-				isOptionActiveChanged = true;
-			}
-			nextIsOptionActive[uId] = opt.IsActive;
-		}
-
-		if (opt.Childs) {
-			for (const child of opt.Childs) {
-				processOption(child, catId, tId);
-			}
-		}
-	};
-
-	const processCategory = (cat: ExRCategoryDto) => {
-		const tId = exrOptionMetaData.categories[cat.Id]?.tabId;
-		if (tId === undefined) {
-			return;
-		}
-		for (const opt of cat.Options) {
-			processOption(opt, cat.Id, tId);
-		}
-	};
-
-	for (const x of updateResults) {
-		if (!x) {
-			continue;
-		}
-		if (x.UpdatedCategory) {
-			processCategory(x.UpdatedCategory);
-		}
-
-		for (const chain of x.ChainUpdatedOption) {
-			const tId = exrOptionMetaData.categories[chain.Id]?.tabId;
-			if (tId === undefined) {
-				continue;
-			}
-			for (const opt of chain.Options) {
-				processOption(opt, chain.Id, tId);
-			}
-		}
-	}
-
-	return {
-		nextValueData,
-		nextIsOptionActive,
-		valueDataChanged,
-		isOptionActiveChanged,
-	};
 }

--- a/src/logics/syncLogic.ts
+++ b/src/logics/syncLogic.ts
@@ -1,5 +1,14 @@
+import type {
+	ExRCategoryDto,
+	ExROptionDto,
+	ExROptionValueData,
+	UniqueOptionId,
+	UpdatedOptions,
+} from "../type";
 import { useStore } from "../useStore";
+import { exrOptionMetaData } from "./api";
 import { getAuOptions, getExrOptions, resetApiCache } from "./api.store";
+import { getUniqueOptionId } from "./optionUtils";
 
 /**
  * 全データの再取得と同期を行う
@@ -11,4 +20,92 @@ export async function performGlobalSync() {
 	resetApiCache();
 	await Promise.all([getExrOptions(), getAuOptions()]);
 	validateOpenedIds();
+}
+
+/**
+ * UpdatedOptionsの情報を元に、ExRのオプション状態を更新するための情報を生成します
+ */
+export function getUpdatedExRState(
+	updateResults: (UpdatedOptions | null)[],
+	currentExrValue: Record<UniqueOptionId, ExROptionValueData>,
+	currentIsExROptionActive: Record<UniqueOptionId, boolean>,
+) {
+	let nextValueData = currentExrValue;
+	let nextIsOptionActive = currentIsExROptionActive;
+
+	let valueDataChanged = false;
+	let isOptionActiveChanged = false;
+
+	const processOption = (opt: ExROptionDto, catId: number, tId: number) => {
+		const uId = getUniqueOptionId(tId, catId, opt.Id);
+
+		// values
+		const currentValData = nextValueData[uId];
+		if (
+			!currentValData ||
+			currentValData.selection !== opt.Selection ||
+			currentValData.values.length !== opt.RangeMeta.Values.length ||
+			currentValData.values.some((v, i) => v !== opt.RangeMeta.Values[i])
+		) {
+			if (!valueDataChanged) {
+				nextValueData = { ...nextValueData };
+				valueDataChanged = true;
+			}
+			nextValueData[uId] = {
+				selection: opt.Selection,
+				values: opt.RangeMeta.Values,
+			};
+		}
+
+		// isOptionActive
+		if (nextIsOptionActive[uId] !== opt.IsActive) {
+			if (!isOptionActiveChanged) {
+				nextIsOptionActive = { ...nextIsOptionActive };
+				isOptionActiveChanged = true;
+			}
+			nextIsOptionActive[uId] = opt.IsActive;
+		}
+
+		if (opt.Childs) {
+			for (const child of opt.Childs) {
+				processOption(child, catId, tId);
+			}
+		}
+	};
+
+	const processCategory = (cat: ExRCategoryDto) => {
+		const tId = exrOptionMetaData.categories[cat.Id]?.tabId;
+		if (tId === undefined) {
+			return;
+		}
+		for (const opt of cat.Options) {
+			processOption(opt, cat.Id, tId);
+		}
+	};
+
+	for (const x of updateResults) {
+		if (!x) {
+			continue;
+		}
+		if (x.UpdatedCategory) {
+			processCategory(x.UpdatedCategory);
+		}
+
+		for (const chain of x.ChainUpdatedOption) {
+			const tId = exrOptionMetaData.categories[chain.Id]?.tabId;
+			if (tId === undefined) {
+				continue;
+			}
+			for (const opt of chain.Options) {
+				processOption(opt, chain.Id, tId);
+			}
+		}
+	}
+
+	return {
+		nextValueData,
+		nextIsOptionActive,
+		valueDataChanged,
+		isOptionActiveChanged,
+	};
 }

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -1,7 +1,7 @@
 import type { StateCreator } from "zustand";
 import { auOptionMetaData, updateAuOption } from "../logics/api";
-import { parseAuOptionId } from "../logics/optionUtils";
 import { getUpdatedExRState } from "../logics/exrStateLogic";
+import { parseAuOptionId } from "../logics/optionUtils";
 import type { AuOptionId, AuRoleOption } from "../type";
 import { OptionValueType } from "../type";
 import type { ExROptionViewerSlice } from "./exrOptionViewerSlice";

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -1,5 +1,10 @@
 import type { StateCreator } from "zustand";
-import type { AuOptionId } from "../type";
+import { auOptionMetaData, updateAuOption } from "../logics/api";
+import { parseAuOptionId } from "../logics/optionUtils";
+import { getUpdatedExRState } from "../logics/syncLogic";
+import { OptionValueType } from "../type";
+import type { AuOptionId, AuRoleOption } from "../type";
+import type { ExROptionViewerSlice } from "./exrOptionViewerSlice";
 
 /**
  * ExR オプションの状態を管理するスライスのインターフェース
@@ -16,14 +21,24 @@ export interface AuOptionViewerSlice {
 	updateAuOptionSelection: (
 		...args: { auOptionId: AuOptionId; selection: number }[]
 	) => void;
+	updateAuOption: (auOptionId: AuOptionId, selection: number) => Promise<void>;
+	updateAuRoleOption: (
+		chanceOptionId: AuOptionId,
+		chanceSelection: number,
+		maxCountOptionId: AuOptionId,
+		maxCountSelection: number,
+	) => Promise<void>;
 }
 
 /**
  * ExR オプションの状態管理を行うスライスの生成
  */
-export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
-	set,
-) => {
+export const createAuOptionViewerSlice: StateCreator<
+	AuOptionViewerSlice & ExROptionViewerSlice,
+	[],
+	[],
+	AuOptionViewerSlice
+> = (set, get) => {
 	return {
 		selectedAuTabId: 0,
 		isAuTabPending: false,
@@ -53,6 +68,112 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 				}
 				return { auValue: nextAuValue };
 			});
+		},
+		updateAuOption: async (auOptionId, selection) => {
+			const { optionName, valueType } = parseAuOptionId(auOptionId);
+			const meta = auOptionMetaData.options[auOptionId];
+			if (!meta) {
+				return;
+			}
+
+			const newValue = meta.range[selection];
+
+			// ローカル状態を即時更新
+			get().updateAuOptionSelection({ auOptionId, selection });
+
+			try {
+				const result = await updateAuOption({
+					OptionName: optionName,
+					ValueType: valueType,
+					NewValue: newValue as number | boolean | AuRoleOption,
+				});
+
+				if (result) {
+					set((state) => {
+						const {
+							nextValueData,
+							nextIsOptionActive,
+							valueDataChanged,
+							isOptionActiveChanged,
+						} = getUpdatedExRState(
+							[result],
+							state.exrValue,
+							state.isExROptionActive,
+						);
+
+						const patch: Partial<ExROptionViewerSlice> = {};
+						if (valueDataChanged) {
+							patch.exrValue = nextValueData;
+						}
+						if (isOptionActiveChanged) {
+							patch.isExROptionActive = nextIsOptionActive;
+						}
+						return patch;
+					});
+				}
+			} catch (error) {
+				console.error("Error updating AU option:", error);
+			}
+		},
+		updateAuRoleOption: async (
+			chanceOptionId,
+			chanceSelection,
+			maxCountOptionId,
+			maxCountSelection,
+		) => {
+			const { optionName } = parseAuOptionId(chanceOptionId);
+			const chanceMeta = auOptionMetaData.options[chanceOptionId];
+			const maxCountMeta = auOptionMetaData.options[maxCountOptionId];
+
+			if (!chanceMeta || !maxCountMeta) {
+				return;
+			}
+
+			const chanceValue = chanceMeta.range[chanceSelection] as number;
+			const maxCountValue = maxCountMeta.range[maxCountSelection] as number;
+
+			// ローカル状態を即時更新
+			get().updateAuOptionSelection(
+				{ auOptionId: chanceOptionId, selection: chanceSelection },
+				{ auOptionId: maxCountOptionId, selection: maxCountSelection },
+			);
+
+			try {
+				const result = await updateAuOption({
+					OptionName: optionName,
+					ValueType: OptionValueType.RoleBase,
+					NewValue: {
+						Chance: chanceValue,
+						MaxCount: maxCountValue,
+					},
+				});
+
+				if (result) {
+					set((state) => {
+						const {
+							nextValueData,
+							nextIsOptionActive,
+							valueDataChanged,
+							isOptionActiveChanged,
+						} = getUpdatedExRState(
+							[result],
+							state.exrValue,
+							state.isExROptionActive,
+						);
+
+						const patch: Partial<ExROptionViewerSlice> = {};
+						if (valueDataChanged) {
+							patch.exrValue = nextValueData;
+						}
+						if (isOptionActiveChanged) {
+							patch.isExROptionActive = nextIsOptionActive;
+						}
+						return patch;
+					});
+				}
+			} catch (error) {
+				console.error("Error updating AU RoleBase option:", error);
+			}
 		},
 	};
 };

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -2,8 +2,8 @@ import type { StateCreator } from "zustand";
 import { auOptionMetaData, updateAuOption } from "../logics/api";
 import { parseAuOptionId } from "../logics/optionUtils";
 import { getUpdatedExRState } from "../logics/syncLogic";
-import { OptionValueType } from "../type";
 import type { AuOptionId, AuRoleOption } from "../type";
+import { OptionValueType } from "../type";
 import type { ExROptionViewerSlice } from "./exrOptionViewerSlice";
 
 /**

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -1,7 +1,7 @@
 import type { StateCreator } from "zustand";
 import { auOptionMetaData, updateAuOption } from "../logics/api";
 import { parseAuOptionId } from "../logics/optionUtils";
-import { getUpdatedExRState } from "../logics/syncLogic";
+import { getUpdatedExRState } from "../logics/exrStateLogic";
 import type { AuOptionId, AuRoleOption } from "../type";
 import { OptionValueType } from "../type";
 import type { ExROptionViewerSlice } from "./exrOptionViewerSlice";

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -1,8 +1,8 @@
 import type { StateCreator } from "zustand";
 import { auOptionMetaData, updateAuOption } from "../logics/api";
-import { getUpdatedExRState } from "../logics/exrStateLogic";
+import { applyUpdatedOptions } from "../logics/exrStateLogic";
 import { parseAuOptionId } from "../logics/optionUtils";
-import type { AuOptionId, AuRoleOption } from "../type";
+import type { AuOptionId, AuRoleOption, UpdatedOptions } from "../type";
 import { OptionValueType } from "../type";
 import type { ExROptionViewerSlice } from "./exrOptionViewerSlice";
 
@@ -39,6 +39,27 @@ export const createAuOptionViewerSlice: StateCreator<
 	[],
 	AuOptionViewerSlice
 > = (set, get) => {
+	const syncExrState = (result: UpdatedOptions | null) => {
+		if (result) {
+			set((state) => {
+				const patch = applyUpdatedOptions(
+					[result],
+					state.exrValue,
+					state.isExROptionActive,
+				);
+
+				if (!patch) {
+					return state;
+				}
+
+				return {
+					...state,
+					...patch,
+				};
+			});
+		}
+	};
+
 	return {
 		selectedAuTabId: 0,
 		isAuTabPending: false,
@@ -87,30 +108,7 @@ export const createAuOptionViewerSlice: StateCreator<
 					ValueType: valueType,
 					NewValue: newValue as number | boolean | AuRoleOption,
 				});
-
-				if (result) {
-					set((state) => {
-						const {
-							nextValueData,
-							nextIsOptionActive,
-							valueDataChanged,
-							isOptionActiveChanged,
-						} = getUpdatedExRState(
-							[result],
-							state.exrValue,
-							state.isExROptionActive,
-						);
-
-						const patch: Partial<ExROptionViewerSlice> = {};
-						if (valueDataChanged) {
-							patch.exrValue = nextValueData;
-						}
-						if (isOptionActiveChanged) {
-							patch.isExROptionActive = nextIsOptionActive;
-						}
-						return patch;
-					});
-				}
+				syncExrState(result);
 			} catch (error) {
 				console.error("Error updating AU option:", error);
 			}
@@ -147,30 +145,7 @@ export const createAuOptionViewerSlice: StateCreator<
 						MaxCount: maxCountValue,
 					},
 				});
-
-				if (result) {
-					set((state) => {
-						const {
-							nextValueData,
-							nextIsOptionActive,
-							valueDataChanged,
-							isOptionActiveChanged,
-						} = getUpdatedExRState(
-							[result],
-							state.exrValue,
-							state.isExROptionActive,
-						);
-
-						const patch: Partial<ExROptionViewerSlice> = {};
-						if (valueDataChanged) {
-							patch.exrValue = nextValueData;
-						}
-						if (isOptionActiveChanged) {
-							patch.isExROptionActive = nextIsOptionActive;
-						}
-						return patch;
-					});
-				}
+				syncExrState(result);
 			} catch (error) {
 				console.error("Error updating AU RoleBase option:", error);
 			}

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -4,7 +4,7 @@ import {
 	loadPresetNamesFromCookie,
 	savePresetNamesToCookie,
 } from "../logics/cookieUtils";
-import { getUniqueOptionId, parseUniqueOptionId } from "../logics/optionUtils";
+import { parseUniqueOptionId } from "../logics/optionUtils";
 import { getUpdatedExRState } from "../logics/syncLogic";
 import type {
 	ExROptionValueData,

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -4,7 +4,7 @@ import {
 	loadPresetNamesFromCookie,
 	savePresetNamesToCookie,
 } from "../logics/cookieUtils";
-import { getUpdatedExRState } from "../logics/exrStateLogic";
+import { applyUpdatedOptions } from "../logics/exrStateLogic";
 import { parseUniqueOptionId } from "../logics/optionUtils";
 import type {
 	ExROptionValueData,
@@ -108,28 +108,16 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 				);
 
 				set((state) => {
-					const {
-						nextValueData,
-						nextIsOptionActive,
-						valueDataChanged,
-						isOptionActiveChanged,
-					} = getUpdatedExRState(
+					const patch = applyUpdatedOptions(
 						updateResult,
 						state.exrValue,
 						state.isExROptionActive,
 					);
 
-					if (!valueDataChanged && !isOptionActiveChanged) {
+					if (!patch) {
 						return state;
 					}
 
-					const patch: Partial<ExROptionViewerSlice> = {};
-					if (valueDataChanged) {
-						patch.exrValue = nextValueData;
-					}
-					if (isOptionActiveChanged) {
-						patch.isExROptionActive = nextIsOptionActive;
-					}
 					return {
 						...state,
 						...patch,

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -5,7 +5,7 @@ import {
 	savePresetNamesToCookie,
 } from "../logics/cookieUtils";
 import { parseUniqueOptionId } from "../logics/optionUtils";
-import { getUpdatedExRState } from "../logics/syncLogic";
+import { getUpdatedExRState } from "../logics/exrStateLogic";
 import type {
 	ExROptionValueData,
 	OptionTab,

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -4,8 +4,8 @@ import {
 	loadPresetNamesFromCookie,
 	savePresetNamesToCookie,
 } from "../logics/cookieUtils";
-import { parseUniqueOptionId } from "../logics/optionUtils";
 import { getUpdatedExRState } from "../logics/exrStateLogic";
+import { parseUniqueOptionId } from "../logics/optionUtils";
 import type {
 	ExROptionValueData,
 	OptionTab,

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -5,9 +5,8 @@ import {
 	savePresetNamesToCookie,
 } from "../logics/cookieUtils";
 import { getUniqueOptionId, parseUniqueOptionId } from "../logics/optionUtils";
+import { getUpdatedExRState } from "../logics/syncLogic";
 import type {
-	ExRCategoryDto,
-	ExROptionDto,
 	ExROptionValueData,
 	OptionTab,
 	UniqueOptionId,
@@ -109,83 +108,16 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 				);
 
 				set((state) => {
-					let nextValueData = state.exrValue;
-					let nextIsOptionActive = state.isExROptionActive;
-
-					let valueDataChanged = false;
-					let isOptionActiveChanged = false;
-
-					const processOption = (
-						opt: ExROptionDto,
-						catId: number,
-						tId: number,
-					) => {
-						const uId = getUniqueOptionId(tId, catId, opt.Id);
-
-						// values
-						const currentValData = nextValueData[uId];
-						if (
-							!currentValData ||
-							currentValData.selection !== opt.Selection ||
-							currentValData.values.length !== opt.RangeMeta.Values.length ||
-							currentValData.values.some(
-								(v, i) => v !== opt.RangeMeta.Values[i],
-							)
-						) {
-							if (!valueDataChanged) {
-								nextValueData = { ...nextValueData };
-								valueDataChanged = true;
-							}
-							nextValueData[uId] = {
-								selection: opt.Selection,
-								values: opt.RangeMeta.Values,
-							};
-						}
-
-						// isOptionActive
-						if (nextIsOptionActive[uId] !== opt.IsActive) {
-							if (!isOptionActiveChanged) {
-								nextIsOptionActive = { ...nextIsOptionActive };
-								isOptionActiveChanged = true;
-							}
-							nextIsOptionActive[uId] = opt.IsActive;
-						}
-
-						if (opt.Childs) {
-							for (const child of opt.Childs) {
-								processOption(child, catId, tId);
-							}
-						}
-					};
-
-					const processCategory = (cat: ExRCategoryDto) => {
-						const tId = exrOptionMetaData.categories[cat.Id]?.tabId;
-						if (tId === undefined) {
-							return;
-						}
-						for (const opt of cat.Options) {
-							processOption(opt, cat.Id, tId);
-						}
-					};
-
-					updateResult.forEach((x) => {
-						if (!x) {
-							return;
-						}
-						if (x.UpdatedCategory) {
-							processCategory(x.UpdatedCategory);
-						}
-
-						for (const chain of x.ChainUpdatedOption) {
-							const tId = exrOptionMetaData.categories[chain.Id]?.tabId;
-							if (tId === undefined) {
-								continue;
-							}
-							for (const opt of chain.Options) {
-								processOption(opt, chain.Id, tId);
-							}
-						}
-					});
+					const {
+						nextValueData,
+						nextIsOptionActive,
+						valueDataChanged,
+						isOptionActiveChanged,
+					} = getUpdatedExRState(
+						updateResult,
+						state.exrValue,
+						state.isExROptionActive,
+					);
 
 					if (!valueDataChanged && !isOptionActiveChanged) {
 						return state;

--- a/tests/optionUtils.test.ts
+++ b/tests/optionUtils.test.ts
@@ -7,11 +7,33 @@ import {
 	getOptionPairType,
 	getUniqueOptionId,
 	groupOptionPairs,
+	parseAuOptionId,
 } from "../src/logics/optionUtils";
 
 describe("optionUtils", () => {
 	beforeEach(() => {
 		resetExrOptionMetaData();
+	});
+
+	describe("parseAuOptionId", () => {
+		it("should parse AuOptionId correctly", () => {
+			const optionName = 123;
+			const valueType = 5;
+			const prefix = 2;
+			// 123 * 10000 + 5 * 100 + 2 = 1230502
+			const id = optionName * 10000 + valueType * 100 + prefix;
+			const result = parseAuOptionId(id);
+			expect(result.optionName).toBe(optionName);
+			expect(result.valueType).toBe(valueType);
+			expect(result.prefix).toBe(prefix);
+		});
+
+		it("should handle zero values", () => {
+			const result = parseAuOptionId(0);
+			expect(result.optionName).toBe(0);
+			expect(result.valueType).toBe(0);
+			expect(result.prefix).toBe(0);
+		});
 	});
 
 	describe("getUniqueOptionId", () => {


### PR DESCRIPTION
Among Us (AU) のオプション更新処理を実装しました。

### 主な変更点:
1. **API連携の実装**:
   - `/au/option/` への PUT リクエストを行う `updateAuOption` 関数を `src/logics/api.ts` に追加しました。
   - `AuOptionId` から `OptionName` や `ValueType` を抽出する `parseAuOptionId` を追加しました。

2. **ストア (Zustand) の更新**:
   - `auOptionViewerSlice` に `updateAuOption` と `updateAuRoleOption` (RoleBase用) を追加しました。
   - これらのアクションは、ローカルの状態を即時更新（Optimistic Update）した後に API を呼び出し、戻り値の `UpdatedOptions` を使用して ExR 側のオプション状態を同期します。
   - ExR 側の状態更新ロジックを `src/logics/syncLogic.ts` の `getUpdatedExRState` に共通化しました。

3. **コンポーネントの修正**:
   - `AuOptionRow` と `AuRoleSpawnControls` が、単なるローカル更新ではなく、新しく実装した非同期アクションを呼び出すように変更しました。

4. **テストと検証**:
   - `parseAuOptionId` のユニットテストを追加し、正常に動作することを確認しました。
   - Playwright を使用したフロントエンド検証を行い、オプション変更がトリガーされることを確認しました。

---
*PR created automatically by Jules for task [184016459061516785](https://jules.google.com/task/184016459061516785) started by @yukieiji*