### PR TITLE
Among Us役職カテゴリのハイライト修正とリファクタリング

### DIFF
--- a/src/components/parts/HighlightWrapper.tsx
+++ b/src/components/parts/HighlightWrapper.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+interface HighlightWrapperProps {
+	isHighlighted: boolean;
+	children: ReactNode;
+	id?: string;
+	className?: string;
+	"data-testid"?: string;
+}
+
+/**
+ * ハイライト状態を表示するためのラッパーコンポーネント
+ */
+export function HighlightWrapper({
+	isHighlighted,
+	children,
+	id,
+	className = "",
+	"data-testid": testId,
+}: HighlightWrapperProps) {
+	return (
+		<div
+			id={id}
+			data-testid={testId}
+			className={`transition-all duration-500 rounded ${
+				isHighlighted ? "ring-2 ring-blue-500 bg-blue-500/10" : ""
+			} ${className}`}
+		>
+			{children}
+		</div>
+	);
+}

--- a/src/feature/amongus/AuOptionRow.tsx
+++ b/src/feature/amongus/AuOptionRow.tsx
@@ -1,3 +1,4 @@
+import { HighlightWrapper } from "../../components/parts/HighlightWrapper";
 import { auOptionMetaData } from "../../logics/api";
 import { useUpdateAuOptionSelection } from "../../logics/api.store";
 import type { AuOptionId } from "../../type";
@@ -27,11 +28,10 @@ export function AuOptionRow({ auOptionId }: AuOptionRowProps) {
 	const isHighlighted = highlightedAuOptionId === auOptionId;
 
 	return (
-		<div
+		<HighlightWrapper
 			id={`au-option-${auOptionId}`}
-			className={`flex items-center justify-between py-2 border-b border-gray-800 last:border-0 hover:bg-gray-800/50 transition-all duration-500 px-2 rounded ${
-				isHighlighted ? "ring-2 ring-blue-500 bg-blue-500/10" : ""
-			}`}
+			isHighlighted={isHighlighted}
+			className="flex items-center justify-between py-2 border-b border-gray-800 last:border-0 hover:bg-gray-800/50 px-2"
 		>
 			<div className="flex flex-col flex-1 min-w-0 mr-4">
 				<span className="text-gray-200 text-sm font-medium truncate">
@@ -47,6 +47,6 @@ export function AuOptionRow({ auOptionId }: AuOptionRowProps) {
 					}}
 				/>
 			</div>
-		</div>
+		</HighlightWrapper>
 	);
 }

--- a/src/feature/amongus/AuRoleCategoryItem.tsx
+++ b/src/feature/amongus/AuRoleCategoryItem.tsx
@@ -1,4 +1,5 @@
 import { RoleCategoryAccordion } from "../../components/blocks/RoleCategoryAccordion";
+import { HighlightWrapper } from "../../components/parts/HighlightWrapper";
 import { auOptionMetaData } from "../../logics/api";
 import { useStore } from "../../useStore";
 import { AuCategoryOptionList } from "./AuCategoryOptionList";
@@ -17,6 +18,7 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 	);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
 	const auValue = useStore((state) => state.auValue);
+	const highlightedAuOptionId = useStore((state) => state.highlightedAuOptionId);
 
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
 	if (!categoryMeta) {
@@ -37,15 +39,30 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 	// 残りのオプション
 	const otherOptionIds = categoryMeta.options.slice(2);
 
+	const isHighlighted =
+		highlightedAuOptionId !== null &&
+		categoryMeta.options.includes(highlightedAuOptionId);
+
 	return (
-		<RoleCategoryAccordion
-			isOpen={isOpen}
-			onClick={() => toggleAuCategory(categoryId)}
-			text={categoryMeta.name}
-			spawnControl={<AuRoleSpawnControls categoryId={categoryId} />}
-			disable={isChanceZero}
+		<HighlightWrapper
+			isHighlighted={isHighlighted}
+			id={
+				highlightedAuOptionId === chanceOptionId ||
+				highlightedAuOptionId === categoryMeta.options[1]
+					? `au-option-${highlightedAuOptionId}`
+					: undefined
+			}
+			className="mb-2"
 		>
-			<AuCategoryOptionList optionIds={otherOptionIds} />
-		</RoleCategoryAccordion>
+			<RoleCategoryAccordion
+				isOpen={isOpen}
+				onClick={() => toggleAuCategory(categoryId)}
+				text={categoryMeta.name}
+				spawnControl={<AuRoleSpawnControls categoryId={categoryId} />}
+				disable={isChanceZero}
+			>
+				<AuCategoryOptionList optionIds={otherOptionIds} />
+			</RoleCategoryAccordion>
+		</HighlightWrapper>
 	);
 }

--- a/src/feature/amongus/AuRoleCategoryItem.tsx
+++ b/src/feature/amongus/AuRoleCategoryItem.tsx
@@ -29,6 +29,7 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 
 	// 各カテゴリの最初(0)がChance、次(1)がMaxCount
 	const chanceOptionId = categoryMeta.options[0];
+	const maxCountOptionId = categoryMeta.options[1];
 	const chanceValueIndex = auValue[chanceOptionId] ?? 0;
 	const chanceOptionMeta = auOptionMetaData.options[chanceOptionId];
 
@@ -50,7 +51,7 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 			isHighlighted={isHighlighted}
 			id={
 				highlightedAuOptionId === chanceOptionId ||
-				highlightedAuOptionId === categoryMeta.options[1]
+				highlightedAuOptionId === maxCountOptionId
 					? `au-option-${highlightedAuOptionId}`
 					: undefined
 			}

