### PR TITLE
Add ExR General Tab viewer to right panel

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -28,22 +28,28 @@ test("ExR Option Accordion behavior", async ({ page }) => {
 
 	// プリセットカテゴリは非表示になったため、別のカテゴリ「乱数に関する設定」を使用する
 	const categoryName = "乱数に関する設定";
-	const accordionButton = page.getByRole("button", { name: categoryName });
+	const accordionButton = page
+		.getByTestId("main-content-section")
+		.getByRole("button", { name: categoryName });
 	await expect(accordionButton).toBeVisible();
 
 	// 初期状態では閉じている
 	const accordionItem = page
+		.getByTestId("main-content-section")
 		.locator("div.border.border-gray-700")
 		.filter({ hasText: categoryName });
 	const contentContainer = accordionItem.getByTestId("accordion-content");
 	await expect(contentContainer).toHaveClass(/grid-rows-\[0fr\]/);
 
 	// 閉じているときはオプション名が表示されていない（lazy rendering）
-	const optionName = page.getByText("強力なシャッフルを使用する");
+	const optionName = page
+		.getByTestId("main-content-section")
+		.getByText("強力なシャッフルを使用する");
 	await expect(optionName).not.toBeAttached();
 
 	// アコーディオンを開く
 	await accordionButton.click();
+	await page.waitForTimeout(500); // Wait for transition
 	await expect(contentContainer).toHaveClass(/grid-rows-\[1fr\]/);
 	await expect(optionName).toBeVisible();
 

--- a/e2e/exr_toggle.spec.ts
+++ b/e2e/exr_toggle.spec.ts
@@ -28,8 +28,11 @@ test("ExR toggle switch should be visible and functional", async ({ page }) => {
 		.click();
 
 	// '乱数に関する設定' アコーディオンを開く
-	const categoryAccordion = page.getByText("乱数に関する設定");
+	const categoryAccordion = page
+		.getByTestId("main-content-section")
+		.getByText("乱数に関する設定");
 	await categoryAccordion.click();
+	await page.waitForTimeout(500);
 
 	// '強力なシャッフルを使用する' オプションの横にあるトグルを確認
 	const toggle = page.getByTestId("option-toggle").first(); // 最初のトグルを取得
@@ -37,17 +40,23 @@ test("ExR toggle switch should be visible and functional", async ({ page }) => {
 
 	// 初期状態は オフ (Selection 0)
 	await expect(toggle).toHaveAttribute("aria-checked", "false");
-	await expect(page.getByText("オフ")).toBeVisible();
+	await expect(
+		page.getByTestId("main-content-section").getByText("オフ"),
+	).toBeVisible();
 
 	// クリックして オン にする
 	await toggle.click();
 
 	// 状態が オン (Selection 1) になったことを確認
 	await expect(toggle).toHaveAttribute("aria-checked", "true");
-	await expect(page.getByText("オン", { exact: true })).toBeVisible();
+	await expect(
+		page.getByTestId("main-content-section").getByText("オン", { exact: true }),
+	).toBeVisible();
 
 	// 再度クリックして オフ に戻す
 	await toggle.click();
 	await expect(toggle).toHaveAttribute("aria-checked", "false");
-	await expect(page.getByText("オフ")).toBeVisible();
+	await expect(
+		page.getByTestId("main-content-section").getByText("オフ"),
+	).toBeVisible();
 });

--- a/e2e/exr_viewer_navigation.spec.ts
+++ b/e2e/exr_viewer_navigation.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 100;
+	});
+	await page.goto("/");
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+});
+
+test("ExR viewer in right panel can navigate to settings in main editor", async ({
+	page,
+}) => {
+	const rightPanel = page.getByLabel("右フローティングパネル");
+	const toggleButton = page.getByRole("button", { name: "パネルを開く" });
+
+	// 1. 右パネルを開く
+	await toggleButton.click();
+	await expect(rightPanel).toBeVisible();
+
+	// 2. "ExRの設定" アコーディオンを展開（デフォルトで開いているはずだが念のため）
+	const exrSettingsAccordion = rightPanel.getByRole("button", {
+		name: "ExRの設定",
+	});
+	if ((await exrSettingsAccordion.getAttribute("aria-expanded")) === "false") {
+		await exrSettingsAccordion.click();
+	}
+
+	// 3. 一般タブのオプションを探す（Mockデータ: "強力なシャッフルを使用する"）
+	// 右パネル内のオプション行を探す。data-testid が付与されている。
+	const viewerOption = rightPanel
+		.locator("[data-testid^='right-panel-exr-option-']")
+		.first();
+	const testId = await viewerOption.getAttribute("data-testid");
+	const uniqueOptionId = testId?.replace("right-panel-exr-option-", "");
+	const optionTitle = await viewerOption
+		.locator("span.truncate")
+		.first()
+		.innerText();
+
+	// 4. ダブルクリックしてナビゲーションを実行
+	// force: true を指定して、アニメーション中やオーバーレイがあっても実行できるようにする
+	await viewerOption.dblclick({ force: true });
+
+	// 5. 右パネルが自動で閉じることを確認
+	await expect(rightPanel).toHaveClass(/translate-x-full/);
+
+	// 6. メインエディターが ExR タブに切り替わっていることを確認
+	await expect(
+		page.getByRole("heading", { name: "ExR Options" }),
+	).toBeVisible();
+
+	// 7. メインエディター内で該当のオプションがハイライトされていることを確認
+	const highlightedOption = page.locator(`#exr-option-${uniqueOptionId}`);
+	await expect(highlightedOption).toBeVisible();
+	await expect(highlightedOption).toHaveClass(/ring-2/);
+	await expect(highlightedOption).toHaveClass(/ring-blue-500/);
+	await expect(highlightedOption).toContainText(optionTitle);
+
+	// 8. 数秒後にハイライトが消えることを確認
+	await expect(highlightedOption).not.toHaveClass(/ring-2/, { timeout: 5000 });
+});

