### PR TITLE
ExROptionRecursiveItem・ExRPairedOptionItemのユニットテスト実装

### DIFF
--- a/src/components/blocks/OptionSingleSlider.tsx
+++ b/src/components/blocks/OptionSingleSlider.tsx
@@ -56,6 +56,7 @@ export function OptionSingleSlider({
 				value={selection}
 				onChange={handleSliderChange}
 				disabled={disabled}
+				aria-label={label}
 				className="w-full h-1.5 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
 			/>
 		</div>

--- a/tests/ExROptionRecursiveItem.test.tsx
+++ b/tests/ExROptionRecursiveItem.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ExROptionRecursiveItem } from "../src/feature/exr/ExROptionRecursiveItem";
+import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import { getUniqueOptionId } from "../src/logics/optionUtils";
+import { useStore } from "../src/useStore";
+
+describe("ExROptionRecursiveItem", () => {
+	const parentUniqueId = getUniqueOptionId(1, 1, 1);
+	const childUniqueId = getUniqueOptionId(1, 1, 2);
+
+	beforeEach(() => {
+		resetExrOptionMetaData();
+		useStore.getState().resetViewer();
+
+		// Setup metadata
+		exrOptionMetaData.options[parentUniqueId] = {
+			metaData: {
+				translatedName: "Parent Option",
+				format: "{0}",
+				type: "Int32",
+			},
+			childOptionIds: [childUniqueId],
+		};
+		exrOptionMetaData.options[childUniqueId] = {
+			metaData: {
+				translatedName: "Child Option",
+				format: "{0}",
+				type: "Int32",
+			},
+			childOptionIds: [],
+		};
+
+		// Setup store state
+		useStore.getState().setExROptions(
+			{
+				[parentUniqueId]: { selection: 1, values: [0, 1] },
+				[childUniqueId]: { selection: 0, values: [0, 1] },
+			},
+			{
+				[parentUniqueId]: true,
+				[childUniqueId]: true,
+			},
+		);
+	});
+
+	it("renders parent option and toggles child options", () => {
+		render(
+			<ExROptionRecursiveItem uniqueOptionId={parentUniqueId} depth={0} />,
+		);
+
+		// Parent should be visible
+		expect(screen.getByText("Parent Option")).toBeInTheDocument();
+
+		// Child should NOT be visible initially (accordion closed)
+		expect(screen.queryByText("Child Option")).not.toBeInTheDocument();
+
+		// Click the parent to toggle
+		const toggleButton = screen.getByRole("button", { name: "開く" });
+		fireEvent.click(toggleButton);
+
+		// Child should be visible now
+		expect(screen.getByText("Child Option")).toBeInTheDocument();
+
+		// Click again to close
+		fireEvent.click(toggleButton);
+		expect(screen.queryByText("Child Option")).not.toBeInTheDocument();
+	});
+
+	it("reflects store's opened state", () => {
+		// Manually open in store
+		useStore.getState().toggleExROption(parentUniqueId);
+
+		render(
+			<ExROptionRecursiveItem uniqueOptionId={parentUniqueId} depth={0} />,
+		);
+
+		// Child should be visible immediately
+		expect(screen.getByText("Child Option")).toBeInTheDocument();
+	});
+});

--- a/tests/ExRPairedOptionItem.test.tsx
+++ b/tests/ExRPairedOptionItem.test.tsx
@@ -75,8 +75,8 @@ describe("ExRPairedOptionItem", () => {
 		// 2nd index of [0,1,2,3,4,5] is 2, formatted as "2s"
 		// 4th index is 4, formatted as "4s"
 		// Both text input and range input have the same value, so we use getAllByDisplayValue
-		expect(screen.getAllByDisplayValue("2").length).toBeGreaterThan(0);
-		expect(screen.getAllByDisplayValue("4").length).toBeGreaterThan(0);
+		expect(screen.getAllByDisplayValue("2")).toHaveLength(2);
+		expect(screen.getAllByDisplayValue("4")).toHaveLength(2);
 	});
 
 	it("calls updateExROptionSelection when min value changes", async () => {

--- a/tests/ExRPairedOptionItem.test.tsx
+++ b/tests/ExRPairedOptionItem.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExRPairedOptionItem } from "../src/feature/exr/ExRPairedOptionItem";
+import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import * as apiStore from "../src/logics/api.store";
+import { getUniqueOptionId } from "../src/logics/optionUtils";
+import { useStore } from "../src/useStore";
+
+describe("ExRPairedOptionItem", () => {
+	const minUniqueId = getUniqueOptionId(1, 1, 10);
+	const maxUniqueId = getUniqueOptionId(1, 1, 11);
+
+	const minData = {
+		uniqueOptionId: minUniqueId,
+		metaData: {
+			translatedName: "Test 最小",
+			format: "{0}s",
+			type: "Int32",
+		},
+		label: "最小",
+	};
+
+	const maxData = {
+		uniqueOptionId: maxUniqueId,
+		metaData: {
+			translatedName: "Test 最大",
+			format: "{0}s",
+			type: "Int32",
+		},
+		label: "最大",
+	};
+
+	beforeEach(() => {
+		resetExrOptionMetaData();
+		useStore.getState().resetViewer();
+
+		// Setup metadata
+		exrOptionMetaData.options[minUniqueId] = {
+			metaData: minData.metaData,
+			childOptionIds: [],
+		};
+		exrOptionMetaData.options[maxUniqueId] = {
+			metaData: maxData.metaData,
+			childOptionIds: [],
+		};
+
+		// Setup store state
+		useStore.getState().setExROptions(
+			{
+				[minUniqueId]: { selection: 2, values: [0, 1, 2, 3, 4, 5] },
+				[maxUniqueId]: { selection: 4, values: [0, 1, 2, 3, 4, 5] },
+			},
+			{
+				[minUniqueId]: true,
+				[maxUniqueId]: true,
+			},
+		);
+	});
+
+	it("renders base name and current values", () => {
+		render(
+			<ExRPairedOptionItem
+				baseName="Test"
+				minData={minData}
+				maxData={maxData}
+			/>,
+		);
+
+		expect(screen.getByText("Test")).toBeInTheDocument();
+		// In OptionPairedSliderControl, it might render labels and values
+		expect(screen.getByText("最小")).toBeInTheDocument();
+		expect(screen.getByText("最大")).toBeInTheDocument();
+
+		// Check if current values (formatted) are displayed
+		// 2nd index of [0,1,2,3,4,5] is 2, formatted as "2s"
+		// 4th index is 4, formatted as "4s"
+		// Both text input and range input have the same value, so we use getAllByDisplayValue
+		expect(screen.getAllByDisplayValue("2").length).toBeGreaterThan(0);
+		expect(screen.getAllByDisplayValue("4").length).toBeGreaterThan(0);
+	});
+
+	it("calls updateExROptionSelection when min value changes", async () => {
+		const updateMock = vi.fn();
+		vi.spyOn(apiStore, "useUpdateExROptionSelection").mockReturnValue(
+			updateMock,
+		);
+
+		render(
+			<ExRPairedOptionItem
+				baseName="Test"
+				minData={minData}
+				maxData={maxData}
+			/>,
+		);
+
+		// Find the min slider. In OptionPairedSliderControl, there are two ranges.
+		const sliders = screen.getAllByRole("slider");
+		const minSlider = sliders[0];
+
+		fireEvent.change(minSlider, { target: { value: "3" } });
+
+		expect(updateMock).toHaveBeenCalledWith({
+			uniqueOptionId: minUniqueId,
+			selection: 3,
+		});
+	});
+
+	it("calls updateExROptionSelection when max value changes", async () => {
+		const updateMock = vi.fn();
+		vi.spyOn(apiStore, "useUpdateExROptionSelection").mockReturnValue(
+			updateMock,
+		);
+
+		render(
+			<ExRPairedOptionItem
+				baseName="Test"
+				minData={minData}
+				maxData={maxData}
+			/>,
+		);
+
+		const sliders = screen.getAllByRole("slider");
+		const maxSlider = sliders[1];
+
+		fireEvent.change(maxSlider, { target: { value: "5" } });
+
+		expect(updateMock).toHaveBeenCalledWith({
+			uniqueOptionId: maxUniqueId,
+			selection: 5,
+		});
+	});
+});

--- a/tests/ExRPairedOptionItem.test.tsx
+++ b/tests/ExRPairedOptionItem.test.tsx
@@ -93,9 +93,8 @@ describe("ExRPairedOptionItem", () => {
 			/>,
 		);
 
-		// Find the min slider. In OptionPairedSliderControl, there are two ranges.
-		const sliders = screen.getAllByRole("slider");
-		const minSlider = sliders[0];
+		// Find the min slider by its label
+		const minSlider = screen.getByRole("slider", { name: "最小" });
 
 		fireEvent.change(minSlider, { target: { value: "3" } });
 
@@ -119,8 +118,8 @@ describe("ExRPairedOptionItem", () => {
 			/>,
 		);
 
-		const sliders = screen.getAllByRole("slider");
-		const maxSlider = sliders[1];
+		// Find the max slider by its label
+		const maxSlider = screen.getByRole("slider", { name: "最大" });
 
 		fireEvent.change(maxSlider, { target: { value: "5" } });
 

--- a/tests/OptionPairedSliderControl.test.tsx
+++ b/tests/OptionPairedSliderControl.test.tsx
@@ -48,7 +48,7 @@ describe("OptionPairedSliderControl", () => {
 			/>,
 		);
 
-		const minSlider = screen.getAllByRole("slider")[0];
+		const minSlider = screen.getByRole("slider", { name: "Min" });
 		// Move min to index 4 (value 20), which is greater than max (index 3, value 15)
 		fireEvent.change(minSlider, { target: { value: "4" } });
 
@@ -71,7 +71,7 @@ describe("OptionPairedSliderControl", () => {
 			/>,
 		);
 
-		const maxSlider = screen.getAllByRole("slider")[1];
+		const maxSlider = screen.getByRole("slider", { name: "Max" });
 		// Move max to index 0 (value 0), which is less than min (index 1, value 5)
 		fireEvent.change(maxSlider, { target: { value: "0" } });
 


### PR DESCRIPTION
ExROptionRecursiveItem.tsx および ExRPairedOptionItem.tsx のユニットテストを実装しました。

### 変更内容
- `tests/ExROptionRecursiveItem.test.tsx`:
    - アコーディオン形式のオプションが正しくレンダリングされることを確認。
    - アコーディオンの開閉（「開く」ボタンのクリック）により子要素が表示・非表示になることをテスト。
    - ストアの状態（`openedExROptionIds`）がレンダリングに反映されることをテスト。
- `tests/ExRPairedOptionItem.test.tsx`:
    - 最小・最大値のペアオプションが正しく表示されることを確認。
    - スライダーの操作により `useUpdateExROptionSelection` が正しい引数で呼び出されることをテスト。
- 全体的なテストの実行（146件すべてパス）および biome によるフォーマット適用。

### 検証結果
- `pnpm run check`: パス
- `pnpm run test`: パス (146 passed)
- `pnpm run e2e`: flakiness はあったものの、再実行によりパスすることを確認。

---
*PR created automatically by Jules for task [7583138679378292353](https://jules.google.com/task/7583138679378292353) started by @yukieiji*