### PR TITLE
Implement ExR Option Viewer in Right Panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,16 +99,18 @@ function App() {
 		<div className="min-h-screen bg-gray-50 flex">
 			<BlockableLoading />
 			<BlockableDialog />
-			<Suspense fallback={<LoadingView />}>
-				<OptionGroupToggleSidebar />
-				<main
-					className={`
-            flex-1 p-8 transition-all duration-300
-            ${isSidebarOpen ? "ml-64" : "ml-12"}
-          `}
-				>
+			<OptionGroupToggleSidebar />
+			<main
+				className={`
+          flex-1 p-8 transition-all duration-300
+          ${isSidebarOpen ? "ml-64" : "ml-12"}
+        `}
+			>
+				<Suspense fallback={<LoadingView />}>
 					<MainContent />
-				</main>
+				</Suspense>
+			</main>
+			<Suspense fallback={null}>
 				<RightFloatingPanel />
 			</Suspense>
 		</div>

--- a/src/components/blocks/ExROptionRow.tsx
+++ b/src/components/blocks/ExROptionRow.tsx
@@ -17,16 +17,17 @@ export function ExROptionRow({
 	depth = 0,
 	isLeaf = false,
 }: ExROptionRowProps) {
-	return isLeaf ? (
-		<OptionRowContainer
-			id={`exr-option-${uniqueOptionId}`}
-			leading={<LargePoint />}
-			content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
-			className={depth > 0 ? "border-l-2 border-blue-500/30 ml-4" : ""}
-		/>
-	) : (
+	return (
 		<div id={`exr-option-${uniqueOptionId}`}>
-			<ExROptionRowContent uniqueOptionId={uniqueOptionId} />
+			{isLeaf ? (
+				<OptionRowContainer
+					leading={<LargePoint />}
+					content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
+					className={depth > 0 ? "border-l-2 border-blue-500/30 ml-4" : ""}
+				/>
+			) : (
+				<ExROptionRowContent uniqueOptionId={uniqueOptionId} />
+			)}
 		</div>
 	);
 }

--- a/src/components/blocks/ExROptionRow.tsx
+++ b/src/components/blocks/ExROptionRow.tsx
@@ -19,11 +19,14 @@ export function ExROptionRow({
 }: ExROptionRowProps) {
 	return isLeaf ? (
 		<OptionRowContainer
+			id={`exr-option-${uniqueOptionId}`}
 			leading={<LargePoint />}
 			content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
 			className={depth > 0 ? "border-l-2 border-blue-500/30 ml-4" : ""}
 		/>
 	) : (
-		<ExROptionRowContent uniqueOptionId={uniqueOptionId} />
+		<div id={`exr-option-${uniqueOptionId}`}>
+			<ExROptionRowContent uniqueOptionId={uniqueOptionId} />
+		</div>
 	);
 }

--- a/src/components/parts/OptionRowContainer.tsx
+++ b/src/components/parts/OptionRowContainer.tsx
@@ -4,7 +4,6 @@ interface OptionRowContainerProps {
 	leading: ReactNode;
 	content: ReactNode;
 	className?: string;
-	id?: string;
 }
 
 /**
@@ -15,11 +14,9 @@ export function OptionRowContainer({
 	leading,
 	content,
 	className = "",
-	id,
 }: OptionRowContainerProps) {
 	return (
 		<div
-			id={id}
 			className={`flex items-stretch bg-gray-900/50 hover:bg-gray-800/50 transition-colors border-b border-gray-800 last:border-0 ${className}`}
 		>
 			{/* 左側領域（トグルボタンやスペーサー） */}

--- a/src/components/parts/OptionRowContainer.tsx
+++ b/src/components/parts/OptionRowContainer.tsx
@@ -4,6 +4,7 @@ interface OptionRowContainerProps {
 	leading: ReactNode;
 	content: ReactNode;
 	className?: string;
+	id?: string;
 }
 
 /**
@@ -14,9 +15,11 @@ export function OptionRowContainer({
 	leading,
 	content,
 	className = "",
+	id,
 }: OptionRowContainerProps) {
 	return (
 		<div
+			id={id}
 			className={`flex items-stretch bg-gray-900/50 hover:bg-gray-800/50 transition-colors border-b border-gray-800 last:border-0 ${className}`}
 		>
 			{/* 左側領域（トグルボタンやスペーサー） */}

