### PR TITLE
AmongUsタブ0設定の右パネル表示とナビゲーション機能の実装

### DIFF
--- a/e2e/auTab0Navigation.spec.ts
+++ b/e2e/auTab0Navigation.spec.ts
@@ -52,6 +52,12 @@ test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 			{ timeout: 10000 },
 		);
 
+		// サイドバーと右パネルが閉じていることを確認
+		await expect(page.getByLabel("オプションサイドバー")).toHaveClass(/w-12/);
+		await expect(page.getByLabel("右フローティングパネル")).toHaveClass(
+			/translate-x-full/,
+		);
+
 		// ハイライト用のクラスやスタイルが適用されているか確認
 		// id="au-option-..." の要素がリングクラスを持っているか
 		const impCountRow = page.locator('[id^="au-option-10200"]').first();
@@ -59,6 +65,6 @@ test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 		await expect(impCountRow).toHaveClass(/ring-blue-500/);
 
 		// 7. 数秒後にハイライトが消えることを確認
-		await expect(impCountRow).not.toHaveClass(/ring-2/, { timeout: 3000 });
+		await expect(impCountRow).not.toHaveClass(/ring-2/, { timeout: 10000 });
 	});
 });

--- a/e2e/auTab0Navigation.spec.ts
+++ b/e2e/auTab0Navigation.spec.ts
@@ -34,6 +34,9 @@ test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 		await impCountSetting.scrollIntoViewIfNeeded();
 		await expect(impCountSetting).toBeVisible({ timeout: 15000 });
 
+		// 値が表示されていることを確認（モックデータでは1のはず）
+		await expect(impCountSetting.locator("span").last()).toHaveText("1");
+
 		// 4. メインエディタで一旦 ExR Options に切り替えておく
 		// 右パネルのオーバーレイが邪魔をする可能性があるので、一旦右パネルを閉じる
 		await page.getByRole("button", { name: "閉じる", exact: true }).click();

--- a/e2e/auTab0Navigation.spec.ts
+++ b/e2e/auTab0Navigation.spec.ts
@@ -2,12 +2,10 @@ import { expect, test } from "@playwright/test";
 
 test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 	test.beforeEach(async ({ page }) => {
-		// モックデータを使用するために dev:mock 相当の設定で起動している前提
 		await page.goto("/");
-		// 初期ロード待ち
-		// testIdがうまく取れない場合を考慮して見出しを確認
-		await expect(page.getByRole("heading", { name: /Options/ })).toBeVisible({
-			timeout: 15000,
+		// ローディング画面が消えるのを待つ
+		await expect(page.getByText("Loading data...")).not.toBeVisible({
+			timeout: 30000,
 		});
 	});
 
@@ -15,43 +13,52 @@ test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 		page,
 	}) => {
 		// 1. 右パネルを開く
-		const rightPanelToggle = page.getByLabel("パネルを開く");
-		if (await rightPanelToggle.isVisible()) {
-			await rightPanelToggle.click();
-		}
+		const rightPanelToggle = page.getByRole("button", { name: "パネルを開く" });
+		await rightPanelToggle.click();
 		await expect(page.getByLabel("右フローティングパネル")).toBeVisible();
 
 		// 2. 「AmongUsの設定」アコーディオンを展開（デフォルトで開いているはずだが念のため）
-		const auSettingsAccordion = page.getByText("AmongUsの設定");
+		const auSettingsAccordion = page.getByRole("button", {
+			name: "AmongUsの設定",
+		});
 		await expect(auSettingsAccordion).toBeVisible();
 
-		// 3. Tab 0の内容（例: 「マップ」）が表示されていることを確認
-		const mapSetting = page.getByText("マップ", { exact: true });
-		await expect(mapSetting).toBeVisible();
+		// アコーディオンが閉じている場合はクリックして開く（初期値 ?? true だが開いていない可能性を考慮）
+		if ((await auSettingsAccordion.getAttribute("aria-expanded")) === "false") {
+			await auSettingsAccordion.click();
+		}
+
+		// 3. Tab 0の内容が表示されていることを確認 (インポスター数 = right-panel-option-10200)
+		const impCountSetting = page.getByTestId("right-panel-option-10200");
+		// スクロールが必要な場合がある
+		await impCountSetting.scrollIntoViewIfNeeded();
+		await expect(impCountSetting).toBeVisible({ timeout: 15000 });
 
 		// 4. メインエディタで一旦 ExR Options に切り替えておく
+		// 右パネルのオーバーレイが邪魔をする可能性があるので、一旦右パネルを閉じる
+		await page.getByRole("button", { name: "閉じる", exact: true }).click();
 		await page.getByRole("button", { name: "ExR Options" }).click();
 		await expect(
 			page.getByRole("heading", { name: "ExR Options" }),
 		).toBeVisible();
 
-		// 5. 右パネルの「マップ」をダブルクリック
-		await mapSetting.dblclick();
+		// 5. 右パネルの項目をダブルクリック
+		// 再び開く
+		await page.getByRole("button", { name: "パネルを開く" }).click();
+		await impCountSetting.dblclick();
 
 		// 6. 自動的に Au Options に戻り、項目が表示されていることを確認
-		await expect(
-			page.getByRole("heading", { name: "Au Options" }),
-		).toBeVisible();
+		await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible(
+			{ timeout: 10000 },
+		);
 
 		// ハイライト用のクラスやスタイルが適用されているか確認
 		// id="au-option-..." の要素がリングクラスを持っているか
-		const mapRow = page
-			.locator('[id^="au-option-"]')
-			.filter({ hasText: "マップ" });
-		await expect(mapRow).toHaveClass(/ring-2/);
-		await expect(mapRow).toHaveClass(/ring-blue-500/);
+		const impCountRow = page.locator('[id^="au-option-10200"]').first();
+		await expect(impCountRow).toHaveClass(/ring-2/);
+		await expect(impCountRow).toHaveClass(/ring-blue-500/);
 
 		// 7. 数秒後にハイライトが消えることを確認
-		await expect(mapRow).not.toHaveClass(/ring-2/, { timeout: 3000 });
+		await expect(impCountRow).not.toHaveClass(/ring-2/, { timeout: 3000 });
 	});
 });

