### PR TITLE
役職有効化時のアコーディオン自動開閉機能の追加

### DIFF
--- a/e2e/au-options.spec.ts
+++ b/e2e/au-options.spec.ts
@@ -123,7 +123,8 @@ test.describe("Au Option Interactions", () => {
 			.fill("10");
 
 		await expect(toggleButton).not.toBeDisabled();
-		await toggleButton.click();
+		// Automatically opens when changed to non-zero, so toggleButton should already be expanded
+		await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
 
 		// Should show additional options inside
 		// Since I don't know the exact options in mock data, I'll just check if the content area appears

--- a/e2e/au_role_accordion_auto_open.spec.ts
+++ b/e2e/au_role_accordion_auto_open.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 0;
+	});
+	await page.goto("/");
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+});
+
+test.describe("Au Role Accordion Auto Open", () => {
+	test("should open accordion when role is enabled by chance or max count", async ({ page }) => {
+		// Au Options の 役職タブ（タブ 1）に移動
+		await page.getByRole("button", { name: "1", exact: true }).first().click();
+
+		// 科学者 (Scientist) カテゴリ ID=5
+		const categoryId = "5";
+		const category = page.getByTestId(`au-category-${categoryId}`);
+		const toggleButton = category.getByRole("button").first();
+		const chanceSlider = category.getByTestId("au-chance-control").locator('input[type="range"]');
+		const countSlider = category.getByTestId("au-max-count-control").locator('input[type="range"]');
+
+		// 初期状態：閉じていて無効
+		await expect(toggleButton).toBeDisabled();
+		await expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+
+		// 1. レートを 10% に変更
+		await chanceSlider.fill("1");
+		await expect(toggleButton).toBeEnabled();
+		await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+		// 内容が表示されていることを確認（適当な子要素をチェック）
+		await expect(category.getByText("バイタル画面クールダウン")).toBeVisible();
+
+		// 2. 0% に戻して閉じることを確認
+		await chanceSlider.fill("0");
+		await expect(toggleButton).toBeDisabled();
+		await expect(category.getByText("バイタル画面クールダウン")).not.toBeVisible();
+
+		// 3. 数を 1 に変更して有効化
+		await countSlider.fill("1");
+		await expect(toggleButton).toBeEnabled();
+		await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+		await expect(category.getByText("バイタル画面クールダウン")).toBeVisible();
+	});
+});

