### PR TITLE
右サイドバーのAmongUsデータ初期表示の修正

### DIFF
--- a/src/feature/rightsidepanel/AuTab0Viewer.tsx
+++ b/src/feature/rightsidepanel/AuTab0Viewer.tsx
@@ -1,6 +1,7 @@
 import { use } from "react";
 import { auOptionMetaData } from "../../logics/api";
 import { getAllOptions } from "../../logics/api.store";
+import { useStore } from "../../useStore";
 import { AuTab0GeneralCategory } from "./AuTab0GeneralCategory";
 import { AuTab0MapCategory } from "./AuTab0MapCategory";
 
@@ -9,6 +10,10 @@ import { AuTab0MapCategory } from "./AuTab0MapCategory";
  */
 export function AuTab0Viewer() {
 	use(getAllOptions());
+	// auValueを購読することで、データがロードされた際に再レンダリングを走らせる
+	useStore((state) => {
+		return state.auValue;
+	});
 	const tab0CategoryIds = auOptionMetaData.tabCategoryMap[0] || [];
 
 	return (


### PR DESCRIPTION
右サイドバーの「AmongUsの設定」アコーディオンを開いた際、初回のみ中身が空になり、一度閉じてから再度開かないと表示されない問題を修正しました。

原因は `AuTab0Viewer` コンポーネントがグローバルなデータ（`auOptionMetaData`）に依存しているにも関わらず、Store（`auValue`）の更新を購読していなかったため、データのロード完了時に再レンダリングが走らなかったことにあります。

修正内容：
1. `AuTab0Viewer` に `useStore` による `auValue` の購読を追加しました。
2. `RightFloatingPanel` において、パネルが閉じている間はコンテンツをレンダリングしないように変更し、開いた際に最新の状態でマウントされるようにしました。

E2Eテストおよびフロントエンドの目視確認により、初期状態でサイドバーを開いた際に正しくデータが表示されることを確認済みです。

---
*PR created automatically by Jules for task [16062243266666564061](https://jules.google.com/task/16062243266666564061) started by @yukieiji*