--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -37,21 +37,32 @@ test("Options interaction behavior", async ({ page }) => {
 	await expect(page.getByText("Test Preset")).toBeVisible();
 
 	// 別のカテゴリの操作を確認
-	const shuffleCategory = page.getByRole("button", {
-		name: "乱数に関する設定",
-	});
+	const shuffleCategory = page
+		.getByTestId("main-content-section")
+		.getByRole("button", {
+			name: "乱数に関する設定",
+		});
 	await shuffleCategory.click();
 
-	const shuffleOption = page.getByText("強力なシャッフルを使用する");
+	const shuffleOption = page
+		.getByTestId("main-content-section")
+		.getByText("強力なシャッフルを使用する");
 	await expect(shuffleOption).toBeVisible({ timeout: 3000 });
 
 	// トグルスイッチに変更されたので、トグルを操作する
-	const toggle = page.getByTestId("option-toggle").first();
+	const toggle = page
+		.getByTestId("main-content-section")
+		.getByTestId("option-toggle")
+		.first();
 	await expect(toggle).toHaveAttribute("aria-checked", "false");
-	await expect(page.getByText("オフ")).toBeVisible();
+	await expect(
+		page.getByTestId("main-content-section").getByText("オフ"),
+	).toBeVisible();
 
 	// トグルを切り替え
 	await toggle.click();
 	await expect(toggle).toHaveAttribute("aria-checked", "true");
-	await expect(page.getByText("オン", { exact: true })).toBeVisible();
+	await expect(
+		page.getByTestId("main-content-section").getByText("オン", { exact: true }),
+	).toBeVisible();
 });