--- a/e2e/auTab0Navigation.spec.ts
+++ b/e2e/auTab0Navigation.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
+	test.beforeEach(async ({ page }) => {
+		// モックデータを使用するために dev:mock 相当の設定で起動している前提
+		await page.goto("/");
+		// 初期ロード待ち
+		// testIdがうまく取れない場合を考慮して見出しを確認
+		await expect(page.getByRole("heading", { name: /Options/ })).toBeVisible({
+			timeout: 15000,
+		});
+	});
+
+	test("navigates and highlights when an option is double-clicked in the right panel", async ({
+		page,
+	}) => {
+		// 1. 右パネルを開く
+		const rightPanelToggle = page.getByLabel("パネルを開く");
+		if (await rightPanelToggle.isVisible()) {
+			await rightPanelToggle.click();
+		}
+		await expect(page.getByLabel("右フローティングパネル")).toBeVisible();
+
+		// 2. 「AmongUsの設定」アコーディオンを展開（デフォルトで開いているはずだが念のため）
+		const auSettingsAccordion = page.getByText("AmongUsの設定");
+		await expect(auSettingsAccordion).toBeVisible();
+
+		// 3. Tab 0の内容（例: 「マップ」）が表示されていることを確認
+		const mapSetting = page.getByText("マップ", { exact: true });
+		await expect(mapSetting).toBeVisible();
+
+		// 4. メインエディタで一旦 ExR Options に切り替えておく
+		await page.getByRole("button", { name: "ExR Options" }).click();
+		await expect(
+			page.getByRole("heading", { name: "ExR Options" }),
+		).toBeVisible();
+
+		// 5. 右パネルの「マップ」をダブルクリック
+		await mapSetting.dblclick();
+
+		// 6. 自動的に Au Options に戻り、項目が表示されていることを確認
+		await expect(
+			page.getByRole("heading", { name: "Au Options" }),
+		).toBeVisible();
+
+		// ハイライト用のクラスやスタイルが適用されているか確認
+		// id="au-option-..." の要素がリングクラスを持っているか
+		const mapRow = page
+			.locator('[id^="au-option-"]')
+			.filter({ hasText: "マップ" });
+		await expect(mapRow).toHaveClass(/ring-2/);
+		await expect(mapRow).toHaveClass(/ring-blue-500/);
+
+		// 7. 数秒後にハイライトが消えることを確認
+		await expect(mapRow).not.toHaveClass(/ring-2/, { timeout: 3000 });
+	});
+});

--- a/e2e/auTab0Navigation.spec.ts
+++ b/e2e/auTab0Navigation.spec.ts
@@ -48,7 +48,8 @@ test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 		// 5. 右パネルの項目をダブルクリック
 		// 再び開く
 		await page.getByRole("button", { name: "パネルを開く" }).click();
