### PR TITLE
Centralize untranslated Japanese text to noTrans.ts

### DIFF
--- a/src/components/blocks/OptionEditableAccordion.tsx
+++ b/src/components/blocks/OptionEditableAccordion.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { CLOSE, OPEN } from "../../noTrans";
 import { AccordionContentContainer } from "../parts/AccordionContentContainer";
 import { AccordionSvg } from "../parts/AccordionSvg";
 import { OptionRowContainer } from "../parts/OptionRowContainer";
@@ -33,7 +34,7 @@ export function OptionEditableAccordion({
 							onClick={onToggle}
 							className="flex items-center justify-center text-gray-500 hover:text-gray-300 w-full h-full"
 							aria-expanded={isOpen}
-							aria-label={isOpen ? "閉じる" : "開く"}
+							aria-label={isOpen ? CLOSE : OPEN}
 						>
 							<AccordionSvg className={"w-4 h-4"} isOpen={isOpen} />
 						</button>

--- a/src/components/blocks/RoleSpawnControls.tsx
+++ b/src/components/blocks/RoleSpawnControls.tsx
@@ -1,3 +1,4 @@
+import { ROLE_SPAWN_COUNT, ROLE_SPAWN_RATE } from "../../noTrans";
 import { CompactSlider } from "../parts/CompactSlider";
 
 interface ControlProps {
@@ -16,7 +17,7 @@ export function RoleSpawnControls({ rate, num }: RoleSpawnControlsProps) {
 	return (
 		<div className="flex items-center gap-4">
 			<CompactSlider
-				label="レート"
+				label={ROLE_SPAWN_RATE}
 				values={rate.values}
 				currentSelection={rate.currentSelection}
 				onSelectionChange={rate.onSelectionChange}
@@ -24,7 +25,7 @@ export function RoleSpawnControls({ rate, num }: RoleSpawnControlsProps) {
 				testId="spawn-rate-control"
 			/>
 			<CompactSlider
-				label="数"
+				label={ROLE_SPAWN_COUNT}
 				values={num.values}
 				currentSelection={num.currentSelection}
 				onSelectionChange={num.onSelectionChange}

--- a/src/components/parts/ConfirmDialog.tsx
+++ b/src/components/parts/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+import { CANCEL } from "../../noTrans";
+
 interface ConfirmDialogProps {
 	title: string;
 	message: string;
@@ -28,7 +30,7 @@ export function ConfirmDialog({
 					onClick={onCancel}
 					className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
 				>
-					キャンセル
+					{CANCEL}
 				</button>
 				<button
 					type="button"

--- a/src/components/parts/OptionGroupToggleSidebarToggleButton.tsx
+++ b/src/components/parts/OptionGroupToggleSidebarToggleButton.tsx
@@ -1,3 +1,5 @@
+import { SIDEBAR_CLOSE_ARIA, SIDEBAR_OPEN_ARIA } from "../../noTrans";
+
 interface OptionGroupToggleSidebarToggleButtonProps {
 	onClick: () => void;
 	isOpen: boolean;
@@ -15,7 +17,7 @@ export function OptionGroupToggleSidebarToggleButton({
 			type="button"
 			onClick={onClick}
 			className="p-2 bg-gray-200 hover:bg-gray-300 rounded-md transition-colors"
-			aria-label={isOpen ? "サイドバーを閉じる" : "サイドバーを開く"}
+			aria-label={isOpen ? SIDEBAR_CLOSE_ARIA : SIDEBAR_OPEN_ARIA}
 		>
 			{isOpen ? "◀" : "▶"}
 		</button>

--- a/src/components/parts/SyncButton.tsx
+++ b/src/components/parts/SyncButton.tsx
@@ -1,3 +1,5 @@
+import { SYNC_BUTTON_ARIA, SYNC_BUTTON_TITLE } from "../../noTrans";
+
 interface SyncButtonProps {
 	onClick: () => void;
 	disabled?: boolean;
@@ -17,8 +19,8 @@ export function SyncButton({ onClick, disabled }: SyncButtonProps) {
         p-2 rounded-full transition-all duration-200
         ${disabled ? "text-gray-400 cursor-not-allowed" : "text-blue-600 hover:bg-blue-50 active:bg-blue-100 shadow-sm border border-gray-200 bg-white"}
       `}
-			title="同期"
-			aria-label="データを同期"
+			title={SYNC_BUTTON_TITLE}
+			aria-label={SYNC_BUTTON_ARIA}
 		>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"

--- a/src/components/parts/ViewerOptionRow.tsx
+++ b/src/components/parts/ViewerOptionRow.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { VIEWER_ROW_TITLE } from "../../noTrans";
 
 interface ViewerOptionRowProps {
 	title: string;
@@ -22,7 +23,7 @@ export function ViewerOptionRow({
 			data-testid={testId}
 			onDoubleClick={onDoubleClick}
 			className="w-full flex justify-between items-center py-1 px-2 hover:bg-gray-700/50 rounded cursor-pointer select-none gap-2 group"
-			title="ダブルクリックで設定場所へ移動"
+			title={VIEWER_ROW_TITLE}
 		>
 			<span className="text-sm text-gray-300 truncate flex-1 text-left group-hover:text-white transition-colors">
 				{title}

--- a/src/feature/OptionGroupToggleSidebar.tsx
+++ b/src/feature/OptionGroupToggleSidebar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useTransition } from "react";
+import { OPTION_SIDEBAR_ARIA } from "../noTrans";
 import { OptionGroupToggleSidebarToggleButton } from "../components/parts/OptionGroupToggleSidebarToggleButton";
 import type { SelectedTab } from "../slices/optionGroupToggleSidebarSlice";
 import { useStore } from "../useStore";
@@ -80,7 +81,7 @@ export function OptionGroupToggleSidebar() {
         fixed left-0 top-0 h-full bg-gray-100 border-r border-gray-300 transition-all duration-300 z-10
         ${isSidebarOpen ? "w-64" : "w-12"}
       `}
-			aria-label="オプションサイドバー"
+			aria-label={OPTION_SIDEBAR_ARIA}
 		>
 			<div className="flex justify-between items-center p-2 border-b border-gray-200">
 				{import.meta.env.DEV && (

--- a/src/feature/exr/PresetSelector.tsx
+++ b/src/feature/exr/PresetSelector.tsx
@@ -1,4 +1,11 @@
 import { useEffect, useRef } from "react";
+import {
+	PRESET_INPUT_PLACEHOLDER,
+	PRESET_SELECT_ARIA,
+	PRESET_SWITCH_MESSAGE,
+	PRESET_SWITCH_TITLE,
+	format,
+} from "../../noTrans";
 import { useBackendUpdate } from "../../hooks/useBackend";
 import { useOptionData } from "../../hooks/useOptionData";
 import { updateExrOption } from "../../logics/api";
@@ -59,8 +66,8 @@ export function PresetSelector() {
 		const newPreset = presetNames[index] ?? String(presetValues[index]);
 
 		setBlockDialog({
-			title: "プリセットの切り替え",
-			message: `プリセットを「${currentPresetName}」から「${newPreset}」に切り替えます`,
+			title: PRESET_SWITCH_TITLE,
+			message: format(PRESET_SWITCH_MESSAGE, currentPresetName, newPreset),
 			onConfirm: () =>
 				backendUpdator(async () => {
 					await updateExrOption(0, 0, 0, index);
@@ -118,13 +125,13 @@ export function PresetSelector() {
 					onBlur={handleBlur}
 					onKeyDown={handleKeyDown}
 					className="px-3 py-1.5 text-sm bg-transparent text-gray-200 outline-none w-48"
-					placeholder="プリセット名を入力..."
+					placeholder={PRESET_INPUT_PLACEHOLDER}
 				/>
 				<button
 					type="button"
 					onClick={toggleDropdown}
 					className="px-2 py-1.5 bg-gray-700 hover:bg-gray-600 border-l border-gray-600 transition-colors"
-					aria-label="プリセットを選択"
+					aria-label={PRESET_SELECT_ARIA}
 				>
 					<svg
 						className={`w-4 h-4 text-gray-400 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}

--- a/src/feature/rightsidepanel/AuOptionViewer.tsx
+++ b/src/feature/rightsidepanel/AuOptionViewer.tsx
@@ -1,3 +1,4 @@
+import { CREW_ROLES_TITLE, IMPOSTOR_ROLES_TITLE } from "../../noTrans";
 import { auOptionMetaData } from "../../logics/api";
 import { useStore } from "../../useStore";
 import { AuRoleViewerSection } from "./AuRoleViewerSection";
@@ -35,13 +36,13 @@ export function AuOptionViewer() {
 			})}
 			<AuRoleViewerSection
 				tabId={1}
-				title="クルー役職"
+				title={CREW_ROLES_TITLE}
 				isOpen={isAuCrewmateRolesOpen}
 				onToggle={toggleAuCrewmateRoles}
 			/>
 			<AuRoleViewerSection
 				tabId={2}
-				title="インポスター役職"
+				title={IMPOSTOR_ROLES_TITLE}
 				isOpen={isAuImpostorRolesOpen}
 				onToggle={toggleAuImpostorRoles}
 			/>

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -1,4 +1,14 @@
 import { use, useEffect } from "react";
+import {
+	AU_SETTINGS_TITLE,
+	CLOSE,
+	EXR_CONTENT_TEMP,
+	EXR_SETTINGS_TITLE,
+	PANEL_CLOSE_ARIA,
+	PANEL_OPEN_ARIA,
+	RIGHT_PANEL_ARIA,
+	SETTING_VALUES_TITLE,
+} from "../../noTrans";
 import { CompactAccordion } from "../../components/blocks/CompactAccordion";
 import { getAllOptions } from "../../logics/api.store";
 import { useStore } from "../../useStore";
@@ -52,7 +62,7 @@ export function RightFloatingPanel() {
           cursor-pointer
           ${isRightPanelOpen ? "right-80" : "right-0"}
         `}
-				aria-label={isRightPanelOpen ? "パネルを閉じる" : "パネルを開く"}
+				aria-label={isRightPanelOpen ? PANEL_CLOSE_ARIA : PANEL_OPEN_ARIA}
 			>
 				<span className="text-sm font-bold">
 					{isRightPanelOpen ? "▶" : "◀"}
@@ -66,7 +76,7 @@ export function RightFloatingPanel() {
           transition-transform duration-300 ease-in-out transform
           ${isRightPanelOpen ? "translate-x-0" : "translate-x-full"}
         `}
-				aria-label="右フローティングパネル"
+				aria-label={RIGHT_PANEL_ARIA}
 			>
 				<div className="flex flex-col h-full">
 					<div className="flex items-center justify-between p-4 border-b border-gray-100">
@@ -74,24 +84,24 @@ export function RightFloatingPanel() {
 					</div>
 					<div className="flex-1 overflow-y-auto p-3">
 						<CompactAccordion
-							title="設定値"
+							title={SETTING_VALUES_TITLE}
 							isOpen={isSettingsOpen}
 							onToggle={toggleSettings}
 						>
 							<div className="flex flex-col">
 								<CompactAccordion
-									title="AmongUsの設定"
+									title={AU_SETTINGS_TITLE}
 									isOpen={isAuSettingsOpen}
 									onToggle={toggleAuSettings}
 								>
 									<AuOptionViewer />
 								</CompactAccordion>
 								<CompactAccordion
-									title="ExRの設定"
+									title={EXR_SETTINGS_TITLE}
 									isOpen={isExrSettingsOpen}
 									onToggle={toggleExrSettings}
 								>
-									<p className="text-gray-400 text-sm">ExRの設定コンテンツ</p>
+									<p className="text-gray-400 text-sm">{EXR_CONTENT_TEMP}</p>
 								</CompactAccordion>
 							</div>
 						</CompactAccordion>
@@ -105,7 +115,7 @@ export function RightFloatingPanel() {
 					type="button"
 					className="fixed inset-0 bg-black/20 z-30 cursor-default"
 					onClick={toggleRightPanel}
-					aria-label="閉じる"
+					aria-label={CLOSE}
 				/>
 			)}
 		</>

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -1,0 +1,41 @@
+/**
+ * 翻訳されていない日本語テキストの定数定義
+ */
+
+export const SYNC_BUTTON_TITLE = "同期";
+export const SYNC_BUTTON_ARIA = "データを同期";
+export const CANCEL = "キャンセル";
+export const SIDEBAR_CLOSE_ARIA = "サイドバーを閉じる";
+export const SIDEBAR_OPEN_ARIA = "サイドバーを開く";
+export const VIEWER_ROW_TITLE = "ダブルクリックで設定場所へ移動";
+export const ROLE_SPAWN_RATE = "レート";
+export const ROLE_SPAWN_COUNT = "数";
+export const CLOSE = "閉じる";
+export const OPEN = "開く";
+export const PRESET_SWITCH_TITLE = "プリセットの切り替え";
+export const PRESET_SWITCH_MESSAGE = "プリセットを「{0}」から「{1}」に切り替えます";
+export const PRESET_INPUT_PLACEHOLDER = "プリセット名を入力...";
+export const PRESET_SELECT_ARIA = "プリセットを選択";
+export const PANEL_CLOSE_ARIA = "パネルを閉じる";
+export const PANEL_OPEN_ARIA = "パネルを開く";
+export const RIGHT_PANEL_ARIA = "右フローティングパネル";
+export const SETTING_VALUES_TITLE = "設定値";
+export const AU_SETTINGS_TITLE = "AmongUsの設定";
+export const EXR_SETTINGS_TITLE = "ExRの設定";
+export const EXR_CONTENT_TEMP = "ExRの設定コンテンツ";
+export const CREW_ROLES_TITLE = "クルー役職";
+export const IMPOSTOR_ROLES_TITLE = "インポスター役職";
+export const OPTION_SIDEBAR_ARIA = "オプションサイドバー";
+
+/**
+ * プレースホルダーを含む文字列を置換します。
+ * @param template テンプレート文字列（例: "こんにちは {0} さん"）
+ * @param args 置換する値
+ * @returns 置換後の文字列
+ */
+export function format(template: string, ...args: (string | number)[]): string {
+	return template.replace(/{(\d+)}/g, (match, index) => {
+		const arg = args[Number(index)];
+		return arg !== undefined ? String(arg) : match;
+	});
+}


### PR DESCRIPTION
This change centralizes all user-visible Japanese text that doesn't yet have translations into a single file `src/noTrans.ts`. This serves as a preparation for future internationalization work.

Key changes:
- New file `src/noTrans.ts` containing exported string constants.
- `format` function to handle dynamic strings like "Preset changed from {0} to {1}".
- Migration of strings in:
    - SyncButton
    - ConfirmDialog
    - Sidebar and Toggle Buttons
    - RightFloatingPanel
    - OptionViewers
    - etc.
- Verified that all hardcoded Japanese strings (excluding logic in `optionUtils.ts` and symbols) have been moved.
- Ensured the project builds and all tests pass.

---
*PR created automatically by Jules for task [5206806169071681804](https://jules.google.com/task/5206806169071681804) started by @yukieiji*