### PR TITLE
Fix unit test failures

### DIFF
--- a/tests/AuRoleSpawnControls.test.tsx
+++ b/tests/AuRoleSpawnControls.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuRoleSpawnControls } from "../src/feature/AuRoleSpawnControls";
 import { auOptionMetaData, resetAuOptionMetaData } from "../src/logics/api";
+import * as apiStore from "../src/logics/api.store";
 import { useStore } from "../src/useStore";
 
 describe("AuRoleSpawnControls", () => {
@@ -12,6 +13,13 @@ describe("AuRoleSpawnControls", () => {
 	beforeEach(() => {
 		resetAuOptionMetaData();
 		useStore.getState().resetViewer();
+
+		// Mock useUpdateAuRoleOptionSelection to update the store
+		vi.spyOn(apiStore, "useUpdateAuRoleOptionSelection").mockReturnValue(
+			async (chance, maxCount) => {
+				useStore.getState().updateAuOptionSelection(chance, maxCount);
+			},
+		);
 
 		auOptionMetaData.categoryMetaData[categoryId] = {
 			name: "Test Role",
@@ -43,7 +51,7 @@ describe("AuRoleSpawnControls", () => {
 		expect(screen.getByTestId("au-max-count-control")).toBeInTheDocument();
 	});
 
-	it("syncs chance to 10% when max count is set to non-zero from zero", () => {
+	it("syncs chance to 10% when max count is set to non-zero from zero", async () => {
 		render(<AuRoleSpawnControls categoryId={categoryId} />);
 
 		const countControl = screen.getByTestId("au-max-count-control");
@@ -53,12 +61,14 @@ describe("AuRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "1" } }); // Select 1
 
-		const state = useStore.getState();
-		expect(state.auValue[chanceId]).toBe(1); // Index 1 is 10%
-		expect(state.auValue[maxCountId]).toBe(1); // Index 1 is 1
+		await waitFor(() => {
+			const state = useStore.getState();
+			expect(state.auValue[chanceId]).toBe(1); // Index 1 is 10%
+			expect(state.auValue[maxCountId]).toBe(1); // Index 1 is 1
+		});
 	});
 
-	it("syncs chance to 0% when max count is set to 0", () => {
+	it("syncs chance to 0% when max count is set to 0", async () => {
 		// Initial state: Chance 50% (index 5), Max Count 2 (index 2)
 		useStore.getState().setAuValue({
 			[chanceId]: 5,
@@ -74,12 +84,14 @@ describe("AuRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "0" } });
 
-		const state = useStore.getState();
-		expect(state.auValue[chanceId]).toBe(0); // Index 0 is 0%
-		expect(state.auValue[maxCountId]).toBe(0);
+		await waitFor(() => {
+			const state = useStore.getState();
+			expect(state.auValue[chanceId]).toBe(0); // Index 0 is 0%
+			expect(state.auValue[maxCountId]).toBe(0);
+		});
 	});
 
-	it("syncs max count to 0 when chance is set to 0%", () => {
+	it("syncs max count to 0 when chance is set to 0%", async () => {
 		// Initial state: Chance 50% (index 5), Max Count 2 (index 2)
 		useStore.getState().setAuValue({
 			[chanceId]: 5,
@@ -95,9 +107,11 @@ describe("AuRoleSpawnControls", () => {
 
 		fireEvent.change(slider, { target: { value: "0" } });
 
-		const state = useStore.getState();
-		expect(state.auValue[chanceId]).toBe(0);
-		expect(state.auValue[maxCountId]).toBe(0);
+		await waitFor(() => {
+			const state = useStore.getState();
+			expect(state.auValue[chanceId]).toBe(0);
+			expect(state.auValue[maxCountId]).toBe(0);
+		});
 	});
 
 	it("closes accordion when chance becomes 0%", () => {

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRCategoryList } from "../src/feature/ExRCategoryList";
 import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import * as apiStore from "../src/logics/api.store";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
 import {
 	type ExRTabDto,
@@ -175,24 +176,25 @@ describe("ExRCategoryList Component Selection", () => {
 	it("filters out 50 and 51 from role category body", async () => {
 		useStore.getState().setSelectedExRTabId(OptionTab.CrewmateTab);
 
-		// Mock updateExROptionSelection to update the store manually
-		vi.spyOn(
-			useStore.getState(),
-			"updateExROptionSelection",
-		).mockImplementation(async (...args) => {
-			args.forEach((x) => {
-				useStore.getState().setExROptions(
-					{
-						...useStore.getState().exrValue,
-						[x.uniqueOptionId]: { selection: x.selection, values: [0, 100] },
-					},
-					useStore.getState().isExROptionActive,
-				);
-			});
-		});
+		// Mock useUpdateExROptionSelection to update the store manually
+		vi.spyOn(apiStore, "useUpdateExROptionSelection").mockReturnValue(
+			async (...args) => {
+				args.forEach((x) => {
+					useStore.getState().setExROptions(
+						{
+							...useStore.getState().exrValue,
+							[x.uniqueOptionId]: { selection: x.selection, values: [0, 100] },
+						},
+						useStore.getState().isExROptionActive,
+					);
+				});
+			},
+		);
+
+		const updateExRSelection = apiStore.useUpdateExROptionSelection();
 
 		// Set a non-zero spawn rate so the accordion is enabled
-		await useStore.getState().updateExROptionSelection({
+		await updateExRSelection({
 			uniqueOptionId: getUniqueOptionId(
 				OptionTab.CrewmateTab,
 				2,

--- a/tests/ExRCategoryList.test.tsx
+++ b/tests/ExRCategoryList.test.tsx
@@ -179,15 +179,16 @@ describe("ExRCategoryList Component Selection", () => {
 		// Mock useUpdateExROptionSelection to update the store manually
 		vi.spyOn(apiStore, "useUpdateExROptionSelection").mockReturnValue(
 			async (...args) => {
-				args.forEach((x) => {
-					useStore.getState().setExROptions(
-						{
-							...useStore.getState().exrValue,
-							[x.uniqueOptionId]: { selection: x.selection, values: [0, 100] },
-						},
-						useStore.getState().isExROptionActive,
-					);
-				});
+				const nextExrValue = { ...useStore.getState().exrValue };
+				for (const x of args) {
+					nextExrValue[x.uniqueOptionId] = {
+						selection: x.selection,
+						values: [0, 100],
+					};
+				}
+				useStore
+					.getState()
+					.setExROptions(nextExrValue, useStore.getState().isExROptionActive);
 			},
 		);
 

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -1,13 +1,14 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRHeaderOptionControl } from "../src/feature/ExRHeaderOptionControl";
+import * as apiStore from "../src/logics/api.store";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
 import type { ExROptionDto } from "../src/type";
 import { SPAWN_RATE_OPTION_ID } from "../src/type";
 import { useStore } from "../src/useStore";
 
 function setUpudateExROptionSelectionMock(values: (number | string)[]): void {
-	vi.spyOn(useStore.getState(), "updateExROptionSelection").mockImplementation(
+	vi.spyOn(apiStore, "useUpdateExROptionSelection").mockReturnValue(
 		async (...args) => {
 			args.forEach((x) => {
 				useStore.getState().setExROptions(

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -10,15 +10,16 @@ import { useStore } from "../src/useStore";
 function setUpudateExROptionSelectionMock(values: (number | string)[]): void {
 	vi.spyOn(apiStore, "useUpdateExROptionSelection").mockReturnValue(
 		async (...args) => {
-			args.forEach((x) => {
-				useStore.getState().setExROptions(
-					{
-						...useStore.getState().exrValue,
-						[x.uniqueOptionId]: { selection: x.selection, values: values },
-					},
-					useStore.getState().isExROptionActive,
-				);
-			});
+			const nextExrValue = { ...useStore.getState().exrValue };
+			for (const x of args) {
+				nextExrValue[x.uniqueOptionId] = {
+					selection: x.selection,
+					values: values,
+				};
+			}
+			useStore
+				.getState()
+				.setExROptions(nextExrValue, useStore.getState().isExROptionActive);
 		},
 	);
 }

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -14,19 +14,15 @@ function setUpudateExROptionSelectionSpawnRateMock(): void {
 	// Mock useUpdateExROptionSelection to update the store
 	vi.spyOn(apiStore, "useUpdateExROptionSelection").mockReturnValue(
 		async (...args) => {
-			args.forEach((x) => {
+			const currentStore = useStore.getState();
+			const nextExrValue = { ...currentStore.exrValue };
+			for (const x of args) {
 				const { optionId } = parseUniqueOptionId(x.uniqueOptionId);
 				const values =
 					optionId === SPAWN_RATE_OPTION_ID ? [0, 10, 20, 30] : [1, 2, 3];
-				const currentStore = useStore.getState();
-				currentStore.setExROptions(
-					{
-						...currentStore.exrValue,
-						[x.uniqueOptionId]: { selection: x.selection, values },
-					},
-					currentStore.isExROptionActive,
-				);
-			});
+				nextExrValue[x.uniqueOptionId] = { selection: x.selection, values };
+			}
+			currentStore.setExROptions(nextExrValue, currentStore.isExROptionActive);
 		},
 	);
 }

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
 import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import * as apiStore from "../src/logics/api.store";
 import {
 	getUniqueOptionId,
 	parseUniqueOptionId,
@@ -10,8 +11,8 @@ import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../src/type";
 import { useStore } from "../src/useStore";
 
 function setUpudateExROptionSelectionSpawnRateMock(): void {
-	// Mock updateExROptionSelection to update the store
-	vi.spyOn(useStore.getState(), "updateExROptionSelection").mockImplementation(
+	// Mock useUpdateExROptionSelection to update the store
+	vi.spyOn(apiStore, "useUpdateExROptionSelection").mockReturnValue(
 		async (...args) => {
 			args.forEach((x) => {
 				const { optionId } = parseUniqueOptionId(x.uniqueOptionId);
@@ -116,9 +117,10 @@ describe("ExRRoleSpawnControls", () => {
 		setupTestData(tabId, categoryId);
 
 		setUpudateExROptionSelectionSpawnRateMock();
+		const updateExRSelection = apiStore.useUpdateExROptionSelection();
 
 		// Set initial rate to 10%
-		await useStore.getState().updateExROptionSelection({
+		await updateExRSelection({
 			uniqueOptionId: getUniqueOptionId(
 				tabId,
 				categoryId,
@@ -172,9 +174,10 @@ describe("ExRRoleSpawnControls", () => {
 		setupTestData(tabId, categoryId);
 
 		setUpudateExROptionSelectionSpawnRateMock();
+		const updateExRSelection = apiStore.useUpdateExROptionSelection();
 
 		// Set initial rate to 10% and count to 2 (selection 1)
-		await useStore.getState().updateExROptionSelection({
+		await updateExRSelection({
 			uniqueOptionId: getUniqueOptionId(
 				tabId,
 				categoryId,
@@ -182,7 +185,7 @@ describe("ExRRoleSpawnControls", () => {
 			),
 			selection: 1,
 		});
-		await useStore.getState().updateExROptionSelection({
+		await updateExRSelection({
 			uniqueOptionId: getUniqueOptionId(
 				tabId,
 				categoryId,


### PR DESCRIPTION
Fixed 9 failing unit tests across 4 files. 
1. In ExR-related tests, replaced mocks for the non-existent `updateExROptionSelection` store method with mocks for the `useUpdateExROptionSelection` hook.
2. In Au-related tests, introduced `waitFor` to correctly handle asynchronous store updates during component interactions.
3. Reorganized imports in modified test files to satisfy Biome linting rules.
All 121 unit tests are now passing.

---
*PR created automatically by Jules for task [3779211058234748310](https://jules.google.com/task/3779211058234748310) started by @yukieiji*