-		await impCountSetting.dblclick();
+		await impCountSetting.scrollIntoViewIfNeeded();
+		await impCountSetting.dblclick({ force: true });
 
 		// 6. 自動的に Au Options に戻り、項目が表示されていることを確認
 		await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible(

--- a/src/feature/AuOptionRow.tsx
+++ b/src/feature/AuOptionRow.tsx
@@ -14,6 +14,9 @@ interface AuOptionRowProps {
 export function AuOptionRow({ auOptionId }: AuOptionRowProps) {
 	const optionMeta = auOptionMetaData.options[auOptionId];
 	const selection = useStore((state) => state.auValue[auOptionId] ?? 0);
+	const highlightedAuOptionId = useStore(
+		(state) => state.highlightedAuOptionId,
+	);
 
 	const updateAuOption = useUpdateAuOptionSelection();
 
@@ -21,8 +24,15 @@ export function AuOptionRow({ auOptionId }: AuOptionRowProps) {
 		return null;
 	}
 
+	const isHighlighted = highlightedAuOptionId === auOptionId;
+
 	return (
-		<div className="flex items-center justify-between py-2 border-b border-gray-800 last:border-0 hover:bg-gray-800/50 transition-colors px-2 rounded">
+		<div
+			id={`au-option-${auOptionId}`}
+			className={`flex items-center justify-between py-2 border-b border-gray-800 last:border-0 hover:bg-gray-800/50 transition-all duration-500 px-2 rounded ${
+				isHighlighted ? "ring-2 ring-blue-500 bg-blue-500/10" : ""
+			}`}
+		>
 			<div className="flex flex-col flex-1 min-w-0 mr-4">
 				<span className="text-gray-200 text-sm font-medium truncate">
 					{optionMeta.title}

--- a/src/feature/AuTab0Viewer.tsx
+++ b/src/feature/AuTab0Viewer.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Accordion } from "../components/parts/Accordion";
-import { auOptionMetaData } from "../logics/api";
+import { auOptionMetaData, translationMetaData } from "../logics/api";
 import type { AuOptionId } from "../type";
 import { useStore } from "../useStore";
 
@@ -90,7 +90,9 @@ export function AuTab0Viewer() {
 								let valueDisplay = "";
 								const value = optionMeta.range[selection];
 								if (typeof value === "boolean") {
-									valueDisplay = value ? "ON" : "OFF";
+									valueDisplay =
+										translationMetaData.booleanTransData[value ? 1 : 0] ||
+										(value ? "ON" : "OFF");
 								} else {
 									valueDisplay = optionMeta.format.replace(
 										"{0}",

--- a/src/feature/AuTab0Viewer.tsx
+++ b/src/feature/AuTab0Viewer.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { Accordion } from "../components/parts/Accordion";
+import { auOptionMetaData } from "../logics/api";
+import type { AuOptionId } from "../type";
+import { useStore } from "../useStore";
+
+/**
+ * Auのタブ0の設定内容を表示し、ダブルクリックで該当箇所へ移動するコンポーネント
+ */
+export function AuTab0Viewer() {
+	const setSelectedTab = useStore((state) => state.setSelectedTab);
+	const setSelectedAuTabId = useStore((state) => state.setSelectedAuTabId);
+	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
+	const openedAuCategoryIds = useStore((state) => state.openedAuCategoryIds);
+	const setHighlightedAuOptionId = useStore(
+		(state) => state.setHighlightedAuOptionId,
+	);
+	const auValue = useStore((state) => state.auValue);
+
+	// 右パネル内での各カテゴリの開閉状態（デフォルトすべて真）
+	const [localOpenedCategories, setLocalOpenedCategories] = useState<
+		Record<number, boolean>
+	>(() => {
+		const initial: Record<number, boolean> = {};
+		const ids = auOptionMetaData.tabCategoryMap[0] || [];
+		for (const id of ids) {
+			initial[id] = true;
+		}
+		return initial;
+	});
+
+	const toggleLocalCategory = (categoryId: number) => {
+		setLocalOpenedCategories((prev) => ({
+			...prev,
+			[categoryId]: !prev[categoryId],
+		}));
+	};
+
+	// タブ0のカテゴリIDを取得
+	const tab0CategoryIds = auOptionMetaData.tabCategoryMap[0] || [];
+
+	const handleDoubleClick = (categoryId: number, optionId: AuOptionId) => {
+		// 1. メインタブをAuに切り替え
+		setSelectedTab("Au");
+		// 2. Auタブを0に切り替え
+		setSelectedAuTabId(0);
+		// 3. カテゴリを確実に開く
+		if (!openedAuCategoryIds[categoryId]) {
+			toggleAuCategory(categoryId);
+		}
+
+		// 4. ハイライト設定
+		setHighlightedAuOptionId(optionId);
+
+		// 5. 少し遅らせてスクロール（DOMのレンダリング待ち）
+		setTimeout(() => {
+			const element = document.getElementById(`au-option-${optionId}`);
+			if (element) {
+				element.scrollIntoView({ behavior: "smooth", block: "center" });
+			}
+			// 2秒後にハイライトを消す
+			setTimeout(() => {
+				setHighlightedAuOptionId(null);
+			}, 2000);
+		}, 100);
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			{tab0CategoryIds.map((categoryId) => {
+				const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
+				if (!categoryMeta) {
+					return null;
+				}
+
+				return (
+					<Accordion
+						key={categoryId}
+						title={<span className="text-sm">{categoryMeta.name}</span>}
+						isOpen={localOpenedCategories[categoryId] ?? false}
+						onToggle={() => toggleLocalCategory(categoryId)}
+					>
+						<div className="flex flex-col gap-1">
+							{categoryMeta.options.map((optionId) => {
+								const optionMeta = auOptionMetaData.options[optionId];
+								const selection = auValue[optionId] ?? 0;
+								if (!optionMeta) {
+									return null;
+								}
+
+								let valueDisplay = "";
+								const value = optionMeta.range[selection];
+								if (typeof value === "boolean") {
+									valueDisplay = value ? "ON" : "OFF";
+								} else {
+									valueDisplay = optionMeta.format.replace(
+										"{0}",
+										value.toString(),
+									);
+								}
+
+								return (
+									<button
+										type="button"
+										key={optionId}
+										onDoubleClick={() =>
+											handleDoubleClick(categoryId, optionId)
+										}
+										className="w-full flex justify-between items-center py-1 px-2 hover:bg-gray-700/50 rounded cursor-pointer select-none"
+										title="ダブルクリックで設定場所へ移動"
+									>
+										<span className="text-xs text-gray-300">
+											{optionMeta.title}
+										</span>
+										<span className="text-xs text-blue-400 font-medium text-right">
+											{valueDisplay}
+										</span>
+									</button>
+								);
+							})}
+						</div>
+					</Accordion>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/feature/AuTab0Viewer.tsx
+++ b/src/feature/AuTab0Viewer.tsx
@@ -1,5 +1,7 @@
 import { use } from "react";
 import { Accordion } from "../components/parts/Accordion";
+import { ColoredText } from "../components/parts/ColoredText";
+import { OptionFormat } from "../components/parts/OptionFormat";
 import { auOptionMetaData, translationMetaData } from "../logics/api";
 import { getAllOptions } from "../logics/api.store";
 import type { AuOptionId } from "../type";
@@ -81,20 +83,8 @@ export function AuTab0Viewer() {
 									return null;
 								}
 
-								let valueDisplay = "";
 								const value = optionMeta.range[selection];
-								if (typeof value === "boolean") {
-									valueDisplay =
-										translationMetaData.booleanTransData[value ? 1 : 0] ||
-										(value ? "ON" : "OFF");
-								} else if (optionMeta.format.includes("{0}")) {
-									valueDisplay = optionMeta.format.replace(
-										"{0}",
-										value.toString(),
-									);
-								} else {
-									valueDisplay = value.toString();
-								}
+								const isBoolean = typeof value === "boolean";
 
 								return (
 									<button
@@ -104,15 +94,32 @@ export function AuTab0Viewer() {
 										onDoubleClick={() =>
 											handleDoubleClick(categoryId, optionId)
 										}
-										className="w-full flex justify-between items-center py-1 px-2 hover:bg-gray-700/50 rounded cursor-pointer select-none"
+										className="w-full flex justify-between items-center py-1 px-2 hover:bg-gray-700/50 rounded cursor-pointer select-none gap-2"
 										title="ダブルクリックで設定場所へ移動"
 									>
-										<span className="text-xs text-gray-300">
+										<span className="text-xs text-gray-300 truncate flex-1 text-left">
 											{optionMeta.title}
 										</span>
-										<span className="text-xs text-blue-400 font-medium text-right">
-											{valueDisplay}
-										</span>
+										<div className="flex items-center gap-1 shrink-0">
+											<span className="text-xs text-blue-400 font-medium text-right">
+												{isBoolean ? (
+													<ColoredText
+														text={
+															translationMetaData.booleanTransData[
+																value ? 1 : 0
+															] || (value ? "ON" : "OFF")
+														}
+													/>
+												) : (
+													value.toString()
+												)}
+											</span>
+											{!isBoolean && (
+												<div className="text-[10px] scale-90 origin-right">
+													<OptionFormat format={optionMeta.format} />
+												</div>
+											)}
+										</div>
 									</button>
 								);
 							})}

--- a/src/feature/AuTab0Viewer.tsx
+++ b/src/feature/AuTab0Viewer.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect } from "react";
 import { Accordion } from "../components/parts/Accordion";
 import { auOptionMetaData } from "../logics/api";
 import type { AuOptionId } from "../type";
@@ -17,24 +17,23 @@ export function AuTab0Viewer() {
 	);
 	const auValue = useStore((state) => state.auValue);
 
-	// 右パネル内での各カテゴリの開閉状態（デフォルトすべて真）
-	const [localOpenedCategories, setLocalOpenedCategories] = useState<
-		Record<number, boolean>
-	>(() => {
+	const openedAuTab0CategoryIds = useStore(
+		(state) => state.openedAuTab0CategoryIds,
+	);
+	const setOpenedAuTab0CategoryIds = useStore(
+		(state) => state.setOpenedAuTab0CategoryIds,
+	);
+	const toggleAuTab0Category = useStore((state) => state.toggleAuTab0Category);
+
+	// 初期表示時に全てのカテゴリを開く
+	useEffect(() => {
+		const tab0CategoryIds = auOptionMetaData.tabCategoryMap[0] || [];
 		const initial: Record<number, boolean> = {};
-		const ids = auOptionMetaData.tabCategoryMap[0] || [];
-		for (const id of ids) {
+		for (const id of tab0CategoryIds) {
 			initial[id] = true;
 		}
-		return initial;
-	});
-
-	const toggleLocalCategory = (categoryId: number) => {
-		setLocalOpenedCategories((prev) => ({
-			...prev,
-			[categoryId]: !prev[categoryId],
-		}));
-	};
+		setOpenedAuTab0CategoryIds(initial);
+	}, [setOpenedAuTab0CategoryIds]);
 
 	// タブ0のカテゴリIDを取得
 	const tab0CategoryIds = auOptionMetaData.tabCategoryMap[0] || [];
@@ -77,8 +76,8 @@ export function AuTab0Viewer() {
 					<Accordion
 						key={categoryId}
 						title={<span className="text-sm">{categoryMeta.name}</span>}
-						isOpen={localOpenedCategories[categoryId] ?? false}
-						onToggle={() => toggleLocalCategory(categoryId)}
+						isOpen={openedAuTab0CategoryIds[categoryId] ?? false}
+						onToggle={() => toggleAuTab0Category(categoryId)}
 					>
 						<div className="flex flex-col gap-1">
 							{categoryMeta.options.map((optionId) => {

--- a/src/feature/AuTab0Viewer.tsx
+++ b/src/feature/AuTab0Viewer.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { use } from "react";
 import { Accordion } from "../components/parts/Accordion";
 import { auOptionMetaData, translationMetaData } from "../logics/api";
+import { getAllOptions } from "../logics/api.store";
 import type { AuOptionId } from "../type";
 import { useStore } from "../useStore";
 
@@ -8,6 +9,8 @@ import { useStore } from "../useStore";
  * Auのタブ0の設定内容を表示し、ダブルクリックで該当箇所へ移動するコンポーネント
  */
 export function AuTab0Viewer() {
+	use(getAllOptions());
+
 	const setSelectedTab = useStore((state) => state.setSelectedTab);
 	const setSelectedAuTabId = useStore((state) => state.setSelectedAuTabId);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
@@ -20,20 +23,7 @@ export function AuTab0Viewer() {
 	const openedAuTab0CategoryIds = useStore(
 		(state) => state.openedAuTab0CategoryIds,
 	);
-	const setOpenedAuTab0CategoryIds = useStore(
-		(state) => state.setOpenedAuTab0CategoryIds,
-	);
 	const toggleAuTab0Category = useStore((state) => state.toggleAuTab0Category);
-
-	// 初期表示時に全てのカテゴリを開く
-	useEffect(() => {
-		const tab0CategoryIds = auOptionMetaData.tabCategoryMap[0] || [];
-		const initial: Record<number, boolean> = {};
-		for (const id of tab0CategoryIds) {
-			initial[id] = true;
-		}
-		setOpenedAuTab0CategoryIds(initial);
-	}, [setOpenedAuTab0CategoryIds]);
 
 	// タブ0のカテゴリIDを取得
 	const tab0CategoryIds = auOptionMetaData.tabCategoryMap[0] || [];
@@ -76,7 +66,7 @@ export function AuTab0Viewer() {
 					<Accordion
 						key={categoryId}
 						title={<span className="text-sm">{categoryMeta.name}</span>}
-						isOpen={openedAuTab0CategoryIds[categoryId] ?? false}
+						isOpen={openedAuTab0CategoryIds[categoryId] ?? true}
 						onToggle={() => toggleAuTab0Category(categoryId)}
 					>
 						<div className="flex flex-col gap-1">
@@ -104,6 +94,7 @@ export function AuTab0Viewer() {
 									<button
 										type="button"
 										key={optionId}
+										data-testid={`right-panel-option-${optionId}`}
 										onDoubleClick={() =>
 											handleDoubleClick(categoryId, optionId)
 										}

--- a/src/feature/AuTab0Viewer.tsx
+++ b/src/feature/AuTab0Viewer.tsx
@@ -62,10 +62,98 @@ export function AuTab0Viewer() {
 
 	return (
 		<div className="flex flex-col gap-2">
-			{tab0CategoryIds.map((categoryId) => {
+			{tab0CategoryIds.map((categoryId, index) => {
 				const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
 				if (!categoryMeta) {
 					return null;
+				}
+
+				const isMapCategory = index === 0;
+
+				if (isMapCategory) {
+					const mapOptionId = categoryMeta.options[0];
+					const [_, ...otherOptionIds] = categoryMeta.options;
+					const mapOptionMeta = auOptionMetaData.options[mapOptionId];
+
+					if (!mapOptionMeta) {
+						return null;
+					}
+
+					const mapValue = mapOptionMeta.range[auValue[mapOptionId] ?? 0];
+
+					return (
+						<div
+							key={categoryId}
+							className="border border-gray-700 rounded-lg overflow-hidden mb-2"
+						>
+							<button
+								type="button"
+								data-testid={`right-panel-option-${mapOptionId}`}
+								onDoubleClick={() => handleDoubleClick(categoryId, mapOptionId)}
+								className="w-full flex items-center justify-between p-4 bg-gray-800 border-b border-gray-700 hover:bg-gray-700 transition-colors"
+							>
+								<div className="flex items-center gap-3">
+									<div className="w-5 h-5" />
+									<span className="font-semibold text-gray-200 text-sm">
+										{mapOptionMeta.title}
+									</span>
+								</div>
+								<span className="text-sm text-blue-400 font-medium">
+									{mapValue.toString()}
+								</span>
+							</button>
+							{otherOptionIds.length > 0 && (
+								<div className="p-4 bg-gray-900 space-y-1">
+									{otherOptionIds.map((optionId) => {
+										const optionMeta = auOptionMetaData.options[optionId];
+										const selection = auValue[optionId] ?? 0;
+										if (!optionMeta) {
+											return null;
+										}
+										const value = optionMeta.range[selection];
+										const isBoolean = typeof value === "boolean";
+
+										return (
+											<button
+												type="button"
+												key={optionId}
+												data-testid={`right-panel-option-${optionId}`}
+												onDoubleClick={() =>
+													handleDoubleClick(categoryId, optionId)
+												}
+												className="w-full flex justify-between items-center py-1 px-2 hover:bg-gray-700/50 rounded cursor-pointer select-none gap-2"
+												title="ダブルクリックで設定場所へ移動"
+											>
+												<span className="text-xs text-gray-300 truncate flex-1 text-left">
+													{optionMeta.title}
+												</span>
+												<div className="flex items-center gap-1 shrink-0">
+													<span className="text-xs text-blue-400 font-medium text-right">
+														{isBoolean ? (
+															<ColoredText
+																text={
+																	translationMetaData.booleanTransData[
+																		value ? 1 : 0
+																	] || (value ? "ON" : "OFF")
+																}
+															/>
+														) : (
+															value.toString()
+														)}
+													</span>
+													{!isBoolean && (
+														<div className="text-[10px] scale-90 origin-right">
+															<OptionFormat format={optionMeta.format} />
+														</div>
+													)}
+												</div>
+											</button>
+										);
+									})}
+								</div>
+							)}
+						</div>
+					);
 				}
 
 				return (

--- a/src/feature/AuTab0Viewer.tsx
+++ b/src/feature/AuTab0Viewer.tsx
@@ -12,6 +12,8 @@ export function AuTab0Viewer() {
 	use(getAllOptions());
 
 	const setSelectedTab = useStore((state) => state.setSelectedTab);
+	const setIsSidebarOpen = useStore((state) => state.setIsSidebarOpen);
+	const setRightPanelOpen = useStore((state) => state.setRightPanelOpen);
 	const setSelectedAuTabId = useStore((state) => state.setSelectedAuTabId);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
 	const openedAuCategoryIds = useStore((state) => state.openedAuCategoryIds);
@@ -29,8 +31,10 @@ export function AuTab0Viewer() {
 	const tab0CategoryIds = auOptionMetaData.tabCategoryMap[0] || [];
 
 	const handleDoubleClick = (categoryId: number, optionId: AuOptionId) => {
-		// 1. メインタブをAuに切り替え
+		// 1. メインタブをAuに切り替え、サイドバーと右パネルを閉じる
 		setSelectedTab("Au");
+		setIsSidebarOpen(false);
+		setRightPanelOpen(false);
 		// 2. Auタブを0に切り替え
 		setSelectedAuTabId(0);
 		// 3. カテゴリを確実に開く

--- a/src/feature/AuTab0Viewer.tsx
+++ b/src/feature/AuTab0Viewer.tsx
@@ -87,11 +87,13 @@ export function AuTab0Viewer() {
 									valueDisplay =
 										translationMetaData.booleanTransData[value ? 1 : 0] ||
 										(value ? "ON" : "OFF");
-								} else {
+								} else if (optionMeta.format.includes("{0}")) {
 									valueDisplay = optionMeta.format.replace(
 										"{0}",
 										value.toString(),
 									);
+								} else {
+									valueDisplay = value.toString();
 								}
 
 								return (

--- a/src/feature/MapDropDown.tsx
+++ b/src/feature/MapDropDown.tsx
@@ -21,6 +21,9 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 	const selection = useStore((state) =>
 		mapOptionId ? (state.auValue[mapOptionId] ?? 0) : 0,
 	);
+	const highlightedAuOptionId = useStore(
+		(state) => state.highlightedAuOptionId,
+	);
 
 	if (!categoryMeta || categoryMeta.options.length === 0) {
 		return null;
@@ -36,12 +39,19 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 	// 後で翻訳を適用するが、それまでは一旦 range に含まれる値をそのまま表示する
 	const displayValues = optionMeta.range.map((v) => v.toString());
 
+	const isHighlighted = mapOptionId && highlightedAuOptionId === mapOptionId;
+
 	return (
 		<div
 			className="border border-gray-700 rounded-lg overflow-hidden mb-2"
 			data-testid={`au-category-${categoryId}`}
 		>
-			<div className="flex items-center justify-between p-4 bg-gray-800 border-b border-gray-700">
+			<div
+				id={`au-option-${mapOptionId}`}
+				className={`flex items-center justify-between p-4 bg-gray-800 border-b border-gray-700 transition-all duration-500 ${
+					isHighlighted ? "ring-2 ring-blue-500 bg-blue-500/10" : ""
+				}`}
+			>
 				<div className="flex items-center gap-3">
 					{/* アコーディオンの矢印アイコンのスペースを確保して配置を揃える */}
 					<div className="w-5 h-5" />

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Accordion } from "../components/parts/Accordion";
 import { useStore } from "../useStore";
+import { AuTab0Viewer } from "./AuTab0Viewer";
 
 /**
  * 右フローティングパネルコンポーネント
@@ -81,9 +82,7 @@ export function RightFloatingPanel() {
 									isOpen={isAuSettingsOpen}
 									onToggle={toggleAuSettings}
 								>
-									<p className="text-gray-400 text-sm">
-										AmongUsの設定コンテンツ
-									</p>
+									<AuTab0Viewer />
 								</Accordion>
 								<Accordion
 									title="ExRの設定"

--- a/src/feature/RightFloatingPanel.tsx
+++ b/src/feature/RightFloatingPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { Accordion } from "../components/parts/Accordion";
 import { useStore } from "../useStore";
 import { AuTab0Viewer } from "./AuTab0Viewer";
@@ -82,7 +82,15 @@ export function RightFloatingPanel() {
 									isOpen={isAuSettingsOpen}
 									onToggle={toggleAuSettings}
 								>
-									<AuTab0Viewer />
+									<Suspense
+										fallback={
+											<div className="flex items-center justify-center p-4">
+												<div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+											</div>
+										}
+									>
+										<AuTab0Viewer />
+									</Suspense>
 								</Accordion>
 								<Accordion
 									title="ExRの設定"

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -8,11 +8,13 @@ export interface AuOptionViewerSlice {
 	selectedAuTabId: number;
 	isAuTabPending: boolean;
 	openedAuCategoryIds: Record<number, boolean>;
+	highlightedAuOptionId: AuOptionId | null;
 	auValue: Record<AuOptionId, number>; // セレクション
 	setSelectedAuTabId: (id: number) => void;
 	setIsAuTabPending: (isPending: boolean) => void;
 	setAuValue: (value: Record<AuOptionId, number>) => void;
 	setOpenedAuCategoryIds: (ids: Record<number, boolean>) => void;
+	setHighlightedAuOptionId: (id: AuOptionId | null) => void;
 	toggleAuCategory: (categoryId: number) => void;
 	updateAuOptionSelection: (...args: UpdateAuArg[]) => void;
 }
@@ -27,6 +29,7 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 		selectedAuTabId: 0,
 		isAuTabPending: false,
 		openedAuCategoryIds: {},
+		highlightedAuOptionId: null,
 		auValue: {},
 		setSelectedAuTabId: (id: number) => {
 			set({ selectedAuTabId: id });
@@ -39,6 +42,9 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 		},
 		setOpenedAuCategoryIds: (ids) => {
 			set({ openedAuCategoryIds: ids });
+		},
+		setHighlightedAuOptionId: (id) => {
+			set({ highlightedAuOptionId: id });
 		},
 		toggleAuCategory: (categoryId) => {
 			set((state) => {

--- a/src/slices/optionGroupToggleSidebarSlice.ts
+++ b/src/slices/optionGroupToggleSidebarSlice.ts
@@ -10,6 +10,7 @@ export interface OptionGroupToggleSidebarSlice {
 	selectedTab: SelectedTab;
 	isSidebarPending: boolean;
 	toggleSidebar: () => void;
+	setIsSidebarOpen: (isOpen: boolean) => void;
 	setSelectedTab: (tab: SelectedTab) => void;
 	setIsSidebarPending: (isPending: boolean) => void;
 	resetAll: () => void;
@@ -29,6 +30,9 @@ export const createOptionGroupToggleSidebarSlice: StateCreator<
 			set((state) => {
 				return { isSidebarOpen: !state.isSidebarOpen };
 			});
+		},
+		setIsSidebarOpen: (isOpen: boolean) => {
+			set({ isSidebarOpen: isOpen });
 		},
 		setSelectedTab: (tab: SelectedTab) => {
 			set({ selectedTab: tab });

--- a/src/slices/rightFloatingPanelSlice.ts
+++ b/src/slices/rightFloatingPanelSlice.ts
@@ -13,6 +13,9 @@ export interface RightFloatingPanelSlice {
 	toggleAuSettings: () => void;
 	isExrSettingsOpen: boolean;
 	toggleExrSettings: () => void;
+	openedAuTab0CategoryIds: Record<number, boolean>;
+	setOpenedAuTab0CategoryIds: (ids: Record<number, boolean>) => void;
+	toggleAuTab0Category: (categoryId: number) => void;
 }
 
 /**
@@ -47,6 +50,17 @@ export const createRightFloatingPanelSlice: StateCreator<
 		toggleExrSettings: () => {
 			set((state) => {
 				return { isExrSettingsOpen: !state.isExrSettingsOpen };
+			});
+		},
+		openedAuTab0CategoryIds: {},
+		setOpenedAuTab0CategoryIds: (ids) => {
+			set({ openedAuTab0CategoryIds: ids });
+		},
+		toggleAuTab0Category: (categoryId) => {
+			set((state) => {
+				const next = { ...state.openedAuTab0CategoryIds };
+				next[categoryId] = !next[categoryId];
+				return { openedAuTab0CategoryIds: next };
 			});
 		},
 	};

--- a/tests/AuTab0Viewer.test.tsx
+++ b/tests/AuTab0Viewer.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuTab0Viewer } from "../src/feature/AuTab0Viewer";
+import {
+	auOptionMetaData,
+	resetAuOptionMetaData,
+	translationMetaData,
+} from "../src/logics/api";
+import type { AuOptionId } from "../src/type";
+import { useStore } from "../src/useStore";
+
+describe("AuTab0Viewer", () => {
+	beforeEach(() => {
+		resetAuOptionMetaData();
+		useStore.getState().resetAll();
+		useStore.getState().resetViewer();
+		// 翻訳データの初期化
+		translationMetaData.booleanTransData = ["OFF", "ON"];
+	});
+
+	it("renders Tab 0 categories and options", () => {
+		const optionId = 100 as unknown as AuOptionId;
+		auOptionMetaData.tabCategoryMap = { 0: [1], 1: [], 2: [] };
+		auOptionMetaData.categoryMetaData = {
+			1: { name: "Game Settings", options: [optionId] },
+		};
+		auOptionMetaData.options[optionId] = {
+			title: "Map",
+			format: "{0}",
+			range: ["The Skeld", "Mira HQ"],
+		};
+		useStore.getState().setAuValue({ [optionId]: 0 });
+
+		render(<AuTab0Viewer />);
+
+		expect(screen.getByText("Game Settings")).toBeInTheDocument();
+		expect(screen.getByText("Map")).toBeInTheDocument();
+		expect(screen.getByText("The Skeld")).toBeInTheDocument();
+	});
+
+	it("uses translation data for boolean values", () => {
+		const boolOptionId = 101 as unknown as AuOptionId;
+		auOptionMetaData.tabCategoryMap = { 0: [1] };
+		auOptionMetaData.categoryMetaData = {
+			1: { name: "Settings", options: [boolOptionId] },
+		};
+		auOptionMetaData.options[boolOptionId] = {
+			title: "Anonymous Voting",
+			format: "{0}",
+			range: [false, true],
+		};
+
+		// 翻訳テキストを設定
+		translationMetaData.booleanTransData = ["無効", "有効"];
+		useStore.getState().setAuValue({ [boolOptionId]: 1 });
+
+		render(<AuTab0Viewer />);
+
+		expect(screen.getByText("有効")).toBeInTheDocument();
+	});
+
+	it("calls store actions and scroll on double click", async () => {
+		const optionId = 100 as unknown as AuOptionId;
+		auOptionMetaData.tabCategoryMap = { 0: [1] };
+		auOptionMetaData.categoryMetaData = {
+			1: { name: "Game Settings", options: [optionId] },
+		};
+		auOptionMetaData.options[optionId] = {
+			title: "Map",
+			format: "{0}",
+			range: ["The Skeld"],
+		};
+
+		const setSelectedTabSpy = vi.spyOn(useStore.getState(), "setSelectedTab");
+		const setSelectedAuTabIdSpy = vi.spyOn(
+			useStore.getState(),
+			"setSelectedAuTabId",
+		);
+		const setHighlightedAuOptionIdSpy = vi.spyOn(
+			useStore.getState(),
+			"setHighlightedAuOptionId",
+		);
+
+		// scrollIntoView のモック
+		const scrollIntoViewMock = vi.fn();
+		window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+		// getElementById のモック
+		const mockElement = document.createElement("div");
+		mockElement.id = `au-option-${optionId}`;
+		vi.spyOn(document, "getElementById").mockReturnValue(mockElement);
+
+		render(<AuTab0Viewer />);
+
+		const row = screen.getByText("Map").closest("button");
+		if (!row) throw new Error("Row not found");
+
+		fireEvent.doubleClick(row);
+
+		expect(setSelectedTabSpy).toHaveBeenCalledWith("Au");
+		expect(setSelectedAuTabIdSpy).toHaveBeenCalledWith(0);
+		expect(setHighlightedAuOptionIdSpy).toHaveBeenCalledWith(optionId);
+
+		// setTimeout の処理待ち
+		await vi.waitFor(
+			() => {
+				expect(scrollIntoViewMock).toHaveBeenCalled();
+			},
+			{ timeout: 500 },
+		);
+	});
+});

--- a/tests/AuTab0Viewer.test.tsx
+++ b/tests/AuTab0Viewer.test.tsx
@@ -31,6 +31,12 @@ describe("AuTab0Viewer", () => {
 						Info: { ValueType: 2, OptionName: 1 },
 						Range: ["The Skeld", "Mira HQ"],
 					},
+					{
+						TranslatedTitle: "Anonymous Voting",
+						TranslatedFormat: "{0}",
+						Value: true,
+						Info: { ValueType: 0, OptionName: 2 },
+					},
 				],
 			},
 		];
@@ -60,7 +66,10 @@ describe("AuTab0Viewer", () => {
 				if (url.includes("/au/translation/batch/")) {
 					return Promise.resolve({
 						ok: true,
-						json: vi.fn().mockResolvedValue([]),
+						json: vi.fn().mockResolvedValue([
+							{ Key: "optionOff", Result: "OFF", Param: [] },
+							{ Key: "optionOn", Result: "ON", Param: [] },
+						]),
 					} as unknown as Response);
 				}
 				return Promise.reject(new Error(`Unhandled URL: ${url}`));
@@ -91,22 +100,14 @@ describe("AuTab0Viewer", () => {
 			);
 		});
 
-		expect(screen.getByText("Game Settings")).toBeInTheDocument();
+		// マップカテゴリ（index 0）はカテゴリ名ではなくオプション名が表示される
 		expect(screen.getByText("Map")).toBeInTheDocument();
 		expect(screen.getByText("The Skeld")).toBeInTheDocument();
 	});
 
 	it("uses translation data for boolean values", async () => {
-		const boolOptionId = 101 as unknown as AuOptionId;
-		auOptionMetaData.tabCategoryMap = { 0: [1] };
-		auOptionMetaData.categoryMetaData = {
-			1: { name: "Settings", options: [boolOptionId] },
-		};
-		auOptionMetaData.options[boolOptionId] = {
-			title: "Anonymous Voting",
-			format: "{0}",
-			range: [false, true],
-		};
+		// mockAuData の 2番目のオプション (Anonymous Voting, ValueType 0) を使用
+		const boolOptionId = auOptionMetaData.categoryMetaData[0].options[1];
 
 		// 翻訳テキストを設定
 		translationMetaData.booleanTransData = ["無効", "有効"];
@@ -120,6 +121,7 @@ describe("AuTab0Viewer", () => {
 			);
 		});
 
+		// Boolean値はColoredText経由で表示される
 		expect(screen.getByText("有効")).toBeInTheDocument();
 	});
 

--- a/tests/AuTab0Viewer.test.tsx
+++ b/tests/AuTab0Viewer.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Suspense } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuTab0Viewer } from "../src/feature/AuTab0Viewer";
 import {
@@ -6,19 +7,70 @@ import {
 	resetAuOptionMetaData,
 	translationMetaData,
 } from "../src/logics/api";
-import type { AuOptionId } from "../src/type";
+import { getAllOptions, resetApiCache } from "../src/logics/api.store";
+import type { AuOptionCategoryDto, AuOptionId } from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("AuTab0Viewer", () => {
-	beforeEach(() => {
+	beforeEach(async () => {
+		resetApiCache();
 		resetAuOptionMetaData();
 		useStore.getState().resetAll();
 		useStore.getState().resetViewer();
 		// 翻訳データの初期化
 		translationMetaData.booleanTransData = ["OFF", "ON"];
+
+		const mockAuData: AuOptionCategoryDto[] = [
+			{
+				TranslatedTitle: "Game Settings",
+				Options: [
+					{
+						TranslatedTitle: "Map",
+						TranslatedFormat: "{0}",
+						Value: 0,
+						Info: { ValueType: 2, OptionName: 1 },
+						Range: ["The Skeld", "Mira HQ"],
+					},
+				],
+			},
+		];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((input: RequestInfo | URL) => {
+				const url = typeof input === "string" ? input : input.toString();
+				if (url.includes("/au/option/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue(mockAuData),
+					} as unknown as Response);
+				}
+				if (url.includes("/exr/option/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue([]),
+					} as unknown as Response);
+				}
+				if (url.includes("/au/translation/batch/optionunit/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue([]),
+					} as unknown as Response);
+				}
+				if (url.includes("/au/translation/batch/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue([]),
+					} as unknown as Response);
+				}
+				return Promise.reject(new Error(`Unhandled URL: ${url}`));
+			}),
+		);
+
+		await getAllOptions();
 	});
 
-	it("renders Tab 0 categories and options", () => {
+	it("renders Tab 0 categories and options", async () => {
 		const optionId = 100 as unknown as AuOptionId;
 		auOptionMetaData.tabCategoryMap = { 0: [1], 1: [], 2: [] };
 		auOptionMetaData.categoryMetaData = {
@@ -31,14 +83,20 @@ describe("AuTab0Viewer", () => {
 		};
 		useStore.getState().setAuValue({ [optionId]: 0 });
 
-		render(<AuTab0Viewer />);
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<AuTab0Viewer />
+				</Suspense>,
+			);
+		});
 
 		expect(screen.getByText("Game Settings")).toBeInTheDocument();
 		expect(screen.getByText("Map")).toBeInTheDocument();
 		expect(screen.getByText("The Skeld")).toBeInTheDocument();
 	});
 
-	it("uses translation data for boolean values", () => {
+	it("uses translation data for boolean values", async () => {
 		const boolOptionId = 101 as unknown as AuOptionId;
 		auOptionMetaData.tabCategoryMap = { 0: [1] };
 		auOptionMetaData.categoryMetaData = {
@@ -54,22 +112,19 @@ describe("AuTab0Viewer", () => {
 		translationMetaData.booleanTransData = ["無効", "有効"];
 		useStore.getState().setAuValue({ [boolOptionId]: 1 });
 
-		render(<AuTab0Viewer />);
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<AuTab0Viewer />
+				</Suspense>,
+			);
+		});
 
 		expect(screen.getByText("有効")).toBeInTheDocument();
 	});
 
 	it("calls store actions and scroll on double click", async () => {
-		const optionId = 100 as unknown as AuOptionId;
-		auOptionMetaData.tabCategoryMap = { 0: [1] };
-		auOptionMetaData.categoryMetaData = {
-			1: { name: "Game Settings", options: [optionId] },
-		};
-		auOptionMetaData.options[optionId] = {
-			title: "Map",
-			format: "{0}",
-			range: ["The Skeld"],
-		};
+		const optionId = auOptionMetaData.categoryMetaData[0].options[0];
 
 		const setSelectedTabSpy = vi.spyOn(useStore.getState(), "setSelectedTab");
 		const setSelectedAuTabIdSpy = vi.spyOn(
@@ -90,7 +145,13 @@ describe("AuTab0Viewer", () => {
 		mockElement.id = `au-option-${optionId}`;
 		vi.spyOn(document, "getElementById").mockReturnValue(mockElement);
 
-		render(<AuTab0Viewer />);
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<AuTab0Viewer />
+				</Suspense>,
+			);
+		});
 
 		const row = screen.getByText("Map").closest("button");
 		if (!row) throw new Error("Row not found");

--- a/tests/RightFloatingPanel.test.tsx
+++ b/tests/RightFloatingPanel.test.tsx
@@ -1,12 +1,32 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { describe, expect, it, vi } from "vitest";
 import { RightFloatingPanel } from "../src/feature/RightFloatingPanel";
+import { getAllOptions, resetApiCache } from "../src/logics/api.store";
 import { useStore } from "../src/useStore";
 
 describe("RightFloatingPanel Component", () => {
-	it("renders panel elements correctly", () => {
+	it("renders panel elements correctly", async () => {
+		resetApiCache();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((_input: RequestInfo | URL) => {
+				return Promise.resolve({
+					ok: true,
+					json: vi.fn().mockResolvedValue([]),
+				} as unknown as Response);
+			}),
+		);
+		await getAllOptions();
+
 		useStore.setState({ isRightPanelOpen: true });
-		render(<RightFloatingPanel />);
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<RightFloatingPanel />
+				</Suspense>,
+			);
+		});
 
 		expect(screen.getByText("Right Panel")).toBeInTheDocument();
 		expect(screen.getByText("設定値")).toBeInTheDocument();
@@ -14,9 +34,27 @@ describe("RightFloatingPanel Component", () => {
 		expect(screen.getByText("ExRの設定")).toBeInTheDocument();
 	});
 
-	it("toggles panel visibility when toggle button is clicked", () => {
+	it("toggles panel visibility when toggle button is clicked", async () => {
+		resetApiCache();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((_input: RequestInfo | URL) => {
+				return Promise.resolve({
+					ok: true,
+					json: vi.fn().mockResolvedValue([]),
+				} as unknown as Response);
+			}),
+		);
+		await getAllOptions();
+
 		useStore.setState({ isRightPanelOpen: false });
-		render(<RightFloatingPanel />);
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<RightFloatingPanel />
+				</Suspense>,
+			);
+		});
 
 		const toggleButton = screen.getByLabelText("パネルを開く");
 		fireEvent.click(toggleButton);
@@ -24,13 +62,31 @@ describe("RightFloatingPanel Component", () => {
 		expect(useStore.getState().isRightPanelOpen).toBe(true);
 	});
 
-	it("toggles accordions when clicked", () => {
+	it("toggles accordions when clicked", async () => {
+		resetApiCache();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((_input: RequestInfo | URL) => {
+				return Promise.resolve({
+					ok: true,
+					json: vi.fn().mockResolvedValue([]),
+				} as unknown as Response);
+			}),
+		);
+		await getAllOptions();
+
 		useStore.setState({
 			isRightPanelOpen: true,
 			isSettingsOpen: true,
 			isAuSettingsOpen: true,
 		});
-		render(<RightFloatingPanel />);
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<RightFloatingPanel />
+				</Suspense>,
+			);
+		});
 
 		const auSettingsButton = screen.getByRole("button", {
 			name: /AmongUsの設定/i,
@@ -40,9 +96,27 @@ describe("RightFloatingPanel Component", () => {
 		expect(useStore.getState().isAuSettingsOpen).toBe(false);
 	});
 
-	it("closes panel when Escape key is pressed", () => {
+	it("closes panel when Escape key is pressed", async () => {
+		resetApiCache();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((_input: RequestInfo | URL) => {
+				return Promise.resolve({
+					ok: true,
+					json: vi.fn().mockResolvedValue([]),
+				} as unknown as Response);
+			}),
+		);
+		await getAllOptions();
+
 		useStore.setState({ isRightPanelOpen: true });
-		render(<RightFloatingPanel />);
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<RightFloatingPanel />
+				</Suspense>,
+			);
+		});
 
 		fireEvent.keyDown(window, { key: "Escape" });
 


### PR DESCRIPTION
AmongUsの設定のうち、タブ0の内容を右側のフローティングパネルにアコーディオン形式で表示するようにしました。
各項目をダブルクリックすると、メインエディタ側で該当するタブ（Auタブ0）に切り替わり、該当するカテゴリが展開され、その項目までスクロールして青い縁取りでハイライトされます。
右パネル内では設定値は読み取り専用として表示されます。

---
*PR created automatically by Jules for task [12660073185859049955](https://jules.google.com/task/12660073185859049955) started by @yukieiji*