### PR TITLE
Use dropdown for Map in Au options Tab 0

### DIFF
--- a/e2e/au-options.spec.ts
+++ b/e2e/au-options.spec.ts
@@ -17,28 +17,35 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe("Au Option Interactions", () => {
-	test("should display accordion for general tab categories", async ({
+	test("should display dropdown for map category in general tab", async ({
 		page,
 	}) => {
 		// Tab 0 (General)
 		await page.getByRole("button", { name: "0", exact: true }).click();
 
 		const category = page.getByTestId("au-category-0");
+		// In our new MapDropDown component, the title is displayed directly
 		await expect(category.getByText("map")).toBeVisible();
 
-		// Initially closed
-		// AuOptionControl uses OptionDropdownControl which has a role of "combobox" when using StringSelector
-		// But map category first option is a string selector
-		await expect(category.getByRole("button", { name: "map" })).toBeVisible();
+		// Map is now a direct dropdown (select element)
+		await expect(category.getByRole("combobox")).toBeVisible();
+	});
 
-		// Open it
-		await category.getByRole("button", { name: "map" }).click();
-		// In Accordion.tsx, the content is inside a div with data-testid="accordion-content"
-		const content = category.getByTestId("accordion-content");
-		await expect(content).toBeVisible();
-		// map category has a numeric range [0, 1, 2, 4, 5], so it uses OptionSliderControl
-		await expect(content.locator('input[type="range"]')).toBeVisible();
-		await expect(content.locator('input[type="text"]')).toBeVisible();
+	test("should display accordion for other general tab categories", async ({
+		page,
+	}) => {
+		// Tab 0 (General)
+		await page.getByRole("button", { name: "0", exact: true }).click();
+
+		// index 1 category should still be an accordion
+		const category = page.getByTestId("au-category-1");
+		// "インポスター" is the title of the second category in mock data
+		await expect(category.getByText("インポスター")).toBeVisible();
+
+		// Should be an accordion (button)
+		await expect(
+			category.getByRole("button", { name: "インポスター" }),
+		).toBeVisible();
 	});
 
 	test("should display role controls in header for role tabs", async ({

--- a/src/feature/AuCategoryList.tsx
+++ b/src/feature/AuCategoryList.tsx
@@ -2,6 +2,7 @@ import { auOptionMetaData } from "../logics/api";
 import { useStore } from "../useStore";
 import { AuRoleCategoryItem } from "./AuRoleCategoryItem";
 import { AuStandardCategoryItem } from "./AuStandardCategoryItem";
+import { MapDropDown } from "./MapDropDown";
 
 /**
  * Auの選択されたタブのカテゴリ一覧を表示するコンポーネント
@@ -23,13 +24,19 @@ export function AuCategoryList() {
 					<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
 				</div>
 			)}
-			{tabCategoryIds.map((categoryId) =>
-				isRoleTab ? (
-					<AuRoleCategoryItem key={categoryId} categoryId={categoryId} />
-				) : (
+			{tabCategoryIds.map((categoryId, index) => {
+				if (isRoleTab) {
+					return (
+						<AuRoleCategoryItem key={categoryId} categoryId={categoryId} />
+					);
+				}
+				if (selectedAuTabId === 0 && index === 0) {
+					return <MapDropDown key={categoryId} categoryId={categoryId} />;
+				}
+				return (
 					<AuStandardCategoryItem key={categoryId} categoryId={categoryId} />
-				),
-			)}
+				);
+			})}
 		</div>
 	);
 }

--- a/src/feature/MapDropDown.tsx
+++ b/src/feature/MapDropDown.tsx
@@ -1,0 +1,60 @@
+import { OptionDropdownControl } from "../components/parts/OptionDropdownControl";
+import { auOptionMetaData } from "../logics/api";
+import { useUpdateAuOptionSelection } from "../logics/api.store";
+import { useStore } from "../useStore";
+import { AuOptionRow } from "./AuOptionRow";
+
+interface MapDropDownProps {
+	categoryId: number;
+}
+
+/**
+ * マップ選択用のドロップダウンコンポーネント
+ * Tab 0 の最初のカテゴリ（マップ）で使用される
+ */
+export function MapDropDown({ categoryId }: MapDropDownProps) {
+	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
+	const updateAuOption = useUpdateAuOptionSelection();
+
+	if (!categoryMeta || categoryMeta.options.length === 0) {
+		return null;
+	}
+
+	// 最初のオプションがマップであることを想定
+	const [mapOptionId, ...otherOptionIds] = categoryMeta.options;
+	const optionMeta = auOptionMetaData.options[mapOptionId];
+	const selection = useStore((state) => state.auValue[mapOptionId] ?? 0);
+
+	if (!optionMeta) {
+		return null;
+	}
+
+	// 後で翻訳を適用するためのプレースホルダーとして、現在は数値または既存の値を表示
+	const displayValues = optionMeta.range.map((_, index) => index.toString());
+
+	return (
+		<div className="mb-4">
+			<div className="flex items-center justify-between py-3 px-4 bg-gray-800/30 rounded-lg mb-2 border border-gray-700/50">
+				<div className="flex flex-col">
+					<span className="text-gray-200 text-sm font-semibold">
+						{optionMeta.title}
+					</span>
+				</div>
+				<div className="w-48">
+					<OptionDropdownControl
+						values={displayValues}
+						selection={selection}
+						onChange={(newSelection) => {
+							updateAuOption({ auOptionId: mapOptionId, selection: newSelection });
+						}}
+					/>
+				</div>
+			</div>
+			<div className="space-y-1">
+				{otherOptionIds.map((optionId) => (
+					<AuOptionRow key={optionId} auOptionId={optionId} />
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/feature/MapDropDown.tsx
+++ b/src/feature/MapDropDown.tsx
@@ -37,10 +37,15 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 	const displayValues = optionMeta.range.map((_, index) => index.toString());
 
 	return (
-		<div className="mb-4" data-testid={`au-category-${categoryId}`}>
-			<div className="flex items-center justify-between py-3 px-4 bg-gray-800/30 rounded-lg mb-2 border border-gray-700/50">
-				<div className="flex flex-col">
-					<span className="text-gray-200 text-sm font-semibold">
+		<div
+			className="border border-gray-700 rounded-lg overflow-hidden mb-2"
+			data-testid={`au-category-${categoryId}`}
+		>
+			<div className="flex items-center justify-between p-4 bg-gray-800 border-b border-gray-700">
+				<div className="flex items-center gap-3">
+					{/* アコーディオンの矢印アイコンのスペースを確保して配置を揃える */}
+					<div className="w-5 h-5" />
+					<span className="font-semibold text-gray-200">
 						{optionMeta.title}
 					</span>
 				</div>
@@ -57,11 +62,13 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 					/>
 				</div>
 			</div>
-			<div className="space-y-1">
-				{otherOptionIds.map((optionId) => (
-					<AuOptionRow key={optionId} auOptionId={optionId} />
-				))}
-			</div>
+			{otherOptionIds.length > 0 && (
+				<div className="p-4 bg-gray-900 space-y-1">
+					{otherOptionIds.map((optionId) => (
+						<AuOptionRow key={optionId} auOptionId={optionId} />
+					))}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/feature/MapDropDown.tsx
+++ b/src/feature/MapDropDown.tsx
@@ -37,7 +37,7 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 	const displayValues = optionMeta.range.map((_, index) => index.toString());
 
 	return (
-		<div className="mb-4">
+		<div className="mb-4" data-testid={`au-category-${categoryId}`}>
 			<div className="flex items-center justify-between py-3 px-4 bg-gray-800/30 rounded-lg mb-2 border border-gray-700/50">
 				<div className="flex flex-col">
 					<span className="text-gray-200 text-sm font-semibold">

--- a/src/feature/MapDropDown.tsx
+++ b/src/feature/MapDropDown.tsx
@@ -33,8 +33,8 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 		return null;
 	}
 
-	// 後で翻訳を適用するためのプレースホルダーとして、現在は数値または既存の値を表示
-	const displayValues = optionMeta.range.map((_, index) => index.toString());
+	// 後で翻訳を適用するが、それまでは一旦 range に含まれる値をそのまま表示する
+	const displayValues = optionMeta.range.map((v) => v.toString());
 
 	return (
 		<div

--- a/src/feature/MapDropDown.tsx
+++ b/src/feature/MapDropDown.tsx
@@ -16,14 +16,18 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
 	const updateAuOption = useUpdateAuOptionSelection();
 
+	// 最初のオプションがマップであることを想定
+	const mapOptionId = categoryMeta?.options[0];
+	const selection = useStore((state) =>
+		mapOptionId ? (state.auValue[mapOptionId] ?? 0) : 0,
+	);
+
 	if (!categoryMeta || categoryMeta.options.length === 0) {
 		return null;
 	}
 
-	// 最初のオプションがマップであることを想定
-	const [mapOptionId, ...otherOptionIds] = categoryMeta.options;
+	const [_, ...otherOptionIds] = categoryMeta.options;
 	const optionMeta = auOptionMetaData.options[mapOptionId];
-	const selection = useStore((state) => state.auValue[mapOptionId] ?? 0);
 
 	if (!optionMeta) {
 		return null;
@@ -45,7 +49,10 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 						values={displayValues}
 						selection={selection}
 						onChange={(newSelection) => {
-							updateAuOption({ auOptionId: mapOptionId, selection: newSelection });
+							updateAuOption({
+								auOptionId: mapOptionId,
+								selection: newSelection,
+							});
 						}}
 					/>
 				</div>

--- a/tests/AuCategoryList.test.tsx
+++ b/tests/AuCategoryList.test.tsx
@@ -33,6 +33,10 @@ describe("AuCategoryList", () => {
 		expect(
 			screen.queryByRole("button", { name: "Map Category" }),
 		).not.toBeInTheDocument();
+
+		// Should show actual map names in dropdown
+		expect(screen.getByText("The Skeld")).toBeInTheDocument();
+		expect(screen.getByText("Mira HQ")).toBeInTheDocument();
 	});
 
 	it("renders standard category items for Tab 0 other than the first", () => {

--- a/tests/AuCategoryList.test.tsx
+++ b/tests/AuCategoryList.test.tsx
@@ -11,17 +11,42 @@ describe("AuCategoryList", () => {
 		useStore.getState().resetViewer();
 	});
 
-	it("renders standard category items for Tab 0", () => {
+	it("renders MapDropDown for the first category of Tab 0", () => {
+		const mapOptionId = 100 as unknown as AuOptionId;
 		auOptionMetaData.tabCategoryMap = { 0: [1], 1: [], 2: [] };
 		auOptionMetaData.categoryMetaData = {
-			1: { name: "General Settings", options: [] },
+			1: { name: "Map Category", options: [mapOptionId] },
+		};
+		auOptionMetaData.options[mapOptionId] = {
+			title: "Map",
+			format: "",
+			range: ["The Skeld", "Mira HQ"],
 		};
 		useStore.getState().setSelectedAuTabId(0);
 
 		render(<AuCategoryList />);
 
-		expect(screen.getByText("General Settings")).toBeInTheDocument();
-		expect(screen.getByTestId("au-category-1")).toBeInTheDocument();
+		expect(screen.getByText("Map")).toBeInTheDocument();
+		expect(screen.queryByTestId("au-category-1")).not.toBeInTheDocument();
+	});
+
+	it("renders standard category items for Tab 0 other than the first", () => {
+		auOptionMetaData.tabCategoryMap = { 0: [1, 2], 1: [], 2: [] };
+		auOptionMetaData.categoryMetaData = {
+			1: { name: "Map Category", options: [100 as unknown as AuOptionId] },
+			2: { name: "Other Category", options: [] },
+		};
+		auOptionMetaData.options[100 as unknown as AuOptionId] = {
+			title: "Map",
+			format: "",
+			range: ["The Skeld"],
+		};
+		useStore.getState().setSelectedAuTabId(0);
+
+		render(<AuCategoryList />);
+
+		expect(screen.getByText("Other Category")).toBeInTheDocument();
+		expect(screen.getByTestId("au-category-2")).toBeInTheDocument();
 	});
 
 	it("renders role category items for Tab 1", () => {

--- a/tests/AuCategoryList.test.tsx
+++ b/tests/AuCategoryList.test.tsx
@@ -27,7 +27,12 @@ describe("AuCategoryList", () => {
 		render(<AuCategoryList />);
 
 		expect(screen.getByText("Map")).toBeInTheDocument();
-		expect(screen.queryByTestId("au-category-1")).not.toBeInTheDocument();
+		// MapDropDown also uses data-testid="au-category-1" now
+		expect(screen.getByTestId("au-category-1")).toBeInTheDocument();
+		// But it should not be an accordion (standard items use Accordion which has role button for the title)
+		expect(
+			screen.queryByRole("button", { name: "Map Category" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders standard category items for Tab 0 other than the first", () => {

--- a/tests/OptionEditor.test.tsx
+++ b/tests/OptionEditor.test.tsx
@@ -12,10 +12,10 @@ describe("OptionEditor Components", () => {
 		auOptionMetaData.categoryMetaData = {
 			0: {
 				name: "Test Category",
-				options: [100 as any],
+				options: [100 as unknown as AuOptionId],
 			},
 		};
-		auOptionMetaData.options[100 as any] = {
+		auOptionMetaData.options[100 as unknown as AuOptionId] = {
 			title: "Map",
 			format: "",
 			range: ["The Skeld"],

--- a/tests/OptionEditor.test.tsx
+++ b/tests/OptionEditor.test.tsx
@@ -12,14 +12,19 @@ describe("OptionEditor Components", () => {
 		auOptionMetaData.categoryMetaData = {
 			0: {
 				name: "Test Category",
-				options: [],
+				options: [100 as any],
 			},
+		};
+		auOptionMetaData.options[100 as any] = {
+			title: "Map",
+			format: "",
+			range: ["The Skeld"],
 		};
 		auOptionMetaData.tabCategoryMap = { 0: [0] };
 
 		render(<AuOptionEditor />);
 
-		const category = screen.getByText("Test Category");
-		expect(category).toBeTruthy();
+		const mapLabel = screen.getByText("Map");
+		expect(mapLabel).toBeTruthy();
 	});
 });


### PR DESCRIPTION
This change replaces the accordion-style display for the "Map" category (first category in Tab 0 of AmongUs options) with a direct dropdown menu. A new MapDropDown component was introduced to handle this specific display requirement, while maintaining standard row display for any other options within that same category. The dropdown currently shows numeric values as placeholders for future translations.

---
*PR created automatically by Jules for task [4428045300341991923](https://jules.google.com/task/4428045300341991923) started by @yukieiji*