### PR TITLE
e2eテスト(auTab0Navigation)の不具合修正

### DIFF
--- a/e2e/auTab0Navigation.spec.ts
+++ b/e2e/auTab0Navigation.spec.ts
@@ -33,11 +33,10 @@ test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 		// 右パネル内のアコーディオンを指定する
 		const imposterCategory = page
 			.getByLabel("右フローティングパネル")
-			.getByRole("button", { name: "インポスター", exact: true });
-		if (
-			(await imposterCategory.isVisible()) &&
-			(await imposterCategory.getAttribute("aria-expanded")) === "false"
-		) {
+			.getByRole("button", {
+				name: /Collapse インポスター|Expand インポスター/,
+			});
+		if ((await imposterCategory.getAttribute("aria-expanded")) === "false") {
 			await imposterCategory.click();
 		}
 

--- a/e2e/auTab0Navigation.spec.ts
+++ b/e2e/auTab0Navigation.spec.ts
@@ -29,6 +29,18 @@ test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 		}
 
 		// 3. Tab 0の内容が表示されていることを確認 (インポスター数 = right-panel-option-10200)
+		// インポスターカテゴリを展開する必要がある
+		// 右パネル内のアコーディオンを指定する
+		const imposterCategory = page
+			.getByLabel("右フローティングパネル")
+			.getByRole("button", { name: "インポスター", exact: true });
+		if (
+			(await imposterCategory.isVisible()) &&
+			(await imposterCategory.getAttribute("aria-expanded")) === "false"
+		) {
+			await imposterCategory.click();
+		}
+
 		const impCountSetting = page.getByTestId("right-panel-option-10200");
 		// スクロールが必要な場合がある
 		await impCountSetting.scrollIntoViewIfNeeded();

--- a/src/feature/rightsidepanel/AuTab0Viewer.tsx
+++ b/src/feature/rightsidepanel/AuTab0Viewer.tsx
@@ -1,4 +1,6 @@
+import { use } from "react";
 import { auOptionMetaData } from "../../logics/api";
+import { getAllOptions } from "../../logics/api.store";
 import { AuTab0GeneralCategory } from "./AuTab0GeneralCategory";
 import { AuTab0MapCategory } from "./AuTab0MapCategory";
 
@@ -6,6 +8,7 @@ import { AuTab0MapCategory } from "./AuTab0MapCategory";
  * Auのタブ0の設定内容を表示し、ダブルクリックで該当箇所へ移動するコンポーネント
  */
 export function AuTab0Viewer() {
+	use(getAllOptions());
 	const tab0CategoryIds = auOptionMetaData.tabCategoryMap[0] || [];
 
 	return (


### PR DESCRIPTION
e2eテスト `auTab0Navigation.spec.ts` がタイムアウトで失敗していた問題を修正しました。

原因:
1. 右パネルのコンポーネント `AuTab0Viewer` が、非同期でのデータ取得完了を待たずにレンダリングされていたため、初回レンダリング時に項目が表示されず、Playwrightが要素を見つけられませんでした。
2. 右パネル内の「インポスター」カテゴリのアコーディオンが閉じている場合があり、中の要素にアクセスできませんでした。

修正内容:
- `src/feature/rightsidepanel/AuTab0Viewer.tsx`: React 19の `use()` フックを使用して、メタデータのロードが完了するまでサスペンドするように修正しました。
- `e2e/auTab0Navigation.spec.ts`: 要素を操作する前に、右パネル内の対象アコーディオンを展開する処理を追加しました。

検証内容:
- `pnpm run check` (Biome) をパス
- `pnpm run test` (Vitest) をパス
- `pnpm run e2e` (Playwright) において、 `e2e/auTab0Navigation.spec.ts` がパスすることを確認
- フロントエンドの動作確認として、実際に右パネルからダブルクリックでナビゲーションとハイライトが行われることを確認しました。

---
*PR created automatically by Jules for task [3480883000721690227](https://jules.google.com/task/3480883000721690227) started by @yukieiji*