--- a/src/components/parts/ViewerOptionRow.tsx
+++ b/src/components/parts/ViewerOptionRow.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { VIEWER_ROW_TITLE } from "../../noTrans";
+import { ColoredText } from "./ColoredText";
 
 interface ViewerOptionRowProps {
 	title: string;
@@ -26,7 +27,7 @@ export function ViewerOptionRow({
 			title={VIEWER_ROW_TITLE}
 		>
 			<span className="text-sm text-gray-300 truncate flex-1 text-left group-hover:text-white transition-colors">
-				{title}
+				<ColoredText text={title} />
 			</span>
 			<div className="flex items-center gap-1 shrink-0">
 				<div className="text-sm text-blue-400 font-medium text-right">

--- a/src/components/parts/ViewerOptionRow.tsx
+++ b/src/components/parts/ViewerOptionRow.tsx
@@ -7,6 +7,7 @@ interface ViewerOptionRowProps {
 	value: ReactNode;
 	onDoubleClick: () => void;
 	testId?: string;
+	valueColorClass?: string;
 }
 
 /**
@@ -17,6 +18,7 @@ export function ViewerOptionRow({
 	value,
 	onDoubleClick,
 	testId,
+	valueColorClass = "text-blue-400",
 }: ViewerOptionRowProps) {
 	return (
 		<button
@@ -30,7 +32,7 @@ export function ViewerOptionRow({
 				<ColoredText text={title} />
 			</span>
 			<div className="flex items-center gap-1 shrink-0">
-				<div className="text-sm text-blue-400 font-medium text-right">
+				<div className={`text-sm font-medium text-right ${valueColorClass}`}>
 					{value}
 				</div>
 			</div>

--- a/src/feature/amongus/AuTabSelector.tsx
+++ b/src/feature/amongus/AuTabSelector.tsx
@@ -2,6 +2,7 @@ import { useEffect, useTransition } from "react";
 import { TabButton } from "../../components/parts/TabButton";
 import { TabButtonContainer } from "../../components/parts/TabButtonContainer";
 import { auOptionMetaData } from "../../logics/api";
+import { type AuTab } from "../../type";
 import { useStore } from "../../useStore";
 
 /**
@@ -26,7 +27,7 @@ export function AuTabSelector() {
 		}
 	}, [isPending, setIsTabPending]);
 
-	const handleClick = (id: number) => {
+	const handleClick = (id: AuTab) => {
 		if (id === selectedAuTabId) {
 			return;
 		}
@@ -40,11 +41,12 @@ export function AuTabSelector() {
 	return (
 		<TabButtonContainer>
 			{auOptionMetaData.tabNames.map((name, index) => {
+				const tabId = index as AuTab;
 				return (
 					<TabButton
 						key={name}
-						onClick={() => handleClick(index)}
-						isSelect={selectedAuTabId === index}
+						onClick={() => handleClick(tabId)}
+						isSelect={selectedAuTabId === tabId}
 					>
 						{name}
 					</TabButton>

--- a/src/feature/exr/ExRTabSelector.tsx
+++ b/src/feature/exr/ExRTabSelector.tsx
@@ -3,7 +3,7 @@ import { ColoredText } from "../../components/parts/ColoredText";
 import { TabButton } from "../../components/parts/TabButton";
 import { TabButtonContainer } from "../../components/parts/TabButtonContainer";
 import { exrOptionMetaData } from "../../logics/api";
-import type { TabId } from "../../type";
+import { OptionTab, type TabId } from "../../type";
 import { useStore } from "../../useStore";
 
 /**
@@ -41,17 +41,19 @@ export function ExRTabSelector() {
 
 	return (
 		<TabButtonContainer>
-			{Object.keys(exrOptionMetaData.tabs).map((tabId) => {
-				const castedTabId = Number(tabId) as TabId;
+			{Object.values(OptionTab).map((tabId) => {
+				const tabMeta = exrOptionMetaData.tabs[tabId];
+				if (!tabMeta) {
+					return null;
+				}
+
 				return (
 					<TabButton
 						key={tabId}
-						onClick={() => handleClick(castedTabId)}
-						isSelect={selectedExRTabId === castedTabId}
+						onClick={() => handleClick(tabId)}
+						isSelect={selectedExRTabId === tabId}
 					>
-						<ColoredText
-							text={exrOptionMetaData.tabs[castedTabId]?.name ?? ""}
-						/>
+						<ColoredText text={tabMeta.name} />
 					</TabButton>
 				);
 			})}

--- a/src/feature/exr/ExRTabSelector.tsx
+++ b/src/feature/exr/ExRTabSelector.tsx
@@ -3,7 +3,7 @@ import { ColoredText } from "../../components/parts/ColoredText";
 import { TabButton } from "../../components/parts/TabButton";
 import { TabButtonContainer } from "../../components/parts/TabButtonContainer";
 import { exrOptionMetaData } from "../../logics/api";
-import type { OptionTab } from "../../type";
+import type { TabId } from "../../type";
 import { useStore } from "../../useStore";
 
 /**
@@ -28,7 +28,7 @@ export function ExRTabSelector() {
 		}
 	}, [isPending, setIsTabPending]);
 
-	const handleClick = (id: OptionTab) => {
+	const handleClick = (id: TabId) => {
 		if (id === selectedExRTabId) {
 			return;
 		}
@@ -42,7 +42,7 @@ export function ExRTabSelector() {
 	return (
 		<TabButtonContainer>
 			{Object.keys(exrOptionMetaData.tabs).map((tabId) => {
-				const castedTabId = Number(tabId) as OptionTab;
+				const castedTabId = Number(tabId) as TabId;
 				return (
 					<TabButton
 						key={tabId}

--- a/src/feature/rightsidepanel/AuRoleViewerRow.tsx
+++ b/src/feature/rightsidepanel/AuRoleViewerRow.tsx
@@ -1,10 +1,11 @@
 import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
 import { useAuNavigation } from "../../hooks/useAuNavigation";
 import { auOptionMetaData } from "../../logics/api";
+import { type AuTab } from "../../type";
 import { useStore } from "../../useStore";
 
 interface AuRoleViewerRowProps {
-	tabId: number;
+	tabId: AuTab;
 	categoryId: number;
 }
 

--- a/src/feature/rightsidepanel/AuRoleViewerRow.tsx
+++ b/src/feature/rightsidepanel/AuRoleViewerRow.tsx
@@ -40,17 +40,20 @@ export function AuRoleViewerRow({ tabId, categoryId }: AuRoleViewerRowProps) {
 		return null;
 	}
 
+	const valueColorClass = tabId === 1 ? "text-blue-400" : "text-red-400";
+
 	return (
 		<div className="border-white border-b">
 			<ViewerOptionRow
 				title={categoryMeta.name}
 				value={
 					<div className="flex items-center gap-2">
-						<span className="text-blue-400">{chanceValue.toString()}%</span>
+						<span>{chanceValue.toString()}%</span>
 						<span className="text-gray-500">/</span>
-						<span className="text-blue-400">{maxCountValue.toString()}</span>
+						<span>{maxCountValue.toString()}</span>
 					</div>
 				}
+				valueColorClass={valueColorClass}
 				onDoubleClick={() => {
 					navigateToOption(tabId, categoryId, chanceOptionId);
 				}}

--- a/src/feature/rightsidepanel/AuRoleViewerSection.tsx
+++ b/src/feature/rightsidepanel/AuRoleViewerSection.tsx
@@ -1,10 +1,11 @@
 import { CompactAccordion } from "../../components/blocks/CompactAccordion";
 import { auOptionMetaData } from "../../logics/api";
+import { type AuTab } from "../../type";
 import { useStore } from "../../useStore";
 import { AuRoleViewerRow } from "./AuRoleViewerRow";
 
 interface AuRoleViewerSectionProps {
-	tabId: number;
+	tabId: AuTab;
 	title: string;
 	isOpen: boolean;
 	onToggle: () => void;

--- a/src/feature/rightsidepanel/AuTab0OptionValue.tsx
+++ b/src/feature/rightsidepanel/AuTab0OptionValue.tsx
@@ -15,7 +15,7 @@ export function AuTab0OptionValue({ value, format }: AuTab0OptionValueProps) {
 
 	return (
 		<div className="flex items-center gap-1 shrink-0">
-			<span className="text-sm text-blue-400 font-medium text-right">
+			<span className="text-sm font-medium text-right">
 				{isBoolean ? (
 					<ColoredText
 						text={

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -1,5 +1,5 @@
 import { exrOptionMetaData } from "../../logics/api";
-import type { OptionTab } from "../../type";
+import { OptionTab } from "../../type";
 import { useStore } from "../../useStore";
 import { ExRRoleViewerSection } from "./ExRRoleViewerSection";
 
@@ -11,12 +11,20 @@ export function ExROptionViewer() {
 	const toggleExRRoleTab = useStore((state) => state.toggleExRRoleTab);
 
 	// 役職タブ1～7を表示対象とする
-	const roleTabIds = [1, 2, 3, 4, 5, 6, 7] as const;
+	const roleTabIds: OptionTab[] = [
+		OptionTab.CrewmateTab,
+		OptionTab.ImpostorTab,
+		OptionTab.NeutralTab,
+		OptionTab.CombinationTab,
+		OptionTab.GhostCrewmateTab,
+		OptionTab.GhostImpostorTab,
+		OptionTab.GhostNeutralTab,
+	];
 
 	return (
 		<div className="flex flex-col gap-1">
 			{roleTabIds.map((tabId) => {
-				const tabMeta = exrOptionMetaData.tabs[tabId as OptionTab];
+				const tabMeta = exrOptionMetaData.tabs[tabId];
 				if (!tabMeta) {
 					return null;
 				}

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -1,0 +1,34 @@
+import { exrOptionMetaData } from "../../logics/api";
+import { type OptionTab } from "../../type";
+import { useStore } from "../../useStore";
+import { ExRRoleViewerSection } from "./ExRRoleViewerSection";
+
+/**
+ * ExRの設定内容を表示するコンポーネント
+ */
+export function ExROptionViewer() {
+	const openedExRRoleTabIds = useStore((state) => state.openedExRRoleTabIds);
+	const toggleExRRoleTab = useStore((state) => state.toggleExRRoleTab);
+
+	// 役職タブ1～7を表示対象とする
+	const roleTabIds = [1, 2, 3, 4, 5, 6, 7] as const;
+
+	return (
+		<div className="flex flex-col gap-1">
+			{roleTabIds.map((tabId) => {
+				const tabMeta = exrOptionMetaData.tabs[tabId as OptionTab];
+				if (!tabMeta) return null;
+
+				return (
+					<ExRRoleViewerSection
+						key={tabId}
+						tabId={tabId}
+						title={tabMeta.name}
+						isOpen={openedExRRoleTabIds[tabId] ?? false}
+						onToggle={() => toggleExRRoleTab(tabId)}
+					/>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -1,5 +1,5 @@
 import { exrOptionMetaData } from "../../logics/api";
-import { type OptionTab } from "../../type";
+import type { OptionTab } from "../../type";
 import { useStore } from "../../useStore";
 import { ExRRoleViewerSection } from "./ExRRoleViewerSection";
 
@@ -17,7 +17,9 @@ export function ExROptionViewer() {
 		<div className="flex flex-col gap-1">
 			{roleTabIds.map((tabId) => {
 				const tabMeta = exrOptionMetaData.tabs[tabId as OptionTab];
-				if (!tabMeta) return null;
+				if (!tabMeta) {
+					return null;
+				}
 
 				return (
 					<ExRRoleViewerSection

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -1,5 +1,5 @@
 import { exrOptionMetaData } from "../../logics/api";
-import { OptionTab } from "../../type";
+import { OptionTab, type TabId } from "../../type";
 import { useStore } from "../../useStore";
 import { ExRRoleViewerSection } from "./ExRRoleViewerSection";
 
@@ -7,11 +7,11 @@ import { ExRRoleViewerSection } from "./ExRRoleViewerSection";
  * ExRの設定内容を表示するコンポーネント
  */
 export function ExROptionViewer() {
-	const openedExRRoleTabIds = useStore((state) => state.openedExRRoleTabIds);
-	const toggleExRRoleTab = useStore((state) => state.toggleExRRoleTab);
+	const openedExRTabIds = useStore((state) => state.openedExRTabIds);
+	const toggleExRTab = useStore((state) => state.toggleExRTab);
 
 	// 役職タブ1～7を表示対象とする
-	const roleTabIds: OptionTab[] = [
+	const roleTabIds: TabId[] = [
 		OptionTab.CrewmateTab,
 		OptionTab.ImpostorTab,
 		OptionTab.NeutralTab,
@@ -34,8 +34,8 @@ export function ExROptionViewer() {
 						key={tabId}
 						tabId={tabId}
 						title={tabMeta.name}
-						isOpen={openedExRRoleTabIds[tabId] ?? false}
-						onToggle={() => toggleExRRoleTab(tabId)}
+						isOpen={openedExRTabIds[tabId] ?? false}
+						onToggle={() => toggleExRTab(tabId)}
 					/>
 				);
 			})}

--- a/src/feature/rightsidepanel/ExRRoleViewerRow.tsx
+++ b/src/feature/rightsidepanel/ExRRoleViewerRow.tsx
@@ -3,14 +3,14 @@ import { useExrNavigation } from "../../hooks/useExrNavigation";
 import { exrOptionMetaData } from "../../logics/api";
 import { getUniqueOptionId } from "../../logics/optionUtils";
 import {
-	type OptionTab,
 	SPAWN_COUNT_OPTION_ID,
 	SPAWN_RATE_OPTION_ID,
+	type TabId,
 } from "../../type";
 import { useStore } from "../../useStore";
 
 interface ExRRoleViewerRowProps {
-	tabId: OptionTab;
+	tabId: TabId;
 	categoryId: number;
 }
 

--- a/src/feature/rightsidepanel/ExRRoleViewerRow.tsx
+++ b/src/feature/rightsidepanel/ExRRoleViewerRow.tsx
@@ -1,0 +1,64 @@
+import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
+import { useExrNavigation } from "../../hooks/useExrNavigation";
+import { exrOptionMetaData } from "../../logics/api";
+import { getUniqueOptionId } from "../../logics/optionUtils";
+import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../../type";
+import { useStore } from "../../useStore";
+
+interface ExRRoleViewerRowProps {
+	tabId: number;
+	categoryId: number;
+}
+
+/**
+ * ExRの役職の概要を表示する行コンポーネント
+ */
+export function ExRRoleViewerRow({ tabId, categoryId }: ExRRoleViewerRowProps) {
+	const exrValue = useStore((state) => state.exrValue);
+	const { navigateToOption } = useExrNavigation();
+
+	const categoryMeta = exrOptionMetaData.categories[categoryId];
+	if (!categoryMeta) {
+		return null;
+	}
+
+	const uniqueRateId = getUniqueOptionId(
+		tabId,
+		categoryId,
+		SPAWN_RATE_OPTION_ID,
+	);
+	const uniqueCountId = getUniqueOptionId(
+		tabId,
+		categoryId,
+		SPAWN_COUNT_OPTION_ID,
+	);
+
+	const rateData = exrValue[uniqueRateId];
+	const countData = exrValue[uniqueCountId];
+
+	if (!rateData || !countData) {
+		return null;
+	}
+
+	const rateValue = rateData.values[rateData.selection];
+	const countValue = countData.values[countData.selection];
+
+	return (
+		<div className="border-white border-b">
+			<ViewerOptionRow
+				title={categoryMeta.name}
+				value={
+					<div className="flex items-center gap-2">
+						<span className="text-blue-400">{rateValue.toString()}%</span>
+						<span className="text-gray-500">/</span>
+						<span className="text-blue-400">{countValue.toString()}</span>
+					</div>
+				}
+				onDoubleClick={() => {
+					navigateToOption(tabId, categoryId, uniqueRateId);
+				}}
+				testId={`right-panel-exr-role-${categoryId}`}
+			/>
+		</div>
+	);
+}

--- a/src/feature/rightsidepanel/ExRRoleViewerRow.tsx
+++ b/src/feature/rightsidepanel/ExRRoleViewerRow.tsx
@@ -2,11 +2,15 @@ import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
 import { useExrNavigation } from "../../hooks/useExrNavigation";
 import { exrOptionMetaData } from "../../logics/api";
 import { getUniqueOptionId } from "../../logics/optionUtils";
-import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "../../type";
+import {
+	type OptionTab,
+	SPAWN_COUNT_OPTION_ID,
+	SPAWN_RATE_OPTION_ID,
+} from "../../type";
 import { useStore } from "../../useStore";
 
 interface ExRRoleViewerRowProps {
-	tabId: number;
+	tabId: OptionTab;
 	categoryId: number;
 }
 

--- a/src/feature/rightsidepanel/ExRRoleViewerRow.tsx
+++ b/src/feature/rightsidepanel/ExRRoleViewerRow.tsx
@@ -47,17 +47,25 @@ export function ExRRoleViewerRow({ tabId, categoryId }: ExRRoleViewerRowProps) {
 	const rateValue = rateData.values[rateData.selection];
 	const countValue = countData.values[countData.selection];
 
+	const tabMeta = exrOptionMetaData.tabs[tabId];
+	const colorMatch = tabMeta?.name.match(/#[0-9A-F]{6,8}/i);
+	const hexColor = colorMatch ? colorMatch[0] : null;
+
 	return (
 		<div className="border-white border-b">
 			<ViewerOptionRow
 				title={categoryMeta.name}
 				value={
-					<div className="flex items-center gap-2">
-						<span className="text-blue-400">{rateValue.toString()}%</span>
+					<div
+						className="flex items-center gap-2"
+						style={{ color: hexColor ?? "inherit" }}
+					>
+						<span>{rateValue.toString()}%</span>
 						<span className="text-gray-500">/</span>
-						<span className="text-blue-400">{countValue.toString()}</span>
+						<span>{countValue.toString()}</span>
 					</div>
 				}
+				valueColorClass=""
 				onDoubleClick={() => {
 					navigateToOption(tabId, categoryId, uniqueRateId);
 				}}

--- a/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
+++ b/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
@@ -10,7 +10,7 @@ import { useStore } from "../../useStore";
 import { ExRRoleViewerRow } from "./ExRRoleViewerRow";
 
 interface ExRRoleViewerSectionProps {
-	tabId: number;
+	tabId: OptionTab;
 	title: string;
 	isOpen: boolean;
 	onToggle: () => void;

--- a/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
+++ b/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
@@ -26,7 +26,7 @@ export function ExRRoleViewerSection({
 	onToggle,
 }: ExRRoleViewerSectionProps) {
 	const exrValue = useStore((state) => state.exrValue);
-	const tabMetaData = exrOptionMetaData.tabs[tabId as OptionTab];
+	const tabMetaData = exrOptionMetaData.tabs[tabId];
 	const tabCategoryIds = tabMetaData?.categoryIds || [];
 
 	const activeRoleCategoryIds = tabCategoryIds.filter((categoryId: number) => {

--- a/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
+++ b/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
@@ -2,15 +2,15 @@ import { CompactAccordion } from "../../components/blocks/CompactAccordion";
 import { exrOptionMetaData } from "../../logics/api";
 import { getUniqueOptionId } from "../../logics/optionUtils";
 import {
-	type OptionTab,
 	SPAWN_COUNT_OPTION_ID,
 	SPAWN_RATE_OPTION_ID,
+	type TabId,
 } from "../../type";
 import { useStore } from "../../useStore";
 import { ExRRoleViewerRow } from "./ExRRoleViewerRow";
 
 interface ExRRoleViewerSectionProps {
-	tabId: OptionTab;
+	tabId: TabId;
 	title: string;
 	isOpen: boolean;
 	onToggle: () => void;

--- a/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
+++ b/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
@@ -1,4 +1,5 @@
 import { CompactAccordion } from "../../components/blocks/CompactAccordion";
+import { ColoredText } from "../../components/parts/ColoredText";
 import { exrOptionMetaData } from "../../logics/api";
 import { getUniqueOptionId } from "../../logics/optionUtils";
 import {
@@ -60,7 +61,11 @@ export function ExRRoleViewerSection({
 	}
 
 	return (
-		<CompactAccordion title={title} isOpen={isOpen} onToggle={onToggle}>
+		<CompactAccordion
+			title={<ColoredText text={title} />}
+			isOpen={isOpen}
+			onToggle={onToggle}
+		>
 			<div className="flex flex-col gap-0.5">
 				{activeRoleCategoryIds.map((categoryId: number) => (
 					<ExRRoleViewerRow

--- a/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
+++ b/src/feature/rightsidepanel/ExRRoleViewerSection.tsx
@@ -1,0 +1,75 @@
+import { CompactAccordion } from "../../components/blocks/CompactAccordion";
+import { exrOptionMetaData } from "../../logics/api";
+import { getUniqueOptionId } from "../../logics/optionUtils";
+import {
+	type OptionTab,
+	SPAWN_COUNT_OPTION_ID,
+	SPAWN_RATE_OPTION_ID,
+} from "../../type";
+import { useStore } from "../../useStore";
+import { ExRRoleViewerRow } from "./ExRRoleViewerRow";
+
+interface ExRRoleViewerSectionProps {
+	tabId: number;
+	title: string;
+	isOpen: boolean;
+	onToggle: () => void;
+}
+
+/**
+ * ExRの役職設定のセクションコンポーネント
+ */
+export function ExRRoleViewerSection({
+	tabId,
+	title,
+	isOpen,
+	onToggle,
+}: ExRRoleViewerSectionProps) {
+	const exrValue = useStore((state) => state.exrValue);
+	const tabMetaData = exrOptionMetaData.tabs[tabId as OptionTab];
+	const tabCategoryIds = tabMetaData?.categoryIds || [];
+
+	const activeRoleCategoryIds = tabCategoryIds.filter((categoryId: number) => {
+		const uniqueRateId = getUniqueOptionId(
+			tabId,
+			categoryId,
+			SPAWN_RATE_OPTION_ID,
+		);
+		const uniqueCountId = getUniqueOptionId(
+			tabId,
+			categoryId,
+			SPAWN_COUNT_OPTION_ID,
+		);
+
+		const rateData = exrValue[uniqueRateId];
+		const countData = exrValue[uniqueCountId];
+
+		if (!rateData || !countData) {
+			return false;
+		}
+
+		const rateValue = rateData.values[rateData.selection];
+		const countValue = countData.values[countData.selection];
+
+		// スポーンレートが0%より大きく、かつスポーン数が0より大きいもの
+		return Number(rateValue) > 0 && Number(countValue) > 0;
+	});
+
+	if (activeRoleCategoryIds.length === 0) {
+		return null;
+	}
+
+	return (
+		<CompactAccordion title={title} isOpen={isOpen} onToggle={onToggle}>
+			<div className="flex flex-col gap-0.5">
+				{activeRoleCategoryIds.map((categoryId: number) => (
+					<ExRRoleViewerRow
+						key={categoryId}
+						tabId={tabId}
+						categoryId={categoryId}
+					/>
+				))}
+			</div>
+		</CompactAccordion>
+	);
+}

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -4,7 +4,6 @@ import { getAllOptions } from "../../logics/api.store";
 import {
 	AU_SETTINGS_TITLE,
 	CLOSE,
-	EXR_CONTENT_TEMP,
 	EXR_SETTINGS_TITLE,
 	PANEL_CLOSE_ARIA,
 	PANEL_OPEN_ARIA,
@@ -13,6 +12,7 @@ import {
 } from "../../noTrans";
 import { useStore } from "../../useStore";
 import { AuOptionViewer } from "./AuOptionViewer";
+import { ExROptionViewer } from "./ExROptionViewer";
 
 /**
  * 右フローティングパネルコンポーネント
@@ -101,7 +101,7 @@ export function RightFloatingPanel() {
 									isOpen={isExrSettingsOpen}
 									onToggle={toggleExrSettings}
 								>
-									<p className="text-gray-400 text-sm">{EXR_CONTENT_TEMP}</p>
+									<ExROptionViewer />
 								</CompactAccordion>
 							</div>
 						</CompactAccordion>

--- a/src/hooks/useAuNavigation.ts
+++ b/src/hooks/useAuNavigation.ts
@@ -1,4 +1,4 @@
-import type { AuOptionId } from "../type";
+import type { AuOptionId, AuTab } from "../type";
 import { useStore } from "../useStore";
 
 /**
@@ -25,7 +25,7 @@ export function useAuNavigation() {
 	});
 
 	const navigateToOption = (
-		tabId: number,
+		tabId: AuTab,
 		categoryId: number,
 		optionId: AuOptionId,
 	) => {

--- a/src/hooks/useAuNavigation.ts
+++ b/src/hooks/useAuNavigation.ts
@@ -38,13 +38,15 @@ export function useAuNavigation() {
 		setHighlightedAuOptionId(optionId);
 
 		setTimeout(() => {
-			const element = document.getElementById(`au-option-${optionId}`);
-			if (element) {
-				element.scrollIntoView({ behavior: "smooth", block: "center" });
+			if (typeof document !== "undefined") {
+				const element = document.getElementById(`au-option-${optionId}`);
+				if (element) {
+					element.scrollIntoView({ behavior: "smooth", block: "center" });
+				}
+				setTimeout(() => {
+					setHighlightedAuOptionId(null);
+				}, 2000);
 			}
-			setTimeout(() => {
-				setHighlightedAuOptionId(null);
-			}, 2000);
 		}, 100);
 	};
 

--- a/src/hooks/useExrNavigation.ts
+++ b/src/hooks/useExrNavigation.ts
@@ -28,7 +28,7 @@ export function useExrNavigation() {
 	) => {
 		setRightPanelOpen(false);
 		setSelectedTab("ExR");
-		setSelectedExRTabId(tabId as OptionTab);
+		setSelectedExRTabId(tabId);
 		if (!openedExRCategoryIds[categoryId]) {
 			toggleExRCategory(categoryId);
 		}

--- a/src/hooks/useExrNavigation.ts
+++ b/src/hooks/useExrNavigation.ts
@@ -1,4 +1,4 @@
-import type { UniqueOptionId } from "../type";
+import type { OptionTab, UniqueOptionId } from "../type";
 import { useStore } from "../useStore";
 
 /**
@@ -28,15 +28,17 @@ export function useExrNavigation() {
 	) => {
 		setRightPanelOpen(false);
 		setSelectedTab("ExR");
-		setSelectedExRTabId(tabId as any); // OptionTab type
+		setSelectedExRTabId(tabId as OptionTab);
 		if (!openedExRCategoryIds[categoryId]) {
 			toggleExRCategory(categoryId);
 		}
 
 		setTimeout(() => {
-			const element = document.getElementById(`exr-option-${uniqueOptionId}`);
-			if (element) {
-				element.scrollIntoView({ behavior: "smooth", block: "center" });
+			if (typeof document !== "undefined") {
+				const element = document.getElementById(`exr-option-${uniqueOptionId}`);
+				if (element) {
+					element.scrollIntoView({ behavior: "smooth", block: "center" });
+				}
 			}
 		}, 100);
 	};

--- a/src/hooks/useExrNavigation.ts
+++ b/src/hooks/useExrNavigation.ts
@@ -22,7 +22,7 @@ export function useExrNavigation() {
 	});
 
 	const navigateToOption = (
-		tabId: number,
+		tabId: OptionTab,
 		categoryId: number,
 		uniqueOptionId: UniqueOptionId,
 	) => {

--- a/src/hooks/useExrNavigation.ts
+++ b/src/hooks/useExrNavigation.ts
@@ -1,0 +1,45 @@
+import type { UniqueOptionId } from "../type";
+import { useStore } from "../useStore";
+
+/**
+ * ExRの設定項目をダブルクリックした際のナビゲーションを行うフック
+ */
+export function useExrNavigation() {
+	const setSelectedTab = useStore((state) => {
+		return state.setSelectedTab;
+	});
+	const setSelectedExRTabId = useStore((state) => {
+		return state.setSelectedExRTabId;
+	});
+	const toggleExRCategory = useStore((state) => {
+		return state.toggleExRCategory;
+	});
+	const openedExRCategoryIds = useStore((state) => {
+		return state.openedExRCategoryIds;
+	});
+	const setRightPanelOpen = useStore((state) => {
+		return state.setRightPanelOpen;
+	});
+
+	const navigateToOption = (
+		tabId: number,
+		categoryId: number,
+		uniqueOptionId: UniqueOptionId,
+	) => {
+		setRightPanelOpen(false);
+		setSelectedTab("ExR");
+		setSelectedExRTabId(tabId as any); // OptionTab type
+		if (!openedExRCategoryIds[categoryId]) {
+			toggleExRCategory(categoryId);
+		}
+
+		setTimeout(() => {
+			const element = document.getElementById(`exr-option-${uniqueOptionId}`);
+			if (element) {
+				element.scrollIntoView({ behavior: "smooth", block: "center" });
+			}
+		}, 100);
+	};
+
+	return { navigateToOption };
+}

--- a/src/hooks/useExrNavigation.ts
+++ b/src/hooks/useExrNavigation.ts
@@ -1,4 +1,4 @@
-import type { OptionTab, UniqueOptionId } from "../type";
+import type { TabId, UniqueOptionId } from "../type";
 import { useStore } from "../useStore";
 
 /**
@@ -22,7 +22,7 @@ export function useExrNavigation() {
 	});
 
 	const navigateToOption = (
-		tabId: OptionTab,
+		tabId: TabId,
 		categoryId: number,
 		uniqueOptionId: UniqueOptionId,
 	) => {

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -18,6 +18,7 @@ import {
 	GetTranslationResponseArraySchema,
 	OptionTab,
 	OptionValueType,
+	type TabId,
 	UpdatedOptionsSchema,
 } from "../type";
 
@@ -36,8 +37,8 @@ export const translationMetaData: TranslationMetaDataRecords = {
 };
 
 export const exrOptionMetaData: ExROptionMetaDataRecords = {
-	// OptionTabはAPIから取得したデータに基づいて動的に構築され全てあることが保証されるため、初期値は空のオブジェクトで問題ありません
-	tabs: {} as Record<OptionTab, ExRTabMetaData>,
+	// TabIdはAPIから取得したデータに基づいて動的に構築され全てあることが保証されるため、初期値は空のオブジェクトで問題ありません
+	tabs: {} as Record<TabId, ExRTabMetaData>,
 	categories: {},
 	options: {},
 	globalCategoryIdTopLevelMap: {},
@@ -54,7 +55,7 @@ export const auOptionMetaData: AuOptionMetaDataRecords = {
  * ExRオプションのメタデータをリセットする（テスト用）
  */
 export function resetExrOptionMetaData() {
-	exrOptionMetaData.tabs = {} as Record<OptionTab, ExRTabMetaData>;
+	exrOptionMetaData.tabs = {} as Record<TabId, ExRTabMetaData>;
 	exrOptionMetaData.categories = {};
 	exrOptionMetaData.options = {};
 	exrOptionMetaData.globalCategoryIdTopLevelMap = {};
@@ -132,7 +133,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 
 	const processOptions = (
 		options: ExROptionDto[],
-		tabId: OptionTab,
+		tabId: TabId,
 		categoryId: number,
 		parentOptionId: number | null,
 	) => {

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -5,12 +5,12 @@ import type { AuOptionId, UpdateAuArg } from "../type";
  * ExR オプションの状態を管理するスライスのインターフェース
  */
 export interface AuOptionViewerSlice {
-	selectedAuTabId: number;
+	selectedAuTabId: AuTab;
 	isAuTabPending: boolean;
 	openedAuCategoryIds: Record<number, boolean>;
 	highlightedAuOptionId: AuOptionId | null;
 	auValue: Record<AuOptionId, number>; // セレクション
-	setSelectedAuTabId: (id: number) => void;
+	setSelectedAuTabId: (id: AuTab) => void;
 	setIsAuTabPending: (isPending: boolean) => void;
 	setAuValue: (value: Record<AuOptionId, number>) => void;
 	setOpenedAuCategoryIds: (ids: Record<number, boolean>) => void;
@@ -31,7 +31,7 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 		openedAuCategoryIds: {},
 		highlightedAuOptionId: null,
 		auValue: {},
-		setSelectedAuTabId: (id: number) => {
+		setSelectedAuTabId: (id: AuTab) => {
 			set({ selectedAuTabId: id });
 		},
 		setIsAuTabPending: (isPending: boolean) => {

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -1,5 +1,5 @@
 import type { StateCreator } from "zustand";
-import type { AuOptionId, UpdateAuArg } from "../type";
+import type { AuOptionId, AuTab, UpdateAuArg } from "../type";
 
 /**
  * ExR オプションの状態を管理するスライスのインターフェース

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -7,7 +7,7 @@ import {
 } from "../logics/storageUtils";
 import type {
 	ExROptionValueData,
-	OptionTab,
+	TabId,
 	UniqueOptionId,
 	UpdatedOptions,
 } from "../type";
@@ -16,7 +16,7 @@ import type {
  * ExR オプションの状態を管理するスライスのインターフェース
  */
 export interface ExROptionViewerSlice {
-	selectedExRTabId: OptionTab;
+	selectedExRTabId: TabId;
 	isExRTabPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<number, boolean>;
@@ -24,7 +24,7 @@ export interface ExROptionViewerSlice {
 	isPresetDropdownOpen: boolean;
 	exrValue: Record<UniqueOptionId, ExROptionValueData>;
 	isExROptionActive: Record<UniqueOptionId, boolean>;
-	setSelectedExRTabId: (id: OptionTab) => void;
+	setSelectedExRTabId: (id: TabId) => void;
 	setIsExRTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: UniqueOptionId) => void;
@@ -54,7 +54,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		isExROptionActive: {},
 		presetNames: loadPresetNamesFromLocalStorage(),
 		isPresetDropdownOpen: false,
-		setSelectedExRTabId: (id: OptionTab) => {
+		setSelectedExRTabId: (id: TabId) => {
 			set({ selectedExRTabId: id });
 		},
 		setIsExRTabPending: (isPending: boolean) => {

--- a/src/slices/rightFloatingPanelSlice.ts
+++ b/src/slices/rightFloatingPanelSlice.ts
@@ -1,5 +1,5 @@
 import type { StateCreator } from "zustand";
-import type { OptionTab } from "../type";
+import { OptionTab, type TabId } from "../type";
 
 /**
  * 右フローティングパネルの状態管理を行うスライスのインターフェース
@@ -21,8 +21,8 @@ export interface RightFloatingPanelSlice {
 	toggleAuCrewmateRoles: () => void;
 	isAuImpostorRolesOpen: boolean;
 	toggleAuImpostorRoles: () => void;
-	openedExRRoleTabIds: Record<OptionTab, boolean>;
-	toggleExRRoleTab: (tabId: OptionTab) => void;
+	openedExRTabIds: Record<TabId, boolean>;
+	toggleExRTab: (tabId: TabId) => void;
 }
 
 /**
@@ -78,21 +78,21 @@ export const createRightFloatingPanelSlice: StateCreator<
 		toggleAuImpostorRoles: () => {
 			set((state) => ({ isAuImpostorRolesOpen: !state.isAuImpostorRolesOpen }));
 		},
-		openedExRRoleTabIds: {
-			0: true,
-			1: true,
-			2: true,
-			3: true,
-			4: true,
-			5: true,
-			6: true,
-			7: true,
+		openedExRTabIds: {
+			[OptionTab.GeneralTab]: true,
+			[OptionTab.CrewmateTab]: true,
+			[OptionTab.ImpostorTab]: true,
+			[OptionTab.NeutralTab]: true,
+			[OptionTab.CombinationTab]: true,
+			[OptionTab.GhostCrewmateTab]: true,
+			[OptionTab.GhostImpostorTab]: true,
+			[OptionTab.GhostNeutralTab]: true,
 		},
-		toggleExRRoleTab: (tabId) => {
+		toggleExRTab: (tabId) => {
 			set((state) => {
-				const next = { ...state.openedExRRoleTabIds };
+				const next = { ...state.openedExRTabIds };
 				next[tabId] = !next[tabId];
-				return { openedExRRoleTabIds: next };
+				return { openedExRTabIds: next };
 			});
 		},
 	};

--- a/src/slices/rightFloatingPanelSlice.ts
+++ b/src/slices/rightFloatingPanelSlice.ts
@@ -20,6 +20,8 @@ export interface RightFloatingPanelSlice {
 	toggleAuCrewmateRoles: () => void;
 	isAuImpostorRolesOpen: boolean;
 	toggleAuImpostorRoles: () => void;
+	openedExRRoleTabIds: Record<number, boolean>;
+	toggleExRRoleTab: (tabId: number) => void;
 }
 
 /**
@@ -74,6 +76,22 @@ export const createRightFloatingPanelSlice: StateCreator<
 		isAuImpostorRolesOpen: true,
 		toggleAuImpostorRoles: () => {
 			set((state) => ({ isAuImpostorRolesOpen: !state.isAuImpostorRolesOpen }));
+		},
+		openedExRRoleTabIds: {
+			1: true,
+			2: true,
+			3: true,
+			4: true,
+			5: true,
+			6: true,
+			7: true,
+		},
+		toggleExRRoleTab: (tabId) => {
+			set((state) => {
+				const next = { ...state.openedExRRoleTabIds };
+				next[tabId] = !next[tabId];
+				return { openedExRRoleTabIds: next };
+			});
 		},
 	};
 };

--- a/src/slices/rightFloatingPanelSlice.ts
+++ b/src/slices/rightFloatingPanelSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from "zustand";
+import type { OptionTab } from "../type";
 
 /**
  * 右フローティングパネルの状態管理を行うスライスのインターフェース
@@ -20,8 +21,8 @@ export interface RightFloatingPanelSlice {
 	toggleAuCrewmateRoles: () => void;
 	isAuImpostorRolesOpen: boolean;
 	toggleAuImpostorRoles: () => void;
-	openedExRRoleTabIds: Record<number, boolean>;
-	toggleExRRoleTab: (tabId: number) => void;
+	openedExRRoleTabIds: Record<OptionTab, boolean>;
+	toggleExRRoleTab: (tabId: OptionTab) => void;
 }
 
 /**
@@ -78,6 +79,7 @@ export const createRightFloatingPanelSlice: StateCreator<
 			set((state) => ({ isAuImpostorRolesOpen: !state.isAuImpostorRolesOpen }));
 		},
 		openedExRRoleTabIds: {
+			0: true,
 			1: true,
 			2: true,
 			3: true,

--- a/src/type.ts
+++ b/src/type.ts
@@ -67,10 +67,10 @@ export type TabId = (typeof OptionTab)[keyof typeof OptionTab];
 
 export const TabIdSchema = z.preprocess((val) => {
 	if (typeof val === "string" && val in OptionTab) {
-		return TabId[val as keyof typeof OptionTab];
+		return OptionTab[val as keyof typeof OptionTab];
 	}
 	return val;
-}, z.enum(OptionTab));
+}, z.nativeEnum(OptionTab));
 
 /**
  * オプションの範囲メタデータ
@@ -206,7 +206,7 @@ export const OptionValueTypeSchema = z.preprocess((val) => {
 		return OptionValueType[val as keyof typeof OptionValueType];
 	}
 	return val;
-}, z.enum(OptionValueType));
+}, z.nativeEnum(OptionValueType));
 
 export interface AuRoleOption {
 	MaxCount: number;

--- a/src/type.ts
+++ b/src/type.ts
@@ -34,7 +34,7 @@ export interface ExRTabMetaData {
 
 export interface ExRCategoryMetaData {
 	name: string;
-	tabId: OptionTab;
+	tabId: TabId;
 }
 
 export interface ExROptionMetaDataDetail {
@@ -43,7 +43,7 @@ export interface ExROptionMetaDataDetail {
 }
 
 export interface ExROptionMetaDataRecords {
-	tabs: Record<OptionTab, ExRTabMetaData>;
+	tabs: Record<TabId, ExRTabMetaData>;
 	categories: Record<number, ExRCategoryMetaData>;
 	options: Record<UniqueOptionId, ExROptionMetaDataDetail>;
 	globalCategoryIdTopLevelMap: Record<number, UniqueOptionId[]>;
@@ -63,11 +63,11 @@ export const OptionTab = {
 	GhostNeutralTab: 7,
 } as const;
 
-export type OptionTab = (typeof OptionTab)[keyof typeof OptionTab];
+export type TabId = (typeof OptionTab)[keyof typeof OptionTab];
 
-export const OptionTabSchema = z.preprocess((val) => {
+export const TabIdSchema = z.preprocess((val) => {
 	if (typeof val === "string" && val in OptionTab) {
-		return OptionTab[val as keyof typeof OptionTab];
+		return TabId[val as keyof typeof OptionTab];
 	}
 	return val;
 }, z.enum(OptionTab));
@@ -130,13 +130,13 @@ export const ExRCategoryDtoSchema = z.object({
  * タブDTO
  */
 export interface ExRTabDto {
-	Id: OptionTab;
+	Id: TabId;
 	Name: string;
 	Categories: ExRCategoryDto[];
 }
 
 export const ExRTabDtoSchema = z.object({
-	Id: OptionTabSchema,
+	Id: TabIdSchema,
 	Name: z.string(),
 	Categories: z.array(ExRCategoryDtoSchema),
 });
@@ -153,6 +153,14 @@ export const AU_PREFIX = {
 	MAX_COUNT: 1,
 	CHANCE: 2,
 } as const;
+
+export const AuTab = {
+	GeneralTab: 0,
+	CrewmateTab: 1,
+	ImpostorTab: 2,
+} as const;
+
+export type AuTab = (typeof AuTab)[keyof typeof AuTab];
 
 // 全ての値（1 | 2）を型として抽出
 export type AuOptionPrefix = (typeof AU_PREFIX)[keyof typeof AU_PREFIX];

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { ExROptionViewer } from "../src/feature/rightsidepanel/ExROptionViewer";
 import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
-import type { OptionTab } from "../src/type";
+import type { TabId } from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("ExROptionViewer Component", () => {
@@ -12,7 +12,7 @@ describe("ExROptionViewer Component", () => {
 
 		// Setup metadata for all 7 tabs
 		for (let i = 1; i <= 7; i++) {
-			const tabId = i as OptionTab;
+			const tabId = i as TabId;
 			exrOptionMetaData.tabs[tabId] = {
 				name: `Tab ${i}`,
 				categoryIds: [i * 100],

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ExROptionViewer } from "../src/feature/rightsidepanel/ExROptionViewer";
+import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import type { OptionTab } from "../src/type";
+import { useStore } from "../src/useStore";
+
+describe("ExROptionViewer Component", () => {
+	it("renders all 7 role tabs if they have metadata", () => {
+		resetExrOptionMetaData();
+
+		// Setup metadata for all 7 tabs
+		for (let i = 1; i <= 7; i++) {
+			exrOptionMetaData.tabs[i as OptionTab] = {
+				name: `Tab ${i}`,
+				categoryIds: [i * 100],
+			};
+			// Also need a category and active options for it to actually render anything
+			const categoryId = i * 100;
+			exrOptionMetaData.categories[categoryId] = {
+				name: `Role ${i}`,
+				tabId: i as OptionTab,
+			};
+
+			const rateId = (i * 1_000_000_000_000 +
+				categoryId * 1_000_000 +
+				50) as any;
+			const countId = (i * 1_000_000_000_000 +
+				categoryId * 1_000_000 +
+				51) as any;
+
+			useStore.setState((state) => ({
+				exrValue: {
+					...state.exrValue,
+					[rateId]: { selection: 1, values: [0, 100] },
+					[countId]: { selection: 1, values: [0, 1] },
+				},
+			}));
+		}
+
+		render(<ExROptionViewer />);
+
+		for (let i = 1; i <= 7; i++) {
+			expect(screen.getByText(`Tab ${i}`)).toBeInTheDocument();
+		}
+	});
+});

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ExROptionViewer } from "../src/feature/rightsidepanel/ExROptionViewer";
 import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import { getUniqueOptionId } from "../src/logics/optionUtils";
 import type { OptionTab } from "../src/type";
 import { useStore } from "../src/useStore";
 
@@ -20,15 +21,11 @@ describe("ExROptionViewer Component", () => {
 			const categoryId = i * 100;
 			exrOptionMetaData.categories[categoryId] = {
 				name: `Role ${i}`,
-				tabId: i as OptionTab,
+				tabId: tabId,
 			};
 
-			const rateId = (i * 1_000_000_000_000 +
-				categoryId * 1_000_000 +
-				50) as any;
-			const countId = (i * 1_000_000_000_000 +
-				categoryId * 1_000_000 +
-				51) as any;
+			const rateId = getUniqueOptionId(tabId, categoryId, 50);
+			const countId = getUniqueOptionId(tabId, categoryId, 51);
 
 			useStore.setState((state) => ({
 				exrValue: {

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -11,7 +11,8 @@ describe("ExROptionViewer Component", () => {
 
 		// Setup metadata for all 7 tabs
 		for (let i = 1; i <= 7; i++) {
-			exrOptionMetaData.tabs[i as OptionTab] = {
+			const tabId = i as OptionTab;
+			exrOptionMetaData.tabs[tabId] = {
 				name: `Tab ${i}`,
 				categoryIds: [i * 100],
 			};

--- a/tests/ExRRoleViewerSection.test.tsx
+++ b/tests/ExRRoleViewerSection.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ExRRoleViewerSection } from "../src/feature/rightsidepanel/ExRRoleViewerSection";
+import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import { getUniqueOptionId } from "../src/logics/optionUtils";
+import type { OptionTab } from "../src/type";
+import { useStore } from "../src/useStore";
+
+describe("ExRRoleViewerSection Component", () => {
+	it("renders active roles correctly", async () => {
+		resetExrOptionMetaData();
+
+		const tabId = 1; // CrewmateTab
+		const categoryId = 10;
+		const roleName = "Test Role";
+
+		exrOptionMetaData.tabs[tabId as OptionTab] = {
+			name: "Crewmate Roles",
+			categoryIds: [categoryId],
+		};
+		exrOptionMetaData.categories[categoryId] = {
+			name: roleName,
+			tabId: tabId as OptionTab,
+		};
+
+		const rateId = getUniqueOptionId(tabId, categoryId, 50);
+		const countId = getUniqueOptionId(tabId, categoryId, 51);
+
+		exrOptionMetaData.options[rateId] = {
+			metaData: { translatedName: "Rate", format: "{0}%", type: "Int32" },
+			childOptionIds: [],
+		};
+		exrOptionMetaData.options[countId] = {
+			metaData: { translatedName: "Count", format: "{0}", type: "Int32" },
+			childOptionIds: [],
+		};
+
+		useStore.setState({
+			exrValue: {
+				[rateId]: { selection: 1, values: [0, 50, 100] },
+				[countId]: { selection: 1, values: [0, 1, 2] },
+			},
+			openedExRRoleTabIds: { [tabId]: true },
+		});
+
+		render(
+			<ExRRoleViewerSection
+				tabId={tabId}
+				title="Crewmate Roles"
+				isOpen={true}
+				onToggle={() => {}}
+			/>,
+		);
+
+		expect(screen.getByText(roleName)).toBeInTheDocument();
+		expect(screen.getByText("50%")).toBeInTheDocument();
+		expect(screen.getByText("1")).toBeInTheDocument();
+	});
+
+	it("does not render when no active roles", () => {
+		resetExrOptionMetaData();
+		const tabId = 1;
+
+		useStore.setState({
+			exrValue: {},
+		});
+
+		const { container } = render(
+			<ExRRoleViewerSection
+				tabId={tabId}
+				title="Crewmate Roles"
+				isOpen={true}
+				onToggle={() => {}}
+			/>,
+		);
+
+		expect(container.firstChild).toBeNull();
+	});
+});


### PR DESCRIPTION
This PR implements the ExR option viewer in the right-side panel, matching the functionality of the existing Among Us option viewer.

Key changes:
1.  **State Management**: Updated `RightFloatingPanelSlice` to track the open/close state of the 7 ExR role tab sections.
2.  **UI Components**:
    *   `ExROptionViewer`: The main container for ExR settings in the right panel.
    *   `ExRRoleViewerSection`: Represents each of the 7 role tabs (Crewmate, Impostor, Neutral, etc.).
    *   `ExRRoleViewerRow`: Displays the role name and its spawn settings (Rate/Count).
3.  **Filtering Logic**: Roles are only displayed if they have a spawn rate > 0% and a spawn count > 0.
4.  **Navigation**: Users can double-click a role in the viewer to jump to its full setting in the main ExR tab. This involved adding unique element IDs to the `ExROptionRow` components.
5.  **Integration**: Replaced the "ExR settings placeholder" in the right floating panel with the new `ExROptionViewer`.

All changes were verified with local builds and Playwright screenshots.

---
*PR created automatically by Jules for task [9560604983813634645](https://jules.google.com/task/9560604983813634645) started by @yukieiji*