--- a/e2e/au_role_accordion_auto_open.spec.ts
+++ b/e2e/au_role_accordion_auto_open.spec.ts
@@ -13,7 +13,9 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe("Au Role Accordion Auto Open", () => {
-	test("should open accordion when role is enabled by chance or max count", async ({ page }) => {
+	test("should open accordion when role is enabled by chance or max count", async ({
+		page,
+	}) => {
 		// Au Options の 役職タブ（タブ 1）に移動
 		await page.getByRole("button", { name: "1", exact: true }).first().click();
 
@@ -21,8 +23,12 @@ test.describe("Au Role Accordion Auto Open", () => {
 		const categoryId = "5";
 		const category = page.getByTestId(`au-category-${categoryId}`);
 		const toggleButton = category.getByRole("button").first();
-		const chanceSlider = category.getByTestId("au-chance-control").locator('input[type="range"]');
-		const countSlider = category.getByTestId("au-max-count-control").locator('input[type="range"]');
+		const chanceSlider = category
+			.getByTestId("au-chance-control")
+			.locator('input[type="range"]');
+		const countSlider = category
+			.getByTestId("au-max-count-control")
+			.locator('input[type="range"]');
 
 		// 初期状態：閉じていて無効
 		await expect(toggleButton).toBeDisabled();
@@ -38,7 +44,9 @@ test.describe("Au Role Accordion Auto Open", () => {
 		// 2. 0% に戻して閉じることを確認
 		await chanceSlider.fill("0");
 		await expect(toggleButton).toBeDisabled();
-		await expect(category.getByText("バイタル画面クールダウン")).not.toBeVisible();
+		await expect(
+			category.getByText("バイタル画面クールダウン"),
+		).not.toBeVisible();
 
 		// 3. 数を 1 に変更して有効化
 		await countSlider.fill("1");

--- a/e2e/exr_role_accordion_disabled.spec.ts
+++ b/e2e/exr_role_accordion_disabled.spec.ts
@@ -35,9 +35,8 @@ test.describe("ExR Role Accordion Disabled State", () => {
 			.getByTestId("spawn-rate-control")
 			.locator('input[type="range"]');
 
-		// 1. まずレートを 10% にしてアコーディオンを開く
+		// 1. まずレートを 10% にすると、自動的に開くことを確認
 		await rateSlider.fill("1"); // 10%
-		await toggleButton.click();
 		const content = sheriffCategory.getByTestId("exr-category-list-container");
 		await expect(content).toBeVisible();
 
@@ -50,16 +49,30 @@ test.describe("ExR Role Accordion Disabled State", () => {
 		await expect(toggleButton.getByText("・")).toBeVisible();
 		await expect(toggleButton.locator("svg")).not.toBeVisible();
 
-		// 4. レートを 10% に戻すと再度有効化されることを確認
+		// 4. レートを 10% に戻すと再度有効化され、自動的に開くことを確認
 		await rateSlider.fill("1"); // 10%
 		await expect(toggleButton).toBeEnabled();
 		await expect(toggleButton.locator("svg")).toBeVisible();
 		await expect(toggleButton.getByText("・")).not.toBeVisible();
-
-		// 5. 再度開けることを確認
-		// 少し待ってからクリック（状態遷移後の安定を待つ）
-		await page.waitForTimeout(100);
-		await toggleButton.click();
 		await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+		await expect(content).toBeVisible();
+
+		// 5. 一旦閉じてから数を変更しても自動的に開くことを確認
+		await toggleButton.click();
+		await expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+
+		const countSlider = sheriffCategory
+			.getByTestId("spawn-count-control")
+			.locator('input[type="range"]');
+
+		// 既にレートが10%なので、数を変更しても自動では開かないはず（今回の要件は「0から有効になった時」）
+		// 念の為0にしてから動かす
+		await rateSlider.fill("0");
+		await expect(toggleButton).toBeDisabled();
+
+		await countSlider.fill("2"); // 数を2にする（0から0以外へ）
+		await expect(toggleButton).toBeEnabled();
+		await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+		await expect(content).toBeVisible();
 	});
 });

--- a/e2e/exr_role_spawn_options.spec.ts
+++ b/e2e/exr_role_spawn_options.spec.ts
@@ -81,7 +81,7 @@ test.describe("ExR Role Spawn Options in Header", () => {
 		await expect(rateInput).toHaveValue("0");
 	});
 
-	test("interacting with header controls should not toggle accordion", async ({
+	test("interacting with header controls should not toggle accordion when already enabled", async ({
 		page,
 	}) => {
 		await page
@@ -94,13 +94,21 @@ test.describe("ExR Role Spawn Options in Header", () => {
 		// 最初は閉じている
 		await expect(content).not.toBeVisible();
 
-		// レートを 0% から 10% に変更（アコーディオンを有効化）
+		// レートを 0% から 10% に変更（アコーディオンを有効化 -> 自動で開く）
 		const rateSlider = sheriffCategory
 			.getByTestId("spawn-rate-control")
 			.locator('input[type="range"]');
 		await rateSlider.fill("1");
 
-		// まだ閉じているはず（stopPropagationが効いている）
+		// 自動で開くことを確認
+		await expect(content).toBeVisible();
+
+		// 一旦手動で閉じる
+		await sheriffCategory.getByRole("button", { name: "シェリフ" }).click();
+		await expect(content).not.toBeVisible();
+
+		// 既に有効な状態でレートを変更しても、アコーディオンがトグル（勝手に開く）されないことを確認
+		await rateSlider.fill("2");
 		await expect(content).not.toBeVisible();
 
 		// 数も操作してみる
@@ -126,14 +134,12 @@ test.describe("ExR Role Spawn Options in Header", () => {
 
 		const sheriffCategory = page.getByTestId(`exr-category-${SHERIFF_ID}`);
 
-		// レートを 10% に変更（アコーディオンを有効化）
+		// レートを 10% に変更（アコーディオンを有効化 -> 自動で開く）
 		await sheriffCategory
 			.getByTestId("spawn-rate-control")
 			.locator('input[type="range"]')
 			.fill("1");
 
-		// アコーディオンを開く
-		await sheriffCategory.getByRole("button", { name: "シェリフ" }).click();
 		const content = sheriffCategory.locator(".bg-gray-900");
 		await expect(content).toBeVisible();
 

--- a/src/feature/AuRoleSpawnControls.tsx
+++ b/src/feature/AuRoleSpawnControls.tsx
@@ -47,15 +47,15 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 
 	const handleChanceChange = (newSelection: number) => {
 		const newChanceValue = chanceValues[newSelection] ?? 0;
-		const isBecomingEnabled = isChanceZero && newChanceValue > 0;
+		const isBecomingEnabled = isMaxCountZero && newChanceValue > 0;
 
-		// Chanceが0%以外に変更されたとき、数が0なら1にあげる
 		const chanceUpdate = {
 			auOptionId: chanceOptionId,
 			selection: newSelection,
 		};
 
-		if (isMaxCountZero && newChanceValue > 0) {
+		// Chanceが0%以外に変更されたとき、数が0なら1にあげる
+		if (isBecomingEnabled) {
 			updateAuOption(chanceUpdate, {
 				auOptionId: maxCountOptionId,
 				selection: findClosestIndex(maxCountValues, 1),
@@ -95,7 +95,7 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 		};
 
 		// 数が0以外に変更されたとき、現在Chanceが0%なら10%に上げる
-		if (isChanceZero && newMaxCountValue > 0) {
+		if (isBecomingEnabled) {
 			updateAuOption(
 				{
 					auOptionId: chanceOptionId,

--- a/src/feature/AuRoleSpawnControls.tsx
+++ b/src/feature/AuRoleSpawnControls.tsx
@@ -46,18 +46,21 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	const isMaxCountZero = (maxCountValues[maxCountSelection] ?? 0) === 0;
 
 	const handleChanceChange = (newSelection: number) => {
+		const newChanceValue = chanceValues[newSelection] ?? 0;
+		const isBecomingEnabled = isChanceZero && newChanceValue > 0;
+
 		// Chanceが0%以外に変更されたとき、数が0なら1にあげる
 		const chanceUpdate = {
 			auOptionId: chanceOptionId,
 			selection: newSelection,
 		};
 
-		if (isMaxCountZero && (chanceValues[newSelection] ?? 0) > 0) {
+		if (isMaxCountZero && newChanceValue > 0) {
 			updateAuOption(chanceUpdate, {
 				auOptionId: maxCountOptionId,
 				selection: findClosestIndex(maxCountValues, 1),
 			});
-		} else if (chanceValues[newSelection] === 0) {
+		} else if (newChanceValue === 0) {
 			// Chanceが0%になったら、スポーン数も0にしてアコーディオンを閉じる
 			updateAuOption(chanceUpdate, {
 				auOptionId: maxCountOptionId,
@@ -72,6 +75,10 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 				selection: maxCountSelection,
 			});
 		}
+
+		if (isBecomingEnabled && !isOpenedCategory) {
+			toggleAuCategory(categoryId);
+		}
 	};
 
 	const handleChanceInputChange = (val: number) => {
@@ -79,13 +86,16 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 	};
 
 	const handleMaxCountChange = (newSelection: number) => {
+		const newMaxCountValue = maxCountValues[newSelection] ?? 0;
+		const isBecomingEnabled = isChanceZero && newMaxCountValue > 0;
+
 		const maxCountUpdate = {
 			auOptionId: maxCountOptionId,
 			selection: newSelection,
 		};
 
 		// 数が0以外に変更されたとき、現在Chanceが0%なら10%に上げる
-		if (isChanceZero && (maxCountValues[newSelection] ?? 0) > 0) {
+		if (isChanceZero && newMaxCountValue > 0) {
 			updateAuOption(
 				{
 					auOptionId: chanceOptionId,
@@ -93,7 +103,7 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 				},
 				maxCountUpdate,
 			);
-		} else if ((maxCountValues[newSelection] ?? 0) === 0) {
+		} else if (newMaxCountValue === 0) {
 			// 数を0にすると、Chanceも0%にする
 			updateAuOption(
 				{
@@ -113,6 +123,10 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 				},
 				maxCountUpdate,
 			);
+		}
+
+		if (isBecomingEnabled && !isOpenedCategory) {
+			toggleAuCategory(categoryId);
 		}
 	};
 

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -105,8 +105,9 @@ export function ExRRoleSpawnControls({
 					},
 					updateArg,
 				);
+			} else {
+				await updateExROptionSelection(updateArg);
 			}
-			await updateExROptionSelection(updateArg);
 		}
 
 		if (isBecomingEnabled && !isOpenedCategory) {

--- a/src/feature/ExRRoleSpawnControls.tsx
+++ b/src/feature/ExRRoleSpawnControls.tsx
@@ -53,6 +53,8 @@ export function ExRRoleSpawnControls({
 	const currentCountUISelection = isSpawnRateZero ? 0 : spawnCountSelection + 1;
 
 	const handleRateChange = async (newSelection: number) => {
+		const isBecomingEnabled = isSpawnRateZero && rateValues[newSelection] > 0;
+
 		await updateExROptionSelection({
 			uniqueOptionId: uniqueRateId,
 			selection: newSelection,
@@ -64,6 +66,10 @@ export function ExRRoleSpawnControls({
 				toggleExRCategory(categoryId);
 			}
 		}
+
+		if (isBecomingEnabled && !isOpenedCategory) {
+			toggleExRCategory(categoryId);
+		}
 	};
 
 	const handleRateInputChange = async (val: number) => {
@@ -71,6 +77,8 @@ export function ExRRoleSpawnControls({
 	};
 
 	const handleCountUIChange = async (newUISelection: number) => {
+		const isBecomingEnabled = isSpawnRateZero && newUISelection > 0;
+
 		if (newUISelection === 0) {
 			// 数を0にすると、レートも0%にする
 			await updateExROptionSelection(
@@ -99,6 +107,10 @@ export function ExRRoleSpawnControls({
 				);
 			}
 			await updateExROptionSelection(updateArg);
+		}
+
+		if (isBecomingEnabled && !isOpenedCategory) {
+			toggleExRCategory(categoryId);
 		}
 	};
 

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -12,6 +12,7 @@ export interface AuOptionViewerSlice {
 	setSelectedAuTabId: (id: number) => void;
 	setIsAuTabPending: (isPending: boolean) => void;
 	setAuValue: (value: Record<AuOptionId, number>) => void;
+	setOpenedAuCategoryIds: (ids: Record<number, boolean>) => void;
 	toggleAuCategory: (categoryId: number) => void;
 	updateAuOptionSelection: (...args: UpdateAuArg[]) => void;
 }
@@ -35,6 +36,9 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 		},
 		setAuValue(value) {
 			set({ auValue: value });
+		},
+		setOpenedAuCategoryIds: (ids) => {
+			set({ openedAuCategoryIds: ids });
 		},
 		toggleAuCategory: (categoryId) => {
 			set((state) => {

--- a/tests/AuRoleSpawnControls.test.tsx
+++ b/tests/AuRoleSpawnControls.test.tsx
@@ -131,4 +131,39 @@ describe("AuRoleSpawnControls", () => {
 
 		expect(useStore.getState().openedAuCategoryIds[categoryId]).toBe(false);
 	});
+
+	it("opens accordion when chance becomes non-zero from 0%", async () => {
+		// Initial state: Closed and Chance 0%
+		useStore.getState().setAuValue({ [chanceId]: 0, [maxCountId]: 0 });
+		expect(useStore.getState().openedAuCategoryIds[categoryId]).toBeFalsy();
+
+		render(<AuRoleSpawnControls categoryId={categoryId} />);
+
+		const chanceControl = screen.getByTestId("au-chance-control");
+		const slider = chanceControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+
+		fireEvent.change(slider, { target: { value: "1" } }); // Select 10%
+
+		expect(useStore.getState().openedAuCategoryIds[categoryId]).toBe(true);
+	});
+
+	it("opens accordion when max count becomes non-zero from 0", async () => {
+		// Initial state: Closed and Chance 0%
+		useStore.getState().setAuValue({ [chanceId]: 0, [maxCountId]: 0 });
+		useStore.getState().setOpenedAuCategoryIds({}); // Ensure it's empty
+		expect(useStore.getState().openedAuCategoryIds[categoryId]).toBeFalsy();
+
+		render(<AuRoleSpawnControls categoryId={categoryId} />);
+
+		const countControl = screen.getByTestId("au-max-count-control");
+		const slider = countControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+
+		fireEvent.change(slider, { target: { value: "1" } }); // Select 1
+
+		expect(useStore.getState().openedAuCategoryIds[categoryId]).toBe(true);
+	});
 });

--- a/tests/ExRRoleSpawnControls.test.tsx
+++ b/tests/ExRRoleSpawnControls.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExRRoleSpawnControls } from "../src/feature/ExRRoleSpawnControls";
 import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
@@ -209,5 +209,56 @@ describe("ExRRoleSpawnControls", () => {
 			.getByTestId("spawn-count-control")
 			.querySelector('input[type="text"]');
 		expect(countDisplay).toHaveValue("0");
+	});
+
+	it("opens accordion when rate becomes non-zero from 0%", async () => {
+		const tabId = 1;
+		const categoryId = 1;
+		setupTestData(tabId, categoryId);
+
+		setUpudateExROptionSelectionSpawnRateMock();
+
+		useStore.getState().resetViewer();
+		setupTestData(tabId, categoryId);
+
+		expect(useStore.getState().openedExRCategoryIds[categoryId]).toBeFalsy();
+
+		render(<ExRRoleSpawnControls tabId={tabId} categoryId={categoryId} />);
+
+		const rateControl = screen.getByTestId("spawn-rate-control");
+		const slider = rateControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+
+		await fireEvent.change(slider, { target: { value: "1" } }); // Select 10%
+
+		expect(useStore.getState().openedExRCategoryIds[categoryId]).toBe(true);
+	});
+
+	it("opens accordion when count becomes non-zero from 0 rate", async () => {
+		const tabId = 1;
+		const categoryId = 1;
+		setupTestData(tabId, categoryId);
+
+		setUpudateExROptionSelectionSpawnRateMock();
+
+		useStore.getState().resetViewer();
+		setupTestData(tabId, categoryId);
+
+		expect(useStore.getState().openedExRCategoryIds[categoryId]).toBeFalsy();
+
+		render(<ExRRoleSpawnControls tabId={tabId} categoryId={categoryId} />);
+
+		const countControl = screen.getByTestId("spawn-count-control");
+		const slider = countControl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+
+		await fireEvent.change(slider, { target: { value: "1" } }); // Select 1
+
+		await waitFor(() => {
+			const state = useStore.getState();
+			expect(state.openedExRCategoryIds[categoryId]).toBe(true);
+		});
 	});
 });


### PR DESCRIPTION
役職のスポーンレートや数が0から0以外に変更された際（役職が有効になった際）、自動的にアコーディオンを開くように修正しました。

主な変更内容：
- `AuRoleSpawnControls.tsx`: レートまたは数が0から変更された時にアコーディオンを開くロジックを追加。
- `ExRRoleSpawnControls.tsx`: レートまたは数が0から変更された時にアコーディオンを開くロジックを追加。
- `auOptionViewerSlice.ts`: テストでの状態制御を容易にするため `setOpenedAuCategoryIds` を追加。
- `AuRoleSpawnControls.test.tsx`, `ExRRoleSpawnControls.test.tsx`: 自動開閉動作を検証するテストケースを追加。

---
*PR created automatically by Jules for task [12253624876979402636](https://jules.google.com/task/12253624876979402636) started by @yukieiji*