--- a/src/feature/amongus/AuRoleCategoryItem.tsx
+++ b/src/feature/amongus/AuRoleCategoryItem.tsx
@@ -18,7 +18,9 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 	);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
 	const auValue = useStore((state) => state.auValue);
-	const highlightedAuOptionId = useStore((state) => state.highlightedAuOptionId);
+	const highlightedAuOptionId = useStore(
+		(state) => state.highlightedAuOptionId,
+	);
 
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
 	if (!categoryMeta) {

--- a/src/feature/amongus/AuStandardCategoryItem.tsx
+++ b/src/feature/amongus/AuStandardCategoryItem.tsx
@@ -1,4 +1,5 @@
 import { OptionEditorAccordion } from "../../components/blocks/OptionEditorAccordion";
+import { HighlightWrapper } from "../../components/parts/HighlightWrapper";
 import { auOptionMetaData } from "../../logics/api";
 import { useStore } from "../../useStore";
 import { AuCategoryOptionList } from "./AuCategoryOptionList";
@@ -17,14 +18,23 @@ export function AuStandardCategoryItem({
 		(state) => state.openedAuCategoryIds[categoryId] ?? false,
 	);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
+	const highlightedAuOptionId = useStore((state) => state.highlightedAuOptionId);
 
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
 	if (!categoryMeta) {
 		return null;
 	}
 
+	const isHighlighted =
+		highlightedAuOptionId !== null &&
+		categoryMeta.options.includes(highlightedAuOptionId);
+
 	return (
-		<div data-testid={`au-category-${categoryId}`}>
+		<HighlightWrapper
+			isHighlighted={isHighlighted}
+			data-testid={`au-category-${categoryId}`}
+			className="mb-2"
+		>
 			<OptionEditorAccordion
 				title={categoryMeta.name}
 				isOpen={isOpen}
@@ -32,6 +42,6 @@ export function AuStandardCategoryItem({
 			>
 				<AuCategoryOptionList optionIds={categoryMeta.options} />
 			</OptionEditorAccordion>
-		</div>
+		</HighlightWrapper>
 	);
 }

--- a/src/feature/amongus/AuStandardCategoryItem.tsx
+++ b/src/feature/amongus/AuStandardCategoryItem.tsx
@@ -18,7 +18,9 @@ export function AuStandardCategoryItem({
 		(state) => state.openedAuCategoryIds[categoryId] ?? false,
 	);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
-	const highlightedAuOptionId = useStore((state) => state.highlightedAuOptionId);
+	const highlightedAuOptionId = useStore(
+		(state) => state.highlightedAuOptionId,
+	);
 
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
 	if (!categoryMeta) {

--- a/src/feature/amongus/MapDropDown.tsx
+++ b/src/feature/amongus/MapDropDown.tsx
@@ -1,4 +1,5 @@
 import { OptionDropdownControl } from "../../components/parts/OptionDropdownControl";
+import { HighlightWrapper } from "../../components/parts/HighlightWrapper";
 import { auOptionMetaData } from "../../logics/api";
 import { useUpdateAuOptionSelection } from "../../logics/api.store";
 import { useStore } from "../../useStore";
@@ -46,11 +47,10 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 			className="border border-gray-700 rounded-lg overflow-hidden mb-2"
 			data-testid={`au-category-${categoryId}`}
 		>
-			<div
+			<HighlightWrapper
 				id={`au-option-${mapOptionId}`}
-				className={`flex items-center justify-between p-4 bg-gray-800 border-b border-gray-700 transition-all duration-500 ${
-					isHighlighted ? "ring-2 ring-blue-500 bg-blue-500/10" : ""
-				}`}
+				isHighlighted={!!isHighlighted}
+				className="flex items-center justify-between p-4 bg-gray-800 border-b border-gray-700"
 			>
 				<div className="flex items-center gap-3">
 					{/* アコーディオンの矢印アイコンのスペースを確保して配置を揃える */}
@@ -71,7 +71,7 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 						}}
 					/>
 				</div>
-			</div>
+			</HighlightWrapper>
 			{otherOptionIds.length > 0 && (
 				<div className="p-4 bg-gray-900 space-y-1">
 					{otherOptionIds.map((optionId) => (

--- a/src/feature/amongus/MapDropDown.tsx
+++ b/src/feature/amongus/MapDropDown.tsx
@@ -1,5 +1,5 @@
-import { OptionDropdownControl } from "../../components/parts/OptionDropdownControl";
 import { HighlightWrapper } from "../../components/parts/HighlightWrapper";
+import { OptionDropdownControl } from "../../components/parts/OptionDropdownControl";
 import { auOptionMetaData } from "../../logics/api";
 import { useUpdateAuOptionSelection } from "../../logics/api.store";
 import { useStore } from "../../useStore";


### PR DESCRIPTION
Among Usの役職オプションカテゴリ（アコーディオン）が、中のオプション（ChanceやMaxCountなど）が選択されてもハイライトされない問題を修正しました。

主な変更内容：
- ハイライトのスタイルとアニメーションを管理する共通コンポーネント `HighlightWrapper` を作成しました。
- `AuRoleCategoryItem` と `AuStandardCategoryItem` を `HighlightWrapper` で包み、中のオプションがいずれかハイライトされている場合にカテゴリ全体がハイライトされるようにしました。
- 役職のヘッダーにあるオプション（Chance, MaxCount）がハイライトされた際に正しくスクロールされるよう、`HighlightWrapper` に動的なIDを付与しました。
- コードの共通化のため、既存の `AuOptionRow` と `MapDropDown` も `HighlightWrapper` を使用するようにリファクタリングしました。

---
*PR created automatically by Jules for task [7011730797592811113](https://jules.google.com/task/7011730797592811113) started by @yukieiji*