--- a/e2e/right_sidebar.spec.ts
+++ b/e2e/right_sidebar.spec.ts
@@ -37,12 +37,10 @@ test("right sidebar can be opened and accordions can be toggled", async ({
 	// AmongUsの設定を閉じる
 	await auSettings.click();
 	await expect(auSettings).toHaveAttribute("aria-expanded", "false");
-	await expect(page.getByText("AmongUsの設定コンテンツ")).not.toBeVisible();
 
 	// ExRの設定を閉じる
 	await exrSettings.click();
 	await expect(exrSettings).toHaveAttribute("aria-expanded", "false");
-	await expect(page.getByText("ExRの設定コンテンツ")).not.toBeVisible();
 
 	// 設定値アコーディオンを閉じる
 	await settingsAccordion.click();

--- a/src/components/blocks/ExROptionRow.tsx
+++ b/src/components/blocks/ExROptionRow.tsx
@@ -1,4 +1,6 @@
+import { HighlightWrapper } from "../../components/parts/HighlightWrapper";
 import type { UniqueOptionId } from "../../type";
+import { useStore } from "../../useStore";
 import { LargePoint } from "../parts/LargePoint";
 import { OptionRowContainer } from "../parts/OptionRowContainer";
 import { ExROptionRowContent } from "./ExROptionRowContent";
@@ -17,13 +19,27 @@ export function ExROptionRow({
 	depth = 0,
 	isLeaf = false,
 }: ExROptionRowProps) {
+	const highlightedExROptionId = useStore(
+		(state) => state.highlightedExROptionId,
+	);
+	const isHighlighted = highlightedExROptionId === uniqueOptionId;
+
+	const content = (
+		<HighlightWrapper
+			id={`exr-option-${uniqueOptionId}`}
+			isHighlighted={isHighlighted}
+		>
+			<ExROptionRowContent uniqueOptionId={uniqueOptionId} />
+		</HighlightWrapper>
+	);
+
 	return isLeaf ? (
 		<OptionRowContainer
 			leading={<LargePoint />}
-			content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
+			content={content}
 			className={depth > 0 ? "border-l-2 border-blue-500/30 ml-4" : ""}
 		/>
 	) : (
-		<ExROptionRowContent uniqueOptionId={uniqueOptionId} />
+		content
 	);
 }

--- a/src/feature/rightsidepanel/ExRGeneralCategory.tsx
+++ b/src/feature/rightsidepanel/ExRGeneralCategory.tsx
@@ -30,21 +30,21 @@ export function ExRGeneralCategory({ categoryId }: ExRGeneralCategoryProps) {
 		<div data-testid={`right-panel-exr-category-${categoryId}`}>
 			<CompactAccordion
 				title={<span className="text-base">{categoryMeta.name}</span>}
-			isOpen={openedExRCategoryIds[categoryId] ?? true}
-			onToggle={() => {
-				toggleExRCategory(categoryId);
-			}}
-		>
-			<div className="flex flex-col gap-0.5">
-				{topLevelOptionIds.map((uniqueOptionId) => (
-					<ExRViewerOptionRow
-						key={uniqueOptionId}
-						uniqueOptionId={uniqueOptionId}
-						categoryId={categoryId}
-					/>
-				))}
-			</div>
-		</CompactAccordion>
+				isOpen={openedExRCategoryIds[categoryId] ?? true}
+				onToggle={() => {
+					toggleExRCategory(categoryId);
+				}}
+			>
+				<div className="flex flex-col gap-0.5">
+					{topLevelOptionIds.map((uniqueOptionId) => (
+						<ExRViewerOptionRow
+							key={uniqueOptionId}
+							uniqueOptionId={uniqueOptionId}
+							categoryId={categoryId}
+						/>
+					))}
+				</div>
+			</CompactAccordion>
 		</div>
 	);
 }

--- a/src/feature/rightsidepanel/ExRGeneralCategory.tsx
+++ b/src/feature/rightsidepanel/ExRGeneralCategory.tsx
@@ -1,0 +1,48 @@
+import { CompactAccordion } from "../../components/blocks/CompactAccordion";
+import { exrOptionMetaData } from "../../logics/api";
+import { useStore } from "../../useStore";
+import { ExRViewerOptionRow } from "./ExRViewerOptionRow";
+
+interface ExRGeneralCategoryProps {
+	categoryId: number;
+}
+
+/**
+ * ExR一般カテゴリコンポーネント
+ */
+export function ExRGeneralCategory({ categoryId }: ExRGeneralCategoryProps) {
+	const categoryMeta = exrOptionMetaData.categories[categoryId];
+	const topLevelOptionIds =
+		exrOptionMetaData.globalCategoryIdTopLevelMap[categoryId] || [];
+
+	const openedExRCategoryIds = useStore((state) => {
+		return state.openedExRCategoryIds;
+	});
+	const toggleExRCategory = useStore((state) => {
+		return state.toggleExRCategory;
+	});
+
+	if (!categoryMeta) {
+		return null;
+	}
+
+	return (
+		<CompactAccordion
+			title={<span className="text-base">{categoryMeta.name}</span>}
+			isOpen={openedExRCategoryIds[categoryId] ?? true}
+			onToggle={() => {
+				toggleExRCategory(categoryId);
+			}}
+		>
+			<div className="flex flex-col gap-0.5">
+				{topLevelOptionIds.map((uniqueOptionId) => (
+					<ExRViewerOptionRow
+						key={uniqueOptionId}
+						uniqueOptionId={uniqueOptionId}
+						categoryId={categoryId}
+					/>
+				))}
+			</div>
+		</CompactAccordion>
+	);
+}

--- a/src/feature/rightsidepanel/ExRGeneralCategory.tsx
+++ b/src/feature/rightsidepanel/ExRGeneralCategory.tsx
@@ -27,8 +27,9 @@ export function ExRGeneralCategory({ categoryId }: ExRGeneralCategoryProps) {
 	}
 
 	return (
-		<CompactAccordion
-			title={<span className="text-base">{categoryMeta.name}</span>}
+		<div data-testid={`right-panel-exr-category-${categoryId}`}>
+			<CompactAccordion
+				title={<span className="text-base">{categoryMeta.name}</span>}
 			isOpen={openedExRCategoryIds[categoryId] ?? true}
 			onToggle={() => {
 				toggleExRCategory(categoryId);
@@ -44,5 +45,6 @@ export function ExRGeneralCategory({ categoryId }: ExRGeneralCategoryProps) {
 				))}
 			</div>
 		</CompactAccordion>
+		</div>
 	);
 }

--- a/src/feature/rightsidepanel/ExRGeneralCategory.tsx
+++ b/src/feature/rightsidepanel/ExRGeneralCategory.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from "react";
 import { CompactAccordion } from "../../components/blocks/CompactAccordion";
 import { exrOptionMetaData } from "../../logics/api";
+import { PRESET_OPTION_UNIQUE_ID } from "../../logics/optionUtils";
 import { useStore } from "../../useStore";
 import { ExRViewerOptionRow } from "./ExRViewerOptionRow";
 
@@ -14,6 +16,13 @@ export function ExRGeneralCategory({ categoryId }: ExRGeneralCategoryProps) {
 	const categoryMeta = exrOptionMetaData.categories[categoryId];
 	const topLevelOptionIds =
 		exrOptionMetaData.globalCategoryIdTopLevelMap[categoryId] || [];
+
+	const filteredOptionIds = useMemo(() => {
+		if (categoryId !== 0) {
+			return topLevelOptionIds;
+		}
+		return topLevelOptionIds.filter((id) => id !== PRESET_OPTION_UNIQUE_ID);
+	}, [categoryId, topLevelOptionIds]);
 
 	const openedExRCategoryIds = useStore((state) => {
 		return state.openedExRCategoryIds;
@@ -36,7 +45,7 @@ export function ExRGeneralCategory({ categoryId }: ExRGeneralCategoryProps) {
 				}}
 			>
 				<div className="flex flex-col gap-0.5">
-					{topLevelOptionIds.map((uniqueOptionId) => (
+					{filteredOptionIds.map((uniqueOptionId) => (
 						<ExRViewerOptionRow
 							key={uniqueOptionId}
 							uniqueOptionId={uniqueOptionId}

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -1,0 +1,19 @@
+import { exrOptionMetaData } from "../../logics/api";
+import { ExRTabId } from "../../type";
+import { ExRGeneralCategory } from "./ExRGeneralCategory";
+
+/**
+ * ExRの設定内容を表示し、ダブルクリックで該当箇所へ移動するコンポーネント
+ */
+export function ExROptionViewer() {
+	const generalTab = exrOptionMetaData.tabs[ExRTabId.GeneralTab];
+	const categoryIds = generalTab?.categoryIds || [];
+
+	return (
+		<div className="flex flex-col gap-1">
+			{categoryIds.map((categoryId) => (
+				<ExRGeneralCategory key={categoryId} categoryId={categoryId} />
+			))}
+		</div>
+	);
+}

--- a/src/feature/rightsidepanel/ExRViewerOptionRow.tsx
+++ b/src/feature/rightsidepanel/ExRViewerOptionRow.tsx
@@ -1,0 +1,49 @@
+import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
+import { useExRNavigation } from "../../hooks/useExRNavigation";
+import { exrOptionMetaData } from "../../logics/api";
+import { ExRTabId, type UniqueOptionId } from "../../type";
+import { useStore } from "../../useStore";
+import { ExRViewerOptionValue } from "./ExRViewerOptionValue";
+
+interface ExRViewerOptionRowProps {
+	uniqueOptionId: UniqueOptionId;
+	categoryId: number;
+}
+
+/**
+ * ExRの各設定項目の行コンポーネント（閲覧用）
+ */
+export function ExRViewerOptionRow({
+	uniqueOptionId,
+	categoryId,
+}: ExRViewerOptionRowProps) {
+	const exrValue = useStore((state) => state.exrValue[uniqueOptionId]);
+	const isActive = useStore((state) => state.isExROptionActive[uniqueOptionId]);
+	const { navigateToExROption } = useExRNavigation();
+
+	const optionMeta = exrOptionMetaData.options[uniqueOptionId];
+	if (!optionMeta || !isActive) {
+		return null;
+	}
+
+	const selection = exrValue?.selection ?? 0;
+	const value = exrValue?.values[selection];
+
+	return (
+		<div className="border-white border-b">
+			<ViewerOptionRow
+				title={optionMeta.metaData.translatedName}
+				value={
+					<ExRViewerOptionValue
+						value={value}
+						format={optionMeta.metaData.format}
+					/>
+				}
+				onDoubleClick={() => {
+					navigateToExROption(ExRTabId.GeneralTab, categoryId, uniqueOptionId);
+				}}
+				testId={`right-panel-exr-option-${uniqueOptionId}`}
+			/>
+		</div>
+	);
+}

--- a/src/feature/rightsidepanel/ExRViewerOptionValue.tsx
+++ b/src/feature/rightsidepanel/ExRViewerOptionValue.tsx
@@ -1,0 +1,34 @@
+import { ColoredText } from "../../components/parts/ColoredText";
+import { OptionFormat } from "../../components/parts/OptionFormat";
+
+interface ExRViewerOptionValueProps {
+	value: string | number | undefined;
+	format: string;
+}
+
+/**
+ * ExRの設定値を表示用にフォーマットするコンポーネント
+ */
+export function ExRViewerOptionValue({
+	value,
+	format,
+}: ExRViewerOptionValueProps) {
+	if (value === undefined) {
+		return <span className="text-gray-400">-</span>;
+	}
+
+	const isString = typeof value === "string";
+
+	return (
+		<div className="flex items-center gap-1 shrink-0">
+			<span className="text-sm text-blue-400 font-medium text-right">
+				{isString ? <ColoredText text={value} /> : value.toString()}
+			</span>
+			{!isString && (
+				<div className="text-[10px] scale-90 origin-right">
+					<OptionFormat format={format} />
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -4,7 +4,6 @@ import { getAllOptions } from "../../logics/api.store";
 import {
 	AU_SETTINGS_TITLE,
 	CLOSE,
-	EXR_CONTENT_TEMP,
 	EXR_SETTINGS_TITLE,
 	PANEL_CLOSE_ARIA,
 	PANEL_OPEN_ARIA,
@@ -13,6 +12,7 @@ import {
 } from "../../noTrans";
 import { useStore } from "../../useStore";
 import { AuOptionViewer } from "./AuOptionViewer";
+import { ExROptionViewer } from "./ExROptionViewer";
 
 /**
  * 右フローティングパネルコンポーネント
@@ -101,7 +101,7 @@ export function RightFloatingPanel() {
 									isOpen={isExrSettingsOpen}
 									onToggle={toggleExrSettings}
 								>
-									<p className="text-gray-400 text-sm">{EXR_CONTENT_TEMP}</p>
+									<ExROptionViewer />
 								</CompactAccordion>
 							</div>
 						</CompactAccordion>

--- a/src/hooks/useExRNavigation.ts
+++ b/src/hooks/useExRNavigation.ts
@@ -1,0 +1,52 @@
+import type { ExRTabId, UniqueOptionId } from "../type";
+import { useStore } from "../useStore";
+
+/**
+ * ExRの設定項目をダブルクリックした際のナビゲーションとハイライトを行うフック
+ */
+export function useExRNavigation() {
+	const setSelectedTab = useStore((state) => {
+		return state.setSelectedTab;
+	});
+	const setSelectedExRTabId = useStore((state) => {
+		return state.setSelectedExRTabId;
+	});
+	const toggleExRCategory = useStore((state) => {
+		return state.toggleExRCategory;
+	});
+	const openedExRCategoryIds = useStore((state) => {
+		return state.openedExRCategoryIds;
+	});
+	const setHighlightedExROptionId = useStore((state) => {
+		return state.setHighlightedExROptionId;
+	});
+	const setRightPanelOpen = useStore((state) => {
+		return state.setRightPanelOpen;
+	});
+
+	const navigateToExROption = (
+		tabId: ExRTabId,
+		categoryId: number,
+		uniqueOptionId: UniqueOptionId,
+	) => {
+		setRightPanelOpen(false);
+		setSelectedTab("ExR");
+		setSelectedExRTabId(tabId);
+		if (!openedExRCategoryIds[categoryId]) {
+			toggleExRCategory(categoryId);
+		}
+		setHighlightedExROptionId(uniqueOptionId);
+
+		setTimeout(() => {
+			const element = document.getElementById(`exr-option-${uniqueOptionId}`);
+			if (element) {
+				element.scrollIntoView({ behavior: "smooth", block: "center" });
+			}
+			setTimeout(() => {
+				setHighlightedExROptionId(null);
+			}, 2000);
+		}, 100);
+	};
+
+	return { navigateToExROption };
+}

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -20,6 +20,7 @@ export interface ExROptionViewerSlice {
 	isExRTabPending: boolean;
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<number, boolean>;
+	highlightedExROptionId: UniqueOptionId | null;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
 	exrValue: Record<UniqueOptionId, ExROptionValueData>;
@@ -28,6 +29,7 @@ export interface ExROptionViewerSlice {
 	setIsExRTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: UniqueOptionId) => void;
+	setHighlightedExROptionId: (id: UniqueOptionId | null) => void;
 	updateExROption: (updateOptions: (UpdatedOptions | null)[]) => void;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
@@ -50,6 +52,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		isExRTabPending: false,
 		openedExRCategoryIds: {},
 		openedExROptionIds: {},
+		highlightedExROptionId: null,
 		exrValue: {},
 		isExROptionActive: {},
 		presetNames: loadPresetNamesFromLocalStorage(),
@@ -78,6 +81,9 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 					},
 				};
 			});
+		},
+		setHighlightedExROptionId: (id: UniqueOptionId | null) => {
+			set({ highlightedExROptionId: id });
 		},
 		toggleExROption: (uniqueOptionId: number) => {
 			set((state) => {

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -1,0 +1,142 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExROptionViewer } from "../src/feature/rightsidepanel/ExROptionViewer";
+import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import { getAllOptions, resetApiCache } from "../src/logics/api.store";
+import type { ExRTabDto, UniqueOptionId } from "../src/type";
+import { ExRTabId } from "../src/type";
+import { useStore } from "../src/useStore";
+
+describe("ExROptionViewer", () => {
+	beforeEach(async () => {
+		resetApiCache();
+		resetExrOptionMetaData();
+		useStore.getState().resetAll();
+		useStore.getState().resetViewer();
+
+		const mockExRData: ExRTabDto[] = [
+			{
+				Id: ExRTabId.GeneralTab,
+				Name: "General",
+				Categories: [
+					{
+						Id: 1,
+						Name: "Game Settings",
+						Options: [
+							{
+								Id: 10,
+								IsActive: true,
+								TranslatedName: "Game Mode",
+								Selection: 0,
+								Format: "{0}",
+								RangeMeta: { Type: "String", Values: ["Normal", "Hard"] },
+								Childs: [],
+							},
+						],
+					},
+				],
+			},
+		];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((input: RequestInfo | URL) => {
+				const url = typeof input === "string" ? input : input.toString();
+				if (url.includes("/exr/option/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue(mockExRData),
+					} as unknown as Response);
+				}
+				if (url.includes("/au/option/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue([]),
+					} as unknown as Response);
+				}
+				if (url.includes("/au/translation/batch/optionunit/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue([]),
+					} as unknown as Response);
+				}
+				if (url.includes("/au/translation/batch/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue([]),
+					} as unknown as Response);
+				}
+				return Promise.reject(new Error(`Unhandled URL: ${url}`));
+			}),
+		);
+
+		await getAllOptions();
+	});
+
+	it("renders GeneralTab categories and options", async () => {
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<ExROptionViewer />
+				</Suspense>,
+			);
+		});
+
+		expect(screen.getByText("Game Settings")).toBeInTheDocument();
+		expect(screen.getByText("Game Mode")).toBeInTheDocument();
+		expect(screen.getByText("Normal")).toBeInTheDocument();
+	});
+
+	it("calls store actions and scroll on double click", async () => {
+		const uniqueOptionId = Number(
+			Object.keys(exrOptionMetaData.options)[0],
+		) as unknown as UniqueOptionId;
+
+		const setSelectedTabSpy = vi.spyOn(useStore.getState(), "setSelectedTab");
+		const setSelectedExRTabIdSpy = vi.spyOn(
+			useStore.getState(),
+			"setSelectedExRTabId",
+		);
+		const setHighlightedExROptionIdSpy = vi.spyOn(
+			useStore.getState(),
+			"setHighlightedExROptionId",
+		);
+
+		// scrollIntoView のモック
+		const scrollIntoViewMock = vi.fn();
+		window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+		// getElementById のモック
+		const mockElement = document.createElement("div");
+		mockElement.id = `exr-option-${uniqueOptionId}`;
+		vi.spyOn(document, "getElementById").mockReturnValue(mockElement);
+
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<ExROptionViewer />
+				</Suspense>,
+			);
+		});
+
+		const row = screen.getByText("Game Mode").closest("button");
+		if (!row) {
+			throw new Error("Row not found");
+		}
+
+		fireEvent.doubleClick(row);
+
+		expect(setSelectedTabSpy).toHaveBeenCalledWith("ExR");
+		expect(setSelectedExRTabIdSpy).toHaveBeenCalledWith(ExRTabId.GeneralTab);
+		expect(setHighlightedExROptionIdSpy).toHaveBeenCalledWith(uniqueOptionId);
+
+		// setTimeout の処理待ち
+		await vi.waitFor(
+			() => {
+				expect(scrollIntoViewMock).toHaveBeenCalled();
+			},
+			{ timeout: 500 },
+		);
+	});
+});


### PR DESCRIPTION
This PR implements the requested ExR General Tab viewer in the right side panel, matching the style and functionality of the existing AmongUs option viewer.

Key features:
- **ExR Settings Display:** Lists all categories and options from the ExR General Tab in the right floating panel.
- **Accordion Layout:** Uses `CompactAccordion` to organize settings by category, consistent with `AuOptionViewer`.
- **Navigation on Double-Click:** Users can double-click any option in the viewer to automatically switch to the ExR tab, expand the relevant category, and scroll to the option in the main editor.
- **Highlighting:** The target option in the main editor is briefly highlighted when navigated to from the viewer.

Implementation details:
- Created `ExROptionViewer`, `ExRGeneralCategory`, `ExRViewerOptionRow`, and `ExRViewerOptionValue`.
- Added `highlightedExROptionId` state to `ExROptionViewerSlice`.
- Created `useExRNavigation` hook to encapsulate navigation logic.
- Updated `ExROptionRow` to render `HighlightWrapper` and provide an ID for scrolling.
- Integrated the new viewer into `RightFloatingPanel`, replacing the previous placeholder.
- Added unit tests in `tests/ExROptionViewer.test.tsx`.

---
*PR created automatically by Jules for task [3686818308635099255](https://jules.google.com/task/3686818308635099255) started by @yukieiji*