### PR TITLE
Add right floating panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BlockableLoading } from "./feature/BlockableLoading";
 import { ExROptionEditor } from "./feature/ExROptionEditor";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { PresetSelector } from "./feature/PresetSelector";
+import { RightFloatingPanel } from "./feature/RightFloatingPanel";
 import { useSyncBackend } from "./hooks/useBackend";
 import { getAllOptions } from "./logics/api.store";
 import { useStore } from "./useStore";
@@ -108,6 +109,7 @@ function App() {
 				>
 					<MainContent />
 				</main>
+				<RightFloatingPanel />
 			</Suspense>
 		</div>
 	);

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -1,0 +1,76 @@
+import { useStore } from "../useStore";
+
+/**
+ * 右フローティングパネルコンポーネント
+ */
+export function RightFloatingPanel() {
+	const isRightPanelOpen = useStore((state) => {
+		return state.isRightPanelOpen;
+	});
+	const toggleRightPanel = useStore((state) => {
+		return state.toggleRightPanel;
+	});
+
+	return (
+		<>
+			{/* トグルボタン */}
+			<button
+				type="button"
+				onClick={toggleRightPanel}
+				className={`
+          fixed right-4 bottom-4 z-50 p-3 rounded-full bg-blue-600 text-white shadow-lg
+          hover:bg-blue-700 transition-transform active:scale-95 flex items-center justify-center
+          ${isRightPanelOpen ? "rotate-90" : ""}
+        `}
+				aria-label={isRightPanelOpen ? "パネルを閉じる" : "パネルを開く"}
+				style={{ width: "48px", height: "48px" }}
+			>
+				<span className="text-2xl font-bold">
+					{isRightPanelOpen ? "×" : "☰"}
+				</span>
+			</button>
+
+			{/* パネル本体 */}
+			<aside
+				className={`
+          fixed right-0 top-0 h-full w-80 bg-white border-l border-gray-200 shadow-2xl z-40
+          transition-transform duration-300 ease-in-out transform
+          ${isRightPanelOpen ? "translate-x-0" : "translate-x-full"}
+        `}
+				aria-label="右フローティングパネル"
+			>
+				<div className="flex flex-col h-full">
+					<div className="flex items-center justify-between p-4 border-b border-gray-100">
+						<h2 className="text-lg font-semibold">Right Panel</h2>
+						<button
+							type="button"
+							onClick={toggleRightPanel}
+							className="p-1 hover:bg-gray-100 rounded-md transition-colors w-8 h-8 flex items-center justify-center"
+						>
+							<span className="text-xl">×</span>
+						</button>
+					</div>
+					<div className="flex-1 overflow-y-auto p-4">
+						{/* 中身はまだ書かなくて良い */}
+						<p className="text-gray-500 text-center mt-10">
+							Content will be placed here.
+						</p>
+					</div>
+				</div>
+			</aside>
+
+			{/* オーバーレイ */}
+			{isRightPanelOpen && (
+				<button
+					type="button"
+					className="fixed inset-0 bg-black/20 z-30 cursor-default"
+					onClick={toggleRightPanel}
+					onKeyDown={(e) => {
+						if (e.key === "Escape") toggleRightPanel();
+					}}
+					aria-label="閉じる"
+				/>
+			)}
+		</>
+	);
+}

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -38,6 +38,7 @@ export function RightFloatingPanel() {
 				className={`
           fixed top-0 z-50 h-full w-6 bg-blue-600 text-white shadow-md
           hover:bg-blue-700 transition-all duration-300 ease-in-out flex items-center justify-center
+          cursor-pointer
           ${isRightPanelOpen ? "right-80" : "right-0"}
         `}
 				aria-label={isRightPanelOpen ? "パネルを閉じる" : "パネルを開く"}
@@ -73,7 +74,7 @@ export function RightFloatingPanel() {
 			{isRightPanelOpen && (
 				<button
 					type="button"
-					className="fixed inset-0 bg-black/20 z-30 cursor-pointer"
+					className="fixed inset-0 bg-black/20 z-30 cursor-default"
 					onClick={toggleRightPanel}
 					aria-label="閉じる"
 				/>

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useStore } from "../useStore";
 
 /**
@@ -10,6 +11,23 @@ export function RightFloatingPanel() {
 	const toggleRightPanel = useStore((state) => {
 		return state.toggleRightPanel;
 	});
+	const setRightPanelOpen = useStore((state) => {
+		return state.setRightPanelOpen;
+	});
+
+	// Escapeキーでパネルを閉じるためのグローバルリスナー
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape" && isRightPanelOpen) {
+				setRightPanelOpen(false);
+			}
+		};
+
+		window.addEventListener("keydown", handleKeyDown);
+		return () => {
+			window.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [isRightPanelOpen, setRightPanelOpen]);
 
 	return (
 		<>
@@ -55,11 +73,8 @@ export function RightFloatingPanel() {
 			{isRightPanelOpen && (
 				<button
 					type="button"
-					className="fixed inset-0 bg-black/20 z-30 cursor-default"
+					className="fixed inset-0 bg-black/20 z-30 cursor-pointer"
 					onClick={toggleRightPanel}
-					onKeyDown={(e) => {
-						if (e.key === "Escape") toggleRightPanel();
-					}}
 					aria-label="閉じる"
 				/>
 			)}

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -13,6 +13,22 @@ export function RightFloatingPanel() {
 
 	return (
 		<>
+			{/* トグルボタン (縦全体のストリップ) */}
+			<button
+				type="button"
+				onClick={toggleRightPanel}
+				className={`
+          fixed top-0 z-50 h-full w-6 bg-blue-600 text-white shadow-md
+          hover:bg-blue-700 transition-all duration-300 ease-in-out flex items-center justify-center
+          ${isRightPanelOpen ? "right-80" : "right-0"}
+        `}
+				aria-label={isRightPanelOpen ? "パネルを閉じる" : "パネルを開く"}
+			>
+				<span className="text-sm font-bold">
+					{isRightPanelOpen ? "▶" : "◀"}
+				</span>
+			</button>
+
 			{/* パネル本体 */}
 			<aside
 				className={`
@@ -22,27 +38,9 @@ export function RightFloatingPanel() {
         `}
 				aria-label="右フローティングパネル"
 			>
-				{/* トグルボタン (パネルの左側に配置) */}
-				<button
-					type="button"
-					onClick={toggleRightPanel}
-					className={`
-            absolute -left-14 bottom-4 z-50 p-3 rounded-full bg-blue-600 text-white shadow-lg
-            hover:bg-blue-700 transition-transform active:scale-95 flex items-center justify-center
-            ${isRightPanelOpen ? "rotate-90" : "-translate-x-full"}
-          `}
-					aria-label={isRightPanelOpen ? "パネルを閉じる" : "パネルを開く"}
-					style={{ width: "48px", height: "48px" }}
-				>
-					<span className="text-2xl font-bold">
-						{isRightPanelOpen ? "×" : "☰"}
-					</span>
-				</button>
-
 				<div className="flex flex-col h-full">
 					<div className="flex items-center justify-between p-4 border-b border-gray-100">
 						<h2 className="text-lg font-semibold">Right Panel</h2>
-						{/* ヘッダーの閉じるボタンは削除するか、残すか。ユーザーは「左のフローティングボタン」と言ったので、そちらを主役にする */}
 					</div>
 					<div className="flex-1 overflow-y-auto p-4">
 						{/* 中身はまだ書かなくて良い */}

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -13,23 +13,6 @@ export function RightFloatingPanel() {
 
 	return (
 		<>
-			{/* トグルボタン */}
-			<button
-				type="button"
-				onClick={toggleRightPanel}
-				className={`
-          fixed right-4 bottom-4 z-50 p-3 rounded-full bg-blue-600 text-white shadow-lg
-          hover:bg-blue-700 transition-transform active:scale-95 flex items-center justify-center
-          ${isRightPanelOpen ? "rotate-90" : ""}
-        `}
-				aria-label={isRightPanelOpen ? "パネルを閉じる" : "パネルを開く"}
-				style={{ width: "48px", height: "48px" }}
-			>
-				<span className="text-2xl font-bold">
-					{isRightPanelOpen ? "×" : "☰"}
-				</span>
-			</button>
-
 			{/* パネル本体 */}
 			<aside
 				className={`
@@ -39,16 +22,27 @@ export function RightFloatingPanel() {
         `}
 				aria-label="右フローティングパネル"
 			>
+				{/* トグルボタン (パネルの左側に配置) */}
+				<button
+					type="button"
+					onClick={toggleRightPanel}
+					className={`
+            absolute -left-14 bottom-4 z-50 p-3 rounded-full bg-blue-600 text-white shadow-lg
+            hover:bg-blue-700 transition-transform active:scale-95 flex items-center justify-center
+            ${isRightPanelOpen ? "rotate-90" : "-translate-x-full"}
+          `}
+					aria-label={isRightPanelOpen ? "パネルを閉じる" : "パネルを開く"}
+					style={{ width: "48px", height: "48px" }}
+				>
+					<span className="text-2xl font-bold">
+						{isRightPanelOpen ? "×" : "☰"}
+					</span>
+				</button>
+
 				<div className="flex flex-col h-full">
 					<div className="flex items-center justify-between p-4 border-b border-gray-100">
 						<h2 className="text-lg font-semibold">Right Panel</h2>
-						<button
-							type="button"
-							onClick={toggleRightPanel}
-							className="p-1 hover:bg-gray-100 rounded-md transition-colors w-8 h-8 flex items-center justify-center"
-						>
-							<span className="text-xl">×</span>
-						</button>
+						{/* ヘッダーの閉じるボタンは削除するか、残すか。ユーザーは「左のフローティングボタン」と言ったので、そちらを主役にする */}
 					</div>
 					<div className="flex-1 overflow-y-auto p-4">
 						{/* 中身はまだ書かなくて良い */}

--- a/src/slices/rightFloatingPanelSlice.ts
+++ b/src/slices/rightFloatingPanelSlice.ts
@@ -1,0 +1,29 @@
+import type { StateCreator } from "zustand";
+
+/**
+ * 右フローティングパネルの状態管理を行うスライスのインターフェース
+ */
+export interface RightFloatingPanelSlice {
+	isRightPanelOpen: boolean;
+	toggleRightPanel: () => void;
+	setRightPanelOpen: (isOpen: boolean) => void;
+}
+
+/**
+ * 右フローティングパネルの状態管理を行うスライスの生成
+ */
+export const createRightFloatingPanelSlice: StateCreator<
+	RightFloatingPanelSlice
+> = (set) => {
+	return {
+		isRightPanelOpen: false, // デフォルトクローズ
+		toggleRightPanel: () => {
+			set((state) => {
+				return { isRightPanelOpen: !state.isRightPanelOpen };
+			});
+		},
+		setRightPanelOpen: (isOpen: boolean) => {
+			set({ isRightPanelOpen: isOpen });
+		},
+	};
+};

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -7,6 +7,8 @@ import type { GlobalUiSlice } from "./slices/globalUiSlice";
 import { createGlobalUiSlice } from "./slices/globalUiSlice";
 import type { OptionGroupToggleSidebarSlice } from "./slices/optionGroupToggleSidebarSlice";
 import { createOptionGroupToggleSidebarSlice } from "./slices/optionGroupToggleSidebarSlice";
+import type { RightFloatingPanelSlice } from "./slices/rightFloatingPanelSlice";
+import { createRightFloatingPanelSlice } from "./slices/rightFloatingPanelSlice";
 
 /**
  * Zustand ストアの作成
@@ -14,12 +16,14 @@ import { createOptionGroupToggleSidebarSlice } from "./slices/optionGroupToggleS
 export const useStore = create<
 	GlobalUiSlice &
 		OptionGroupToggleSidebarSlice &
+		RightFloatingPanelSlice &
 		AuOptionViewerSlice &
 		ExROptionViewerSlice
 >()((...a) => {
 	return {
 		...createGlobalUiSlice(...a),
 		...createOptionGroupToggleSidebarSlice(...a),
+		...createRightFloatingPanelSlice(...a),
 		...createAuOptionViewerSlice(...a),
 		...createExROptionViewerSlice(...a),
 	};


### PR DESCRIPTION
Added a new right floating panel component that is hidden by default. It includes a toggle button fixed to the bottom-right of the screen and an overlay that allows closing the panel by clicking outside. The state is managed via a new Zustand slice integrated into the main store.

---
*PR created automatically by Jules for task [6032784479065396964](https://jules.google.com/task/6032784479065396964) started by @yukieiji*