### PR TITLE
Implement nested accordions in right sidebar

### DIFF
--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Accordion } from "../components/parts/Accordion";
 import { useStore } from "../useStore";
 
@@ -16,9 +16,12 @@ export function RightFloatingPanel() {
 		return state.setRightPanelOpen;
 	});
 
-	const [isSettingsOpen, setIsSettingsOpen] = useState(true);
-	const [isAuSettingsOpen, setIsAuSettingsOpen] = useState(true);
-	const [isExrSettingsOpen, setIsExrSettingsOpen] = useState(true);
+	const isSettingsOpen = useStore((state) => state.isSettingsOpen);
+	const toggleSettings = useStore((state) => state.toggleSettings);
+	const isAuSettingsOpen = useStore((state) => state.isAuSettingsOpen);
+	const toggleAuSettings = useStore((state) => state.toggleAuSettings);
+	const isExrSettingsOpen = useStore((state) => state.isExrSettingsOpen);
+	const toggleExrSettings = useStore((state) => state.toggleExrSettings);
 
 	// Escapeキーでパネルを閉じるためのグローバルリスナー
 	useEffect(() => {
@@ -70,13 +73,13 @@ export function RightFloatingPanel() {
 						<Accordion
 							title="設定値"
 							isOpen={isSettingsOpen}
-							onToggle={() => setIsSettingsOpen(!isSettingsOpen)}
+							onToggle={toggleSettings}
 						>
 							<div className="flex flex-col gap-2">
 								<Accordion
 									title="AmongUsの設定"
 									isOpen={isAuSettingsOpen}
-									onToggle={() => setIsAuSettingsOpen(!isAuSettingsOpen)}
+									onToggle={toggleAuSettings}
 								>
 									<p className="text-gray-400 text-sm">
 										AmongUsの設定コンテンツ
@@ -85,7 +88,7 @@ export function RightFloatingPanel() {
 								<Accordion
 									title="ExRの設定"
 									isOpen={isExrSettingsOpen}
-									onToggle={() => setIsExrSettingsOpen(!isExrSettingsOpen)}
+									onToggle={toggleExrSettings}
 								>
 									<p className="text-gray-400 text-sm">ExRの設定コンテンツ</p>
 								</Accordion>

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -78,7 +78,9 @@ export function RightFloatingPanel() {
 									isOpen={isAuSettingsOpen}
 									onToggle={() => setIsAuSettingsOpen(!isAuSettingsOpen)}
 								>
-									<p className="text-gray-400 text-sm">AmongUsの設定コンテンツ</p>
+									<p className="text-gray-400 text-sm">
+										AmongUsの設定コンテンツ
+									</p>
 								</Accordion>
 								<Accordion
 									title="ExRの設定"

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { Accordion } from "../components/parts/Accordion";
 import { useStore } from "../useStore";
 
 /**
@@ -14,6 +15,10 @@ export function RightFloatingPanel() {
 	const setRightPanelOpen = useStore((state) => {
 		return state.setRightPanelOpen;
 	});
+
+	const [isSettingsOpen, setIsSettingsOpen] = useState(true);
+	const [isAuSettingsOpen, setIsAuSettingsOpen] = useState(true);
+	const [isExrSettingsOpen, setIsExrSettingsOpen] = useState(true);
 
 	// Escapeキーでパネルを閉じるためのグローバルリスナー
 	useEffect(() => {
@@ -62,10 +67,28 @@ export function RightFloatingPanel() {
 						<h2 className="text-lg font-semibold">Right Panel</h2>
 					</div>
 					<div className="flex-1 overflow-y-auto p-4">
-						{/* 中身はまだ書かなくて良い */}
-						<p className="text-gray-500 text-center mt-10">
-							Content will be placed here.
-						</p>
+						<Accordion
+							title="設定値"
+							isOpen={isSettingsOpen}
+							onToggle={() => setIsSettingsOpen(!isSettingsOpen)}
+						>
+							<div className="flex flex-col gap-2">
+								<Accordion
+									title="AmongUsの設定"
+									isOpen={isAuSettingsOpen}
+									onToggle={() => setIsAuSettingsOpen(!isAuSettingsOpen)}
+								>
+									<p className="text-gray-400 text-sm">AmongUsの設定コンテンツ</p>
+								</Accordion>
+								<Accordion
+									title="ExRの設定"
+									isOpen={isExrSettingsOpen}
+									onToggle={() => setIsExrSettingsOpen(!isExrSettingsOpen)}
+								>
+									<p className="text-gray-400 text-sm">ExRの設定コンテンツ</p>
+								</Accordion>
+							</div>
+						</Accordion>
 					</div>
 				</div>
 			</aside>

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -75,7 +75,7 @@ export function RightFloatingPanel() {
 							isOpen={isSettingsOpen}
 							onToggle={toggleSettings}
 						>
-							<div className="flex flex-col gap-2">
+							<div className="flex flex-col">
 								<Accordion
 									title="AmongUsの設定"
 									isOpen={isAuSettingsOpen}

--- a/src/slices/rightFloatingPanelSlice.ts
+++ b/src/slices/rightFloatingPanelSlice.ts
@@ -7,6 +7,12 @@ export interface RightFloatingPanelSlice {
 	isRightPanelOpen: boolean;
 	toggleRightPanel: () => void;
 	setRightPanelOpen: (isOpen: boolean) => void;
+	isSettingsOpen: boolean;
+	toggleSettings: () => void;
+	isAuSettingsOpen: boolean;
+	toggleAuSettings: () => void;
+	isExrSettingsOpen: boolean;
+	toggleExrSettings: () => void;
 }
 
 /**
@@ -24,6 +30,24 @@ export const createRightFloatingPanelSlice: StateCreator<
 		},
 		setRightPanelOpen: (isOpen: boolean) => {
 			set({ isRightPanelOpen: isOpen });
+		},
+		isSettingsOpen: true,
+		toggleSettings: () => {
+			set((state) => {
+				return { isSettingsOpen: !state.isSettingsOpen };
+			});
+		},
+		isAuSettingsOpen: true,
+		toggleAuSettings: () => {
+			set((state) => {
+				return { isAuSettingsOpen: !state.isAuSettingsOpen };
+			});
+		},
+		isExrSettingsOpen: true,
+		toggleExrSettings: () => {
+			set((state) => {
+				return { isExrSettingsOpen: !state.isExrSettingsOpen };
+			});
 		},
 	};
 };


### PR DESCRIPTION
Implemented a nested accordion structure in the right sidebar as requested. The "設定値" accordion contains "AmongUsの設定" and "ExRの設定" accordions, both of which are open by default and contain placeholder text. Verified the implementation with Playwright screenshots.

---
*PR created automatically by Jules for task [3198156211370332161](https://jules.google.com/task/3198156211370332161) started by @yukieiji*