### PR TITLE
Implement ExROptionViewer for ExR General Tab settings

### DIFF
--- a/src/components/blocks/ExROptionRow.tsx
+++ b/src/components/blocks/ExROptionRow.tsx
@@ -18,11 +18,13 @@ export function ExROptionRow({
 	isLeaf = false,
 }: ExROptionRowProps) {
 	return isLeaf ? (
-		<OptionRowContainer
-			leading={<LargePoint />}
-			content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
-			className={depth > 0 ? "border-l-2 border-blue-500/30 ml-4" : ""}
-		/>
+		<div id={`exr-option-${uniqueOptionId}`}>
+			<OptionRowContainer
+				leading={<LargePoint />}
+				content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
+				className={depth > 0 ? "border-l-2 border-blue-500/30 ml-4" : ""}
+			/>
+		</div>
 	) : (
 		<ExROptionRowContent uniqueOptionId={uniqueOptionId} />
 	);

--- a/src/components/blocks/ExROptionRowContent.tsx
+++ b/src/components/blocks/ExROptionRowContent.tsx
@@ -1,8 +1,8 @@
-import { HighlightWrapper } from "../parts/HighlightWrapper";
 import { ExROptionControl } from "../../feature/exr/ExROptionControl";
 import { exrOptionMetaData } from "../../logics/api";
-import { useStore } from "../../useStore";
 import type { UniqueOptionId } from "../../type";
+import { useStore } from "../../useStore";
+import { HighlightWrapper } from "../parts/HighlightWrapper";
 import { OptionItem } from "../parts/OptionItem";
 import { OptionNameDisplay } from "../parts/OptionNameDisplay";
 

--- a/src/components/blocks/ExROptionRowContent.tsx
+++ b/src/components/blocks/ExROptionRowContent.tsx
@@ -1,5 +1,7 @@
+import { HighlightWrapper } from "../parts/HighlightWrapper";
 import { ExROptionControl } from "../../feature/exr/ExROptionControl";
 import { exrOptionMetaData } from "../../logics/api";
+import { useStore } from "../../useStore";
 import type { UniqueOptionId } from "../../type";
 import { OptionItem } from "../parts/OptionItem";
 import { OptionNameDisplay } from "../parts/OptionNameDisplay";
@@ -12,23 +14,30 @@ export function ExROptionRowContent({
 	uniqueOptionId,
 }: ExROptionRowContentProps) {
 	const optionData = exrOptionMetaData.options[uniqueOptionId]?.metaData;
+	const highlightedExROptionId = useStore(
+		(state) => state.highlightedExROptionId,
+	);
+	const isHighlighted = highlightedExROptionId === uniqueOptionId;
+
 	if (!optionData) {
 		return null;
 	}
 	return (
-		<OptionItem className="min-h-12">
-			<div className="flex-1 min-w-0">
-				<span className="text-sm font-medium text-gray-200 wrap-break-words">
-					<OptionNameDisplay name={optionData.translatedName} />
-				</span>
-			</div>
-			<div className="shrink-0 flex items-center gap-2">
-				<ExROptionControl
-					uniqueOptionId={uniqueOptionId}
-					format={optionData.format}
-					type={optionData.type}
-				/>
-			</div>
-		</OptionItem>
+		<HighlightWrapper isHighlighted={isHighlighted}>
+			<OptionItem className="min-h-12">
+				<div className="flex-1 min-w-0">
+					<span className="text-sm font-medium text-gray-200 wrap-break-words">
+						<OptionNameDisplay name={optionData.translatedName} />
+					</span>
+				</div>
+				<div className="shrink-0 flex items-center gap-2">
+					<ExROptionControl
+						uniqueOptionId={uniqueOptionId}
+						format={optionData.format}
+						type={optionData.type}
+					/>
+				</div>
+			</OptionItem>
+		</HighlightWrapper>
 	);
 }

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -1,0 +1,22 @@
+import { exrOptionMetaData } from "../../logics/api";
+import { ExRTabId } from "../../type";
+import { ExRViewerCategory } from "./ExRViewerCategory";
+
+/**
+ * ExRの設定内容を表示するコンポーネント
+ */
+export function ExROptionViewer() {
+	const generalTab = exrOptionMetaData.tabs[ExRTabId.GeneralTab];
+
+	if (!generalTab) {
+		return null;
+	}
+
+	return (
+		<div className="flex flex-col gap-1">
+			{generalTab.categoryIds.map((categoryId) => (
+				<ExRViewerCategory key={categoryId} categoryId={categoryId} />
+			))}
+		</div>
+	);
+}

--- a/src/feature/rightsidepanel/ExRViewerCategory.tsx
+++ b/src/feature/rightsidepanel/ExRViewerCategory.tsx
@@ -2,10 +2,7 @@ import { CompactAccordion } from "../../components/blocks/CompactAccordion";
 import { exrOptionMetaData } from "../../logics/api";
 import { groupOptionPairs } from "../../logics/optionUtils";
 import { useStore } from "../../useStore";
-import {
-	ExRViewerMinMaxRow,
-	ExRViewerOptionRow,
-} from "./ExRViewerOptionRow";
+import { ExRViewerMinMaxRow, ExRViewerOptionRow } from "./ExRViewerOptionRow";
 
 interface ExRViewerCategoryProps {
 	categoryId: number;
@@ -43,7 +40,7 @@ export function ExRViewerCategory({ categoryId }: ExRViewerCategoryProps) {
 			}}
 		>
 			<div className="flex flex-col gap-0.5">
-				{groupedOptions.map((item, idx) => {
+				{groupedOptions.map((item, _idx) => {
 					if (typeof item === "number") {
 						return <ExRViewerOptionRow key={item} uniqueOptionId={item} />;
 					}

--- a/src/feature/rightsidepanel/ExRViewerCategory.tsx
+++ b/src/feature/rightsidepanel/ExRViewerCategory.tsx
@@ -1,0 +1,62 @@
+import { CompactAccordion } from "../../components/blocks/CompactAccordion";
+import { exrOptionMetaData } from "../../logics/api";
+import { groupOptionPairs } from "../../logics/optionUtils";
+import { useStore } from "../../useStore";
+import {
+	ExRViewerMinMaxRow,
+	ExRViewerOptionRow,
+} from "./ExRViewerOptionRow";
+
+interface ExRViewerCategoryProps {
+	categoryId: number;
+}
+
+/**
+ * ExRのカテゴリコンポーネント（右パネル用）
+ */
+export function ExRViewerCategory({ categoryId }: ExRViewerCategoryProps) {
+	const categoryMeta = exrOptionMetaData.categories[categoryId];
+	const openedExRCategoryIds = useStore((state) => state.openedExRCategoryIds);
+	const toggleExRCategory = useStore((state) => state.toggleExRCategory);
+	const isExROptionActive = useStore((state) => state.isExROptionActive);
+
+	if (!categoryMeta) {
+		return null;
+	}
+
+	const allOptionIds =
+		exrOptionMetaData.globalCategoryIdTopLevelMap[categoryId] || [];
+	const activeOptionIds = allOptionIds.filter((id) => isExROptionActive[id]);
+
+	if (activeOptionIds.length === 0) {
+		return null;
+	}
+
+	const groupedOptions = groupOptionPairs(activeOptionIds);
+
+	return (
+		<CompactAccordion
+			title={<span className="text-base">{categoryMeta.name}</span>}
+			isOpen={openedExRCategoryIds[categoryId] ?? true}
+			onToggle={() => {
+				toggleExRCategory(categoryId);
+			}}
+		>
+			<div className="flex flex-col gap-0.5">
+				{groupedOptions.map((item, idx) => {
+					if (typeof item === "number") {
+						return <ExRViewerOptionRow key={item} uniqueOptionId={item} />;
+					}
+					return (
+						<ExRViewerMinMaxRow
+							key={item.minData.uniqueOptionId}
+							baseName={item.baseName}
+							minUniqueId={item.minData.uniqueOptionId}
+							maxUniqueId={item.maxData.uniqueOptionId}
+						/>
+					);
+				})}
+			</div>
+		</CompactAccordion>
+	);
+}

--- a/src/feature/rightsidepanel/ExRViewerOptionRow.tsx
+++ b/src/feature/rightsidepanel/ExRViewerOptionRow.tsx
@@ -2,12 +2,7 @@ import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
 import { useExRNavigation } from "../../hooks/useExRNavigation";
 import { useOptionData } from "../../hooks/useOptionData";
 import { exrOptionMetaData } from "../../logics/api";
-import {
-	getBaseOptionName,
-	getOptionLabel,
-	isPresetOption,
-	parseUniqueOptionId,
-} from "../../logics/optionUtils";
+import { isPresetOption, parseUniqueOptionId } from "../../logics/optionUtils";
 import type { UniqueOptionId } from "../../type";
 import { useStore } from "../../useStore";
 import { AuTab0OptionValue } from "./AuTab0OptionValue";
@@ -19,7 +14,9 @@ interface ExRViewerOptionRowProps {
 /**
  * ExRの各設定項目の行コンポーネント
  */
-export function ExRViewerOptionRow({ uniqueOptionId }: ExRViewerOptionRowProps) {
+export function ExRViewerOptionRow({
+	uniqueOptionId,
+}: ExRViewerOptionRowProps) {
 	const optionValue = useOptionData(uniqueOptionId);
 	const { navigateToExROption } = useExRNavigation();
 	const presetNames = useStore((state) => state.presetNames);

--- a/src/feature/rightsidepanel/ExRViewerOptionRow.tsx
+++ b/src/feature/rightsidepanel/ExRViewerOptionRow.tsx
@@ -1,0 +1,104 @@
+import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
+import { useExRNavigation } from "../../hooks/useExRNavigation";
+import { useOptionData } from "../../hooks/useOptionData";
+import { exrOptionMetaData } from "../../logics/api";
+import {
+	getBaseOptionName,
+	getOptionLabel,
+	isPresetOption,
+	parseUniqueOptionId,
+} from "../../logics/optionUtils";
+import type { UniqueOptionId } from "../../type";
+import { useStore } from "../../useStore";
+import { AuTab0OptionValue } from "./AuTab0OptionValue";
+
+interface ExRViewerOptionRowProps {
+	uniqueOptionId: UniqueOptionId;
+}
+
+/**
+ * ExRの各設定項目の行コンポーネント
+ */
+export function ExRViewerOptionRow({ uniqueOptionId }: ExRViewerOptionRowProps) {
+	const optionValue = useOptionData(uniqueOptionId);
+	const { navigateToExROption } = useExRNavigation();
+	const presetNames = useStore((state) => state.presetNames);
+
+	const optionMetaDetail = exrOptionMetaData.options[uniqueOptionId];
+	if (!optionMetaDetail) {
+		return null;
+	}
+
+	const { tabId, categoryId, optionId } = parseUniqueOptionId(uniqueOptionId);
+	const { metaData } = optionMetaDetail;
+
+	const selection = optionValue.selection ?? 0;
+	let valueDisplay = optionValue.values[selection];
+
+	// プリセットの場合の特殊処理
+	if (isPresetOption(categoryId, optionId)) {
+		valueDisplay = presetNames[selection] ?? valueDisplay.toString();
+	}
+
+	return (
+		<div className="border-white border-b">
+			<ViewerOptionRow
+				title={metaData.translatedName}
+				value={
+					<AuTab0OptionValue value={valueDisplay} format={metaData.format} />
+				}
+				onDoubleClick={() => {
+					navigateToExROption(tabId, categoryId, uniqueOptionId);
+				}}
+				testId={`right-panel-exr-option-${uniqueOptionId}`}
+			/>
+		</div>
+	);
+}
+
+interface ExRViewerMinMaxRowProps {
+	baseName: string;
+	minUniqueId: UniqueOptionId;
+	maxUniqueId: UniqueOptionId;
+}
+
+export function ExRViewerMinMaxRow({
+	baseName,
+	minUniqueId,
+	maxUniqueId,
+}: ExRViewerMinMaxRowProps) {
+	const minOptionValue = useOptionData(minUniqueId);
+	const maxOptionValue = useOptionData(maxUniqueId);
+	const { navigateToExROption } = useExRNavigation();
+
+	const minMeta = exrOptionMetaData.options[minUniqueId]?.metaData;
+	const maxMeta = exrOptionMetaData.options[maxUniqueId]?.metaData;
+
+	if (!minMeta || !maxMeta) {
+		return null;
+	}
+
+	const { tabId, categoryId } = parseUniqueOptionId(minUniqueId);
+
+	const minVal = minOptionValue.values[minOptionValue.selection ?? 0];
+	const maxVal = maxOptionValue.values[maxOptionValue.selection ?? 0];
+
+	return (
+		<div className="border-white border-b">
+			<ViewerOptionRow
+				title={baseName}
+				value={
+					<div className="flex items-center gap-1">
+						<AuTab0OptionValue value={minVal} format={minMeta.format} />
+						<span className="text-gray-500">-</span>
+						<AuTab0OptionValue value={maxVal} format={maxMeta.format} />
+					</div>
+				}
+				onDoubleClick={() => {
+					navigateToExROption(tabId, categoryId, minUniqueId);
+				}}
+				testId={`right-panel-exr-minmax-${minUniqueId}`}
+			/>
+		</div>
+	);
+}

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -4,7 +4,6 @@ import { getAllOptions } from "../../logics/api.store";
 import {
 	AU_SETTINGS_TITLE,
 	CLOSE,
-	EXR_CONTENT_TEMP,
 	EXR_SETTINGS_TITLE,
 	PANEL_CLOSE_ARIA,
 	PANEL_OPEN_ARIA,

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../noTrans";
 import { useStore } from "../../useStore";
 import { AuOptionViewer } from "./AuOptionViewer";
+import { ExROptionViewer } from "./ExROptionViewer";
 
 /**
  * 右フローティングパネルコンポーネント
@@ -101,7 +102,7 @@ export function RightFloatingPanel() {
 									isOpen={isExrSettingsOpen}
 									onToggle={toggleExrSettings}
 								>
-									<p className="text-gray-400 text-sm">{EXR_CONTENT_TEMP}</p>
+									<ExROptionViewer />
 								</CompactAccordion>
 							</div>
 						</CompactAccordion>

--- a/src/hooks/useExRNavigation.ts
+++ b/src/hooks/useExRNavigation.ts
@@ -1,0 +1,52 @@
+import type { UniqueOptionId } from "../type";
+import { useStore } from "../useStore";
+
+/**
+ * ExRの設定項目をダブルクリックした際のナビゲーションとハイライトを行うフック
+ */
+export function useExRNavigation() {
+	const setSelectedTab = useStore((state) => {
+		return state.setSelectedTab;
+	});
+	const setSelectedExRTabId = useStore((state) => {
+		return state.setSelectedExRTabId;
+	});
+	const toggleExRCategory = useStore((state) => {
+		return state.toggleExRCategory;
+	});
+	const openedExRCategoryIds = useStore((state) => {
+		return state.openedExRCategoryIds;
+	});
+	const setHighlightedExROptionId = useStore((state) => {
+		return state.setHighlightedExROptionId;
+	});
+	const setRightPanelOpen = useStore((state) => {
+		return state.setRightPanelOpen;
+	});
+
+	const navigateToExROption = (
+		tabId: number,
+		categoryId: number,
+		uniqueOptionId: UniqueOptionId,
+	) => {
+		setRightPanelOpen(false);
+		setSelectedTab("ExR");
+		setSelectedExRTabId(tabId);
+		if (!openedExRCategoryIds[categoryId]) {
+			toggleExRCategory(categoryId);
+		}
+		setHighlightedExROptionId(uniqueOptionId);
+
+		setTimeout(() => {
+			const element = document.getElementById(`exr-option-${uniqueOptionId}`);
+			if (element) {
+				element.scrollIntoView({ behavior: "smooth", block: "center" });
+			}
+			setTimeout(() => {
+				setHighlightedExROptionId(null);
+			}, 2000);
+		}, 100);
+	};
+
+	return { navigateToExROption };
+}

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -22,6 +22,7 @@ export interface ExROptionViewerSlice {
 	openedExROptionIds: Record<number, boolean>;
 	presetNames: Record<number, string>;
 	isPresetDropdownOpen: boolean;
+	highlightedExROptionId: UniqueOptionId | null;
 	exrValue: Record<UniqueOptionId, ExROptionValueData>;
 	isExROptionActive: Record<UniqueOptionId, boolean>;
 	setSelectedExRTabId: (id: ExRTabId) => void;
@@ -31,6 +32,7 @@ export interface ExROptionViewerSlice {
 	updateExROption: (updateOptions: (UpdatedOptions | null)[]) => void;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
+	setHighlightedExROptionId: (id: UniqueOptionId | null) => void;
 	resetViewer: () => void;
 	setExROptions: (
 		valueData: Record<UniqueOptionId, ExROptionValueData>,
@@ -54,6 +56,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		isExROptionActive: {},
 		presetNames: loadPresetNamesFromLocalStorage(),
 		isPresetDropdownOpen: false,
+		highlightedExROptionId: null,
 		setSelectedExRTabId: (id: ExRTabId) => {
 			set({ selectedExRTabId: id });
 		},
@@ -136,6 +139,9 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		},
 		setPresetDropdownOpen: (isOpen: boolean) => {
 			set({ isPresetDropdownOpen: isOpen });
+		},
+		setHighlightedExROptionId: (id: UniqueOptionId | null) => {
+			set({ highlightedExROptionId: id });
 		},
 		setExROptions: (
 			valueData: Record<number, ExROptionValueData>,

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "../src/logics/api";
 import { getAllOptions, resetApiCache } from "../src/logics/api.store";
 import { getUniqueOptionId } from "../src/logics/optionUtils";
-import { ExRTabId, type UniqueOptionId } from "../src/type";
+import { ExRTabId } from "../src/type";
 import { useStore } from "../src/useStore";
 
 describe("ExROptionViewer", () => {
@@ -83,7 +83,7 @@ describe("ExROptionViewer", () => {
 	});
 
 	it("renders General Tab categories and options", async () => {
-		const uniqueId = getUniqueOptionId(ExRTabId.GeneralTab, 1, 10);
+		const _uniqueId = getUniqueOptionId(ExRTabId.GeneralTab, 1, 10);
 
 		await act(async () => {
 			render(
@@ -121,7 +121,10 @@ describe("ExROptionViewer", () => {
 			},
 			childOptionIds: [],
 		};
-		exrOptionMetaData.globalCategoryIdTopLevelMap[1] = [minUniqueId, maxUniqueId];
+		exrOptionMetaData.globalCategoryIdTopLevelMap[1] = [
+			minUniqueId,
+			maxUniqueId,
+		];
 
 		useStore.getState().setExROptions(
 			{
@@ -167,10 +170,12 @@ describe("ExROptionViewer", () => {
 			childOptionIds: [],
 		};
 
-		useStore.getState().setExROptions(
-			{ [presetUniqueId]: { selection: 1, values: [1, 2] } },
-			{ [presetUniqueId]: true },
-		);
+		useStore
+			.getState()
+			.setExROptions(
+				{ [presetUniqueId]: { selection: 1, values: [1, 2] } },
+				{ [presetUniqueId]: true },
+			);
 		useStore.getState().updatePresetName(1, "My Custom Preset");
 
 		await act(async () => {

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -1,0 +1,236 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExROptionViewer } from "../src/feature/rightsidepanel/ExROptionViewer";
+import {
+	exrOptionMetaData,
+	resetExrOptionMetaData,
+	translationMetaData,
+} from "../src/logics/api";
+import { getAllOptions, resetApiCache } from "../src/logics/api.store";
+import { getUniqueOptionId } from "../src/logics/optionUtils";
+import { ExRTabId, type UniqueOptionId } from "../src/type";
+import { useStore } from "../src/useStore";
+
+describe("ExROptionViewer", () => {
+	beforeEach(async () => {
+		resetApiCache();
+		resetExrOptionMetaData();
+		useStore.getState().resetAll();
+		useStore.getState().resetViewer();
+		translationMetaData.booleanTransData = ["OFF", "ON"];
+
+		const mockExRData = [
+			{
+				Id: ExRTabId.GeneralTab,
+				Name: "General",
+				Categories: [
+					{
+						Id: 1,
+						Name: "Random Settings",
+						Options: [
+							{
+								Id: 10,
+								TranslatedName: "Option 1",
+								IsActive: true,
+								Selection: 0,
+								Format: "{0}",
+								RangeMeta: { Type: "Int32", Values: [0, 1] },
+								Childs: [],
+							},
+						],
+					},
+				],
+			},
+		];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((input: RequestInfo | URL) => {
+				const url = typeof input === "string" ? input : input.toString();
+				if (url.includes("/exr/option/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue(mockExRData),
+					} as unknown as Response);
+				}
+				if (url.includes("/au/option/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue([]),
+					} as unknown as Response);
+				}
+				if (url.includes("/au/translation/batch/optionunit/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue([]),
+					} as unknown as Response);
+				}
+				if (url.includes("/au/translation/batch/")) {
+					return Promise.resolve({
+						ok: true,
+						json: vi.fn().mockResolvedValue([
+							{ Key: "optionOff", Result: "OFF", Param: [] },
+							{ Key: "optionOn", Result: "ON", Param: [] },
+						]),
+					} as unknown as Response);
+				}
+				return Promise.reject(new Error(`Unhandled URL: ${url}`));
+			}),
+		);
+
+		await getAllOptions();
+	});
+
+	it("renders General Tab categories and options", async () => {
+		const uniqueId = getUniqueOptionId(ExRTabId.GeneralTab, 1, 10);
+
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<ExROptionViewer />
+				</Suspense>,
+			);
+		});
+
+		expect(screen.getByText("Random Settings")).toBeInTheDocument();
+		expect(screen.getByText("Option 1")).toBeInTheDocument();
+		expect(screen.getByText("0")).toBeInTheDocument();
+	});
+
+	it("groups Min-Max option pairs", async () => {
+		// モックデータをMin-Maxペアを含むように上書き
+		const minId = 11;
+		const maxId = 12;
+		const minUniqueId = getUniqueOptionId(ExRTabId.GeneralTab, 1, minId);
+		const maxUniqueId = getUniqueOptionId(ExRTabId.GeneralTab, 1, maxId);
+
+		exrOptionMetaData.options[minUniqueId] = {
+			metaData: {
+				translatedName: "Count Min",
+				format: "{0}",
+				type: "Int32",
+			},
+			childOptionIds: [],
+		};
+		exrOptionMetaData.options[maxUniqueId] = {
+			metaData: {
+				translatedName: "Count Max",
+				format: "{0}",
+				type: "Int32",
+			},
+			childOptionIds: [],
+		};
+		exrOptionMetaData.globalCategoryIdTopLevelMap[1] = [minUniqueId, maxUniqueId];
+
+		useStore.getState().setExROptions(
+			{
+				[minUniqueId]: { selection: 0, values: [1, 2] },
+				[maxUniqueId]: { selection: 1, values: [1, 2] },
+			},
+			{
+				[minUniqueId]: true,
+				[maxUniqueId]: true,
+			},
+		);
+
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<ExROptionViewer />
+				</Suspense>,
+			);
+		});
+
+		expect(screen.getByText("Count")).toBeInTheDocument();
+		expect(screen.getByText("1")).toBeInTheDocument();
+		expect(screen.getByText("-")).toBeInTheDocument();
+		expect(screen.getByText("2")).toBeInTheDocument();
+	});
+
+	it("uses preset names from store", async () => {
+		const presetUniqueId = getUniqueOptionId(ExRTabId.GeneralTab, 0, 0);
+
+		// カテゴリ0, オプション0 はプリセットとして扱われる
+		exrOptionMetaData.categories[0] = {
+			name: "Preset",
+			tabId: ExRTabId.GeneralTab,
+		};
+		exrOptionMetaData.tabs[ExRTabId.GeneralTab].categoryIds.unshift(0);
+		exrOptionMetaData.globalCategoryIdTopLevelMap[0] = [presetUniqueId];
+		exrOptionMetaData.options[presetUniqueId] = {
+			metaData: {
+				translatedName: "Preset",
+				format: "{0}",
+				type: "Int32",
+			},
+			childOptionIds: [],
+		};
+
+		useStore.getState().setExROptions(
+			{ [presetUniqueId]: { selection: 1, values: [1, 2] } },
+			{ [presetUniqueId]: true },
+		);
+		useStore.getState().updatePresetName(1, "My Custom Preset");
+
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<ExROptionViewer />
+				</Suspense>,
+			);
+		});
+
+		expect(screen.getByText("My Custom Preset")).toBeInTheDocument();
+	});
+
+	it("navigates and highlights on double click", async () => {
+		const uniqueId = getUniqueOptionId(ExRTabId.GeneralTab, 1, 10);
+
+		const setSelectedTabSpy = vi.spyOn(useStore.getState(), "setSelectedTab");
+		const setSelectedExRTabIdSpy = vi.spyOn(
+			useStore.getState(),
+			"setSelectedExRTabId",
+		);
+		const setHighlightedExROptionIdSpy = vi.spyOn(
+			useStore.getState(),
+			"setHighlightedExROptionId",
+		);
+
+		// scrollIntoView のモック
+		const scrollIntoViewMock = vi.fn();
+		window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+		// getElementById のモック
+		const mockElement = document.createElement("div");
+		mockElement.id = `exr-option-${uniqueId}`;
+		vi.spyOn(document, "getElementById").mockReturnValue(mockElement);
+
+		await act(async () => {
+			render(
+				<Suspense fallback={<div>Loading...</div>}>
+					<ExROptionViewer />
+				</Suspense>,
+			);
+		});
+
+		const row = screen.getByText("Option 1").closest("button");
+		if (!row) {
+			throw new Error("Row not found");
+		}
+
+		fireEvent.doubleClick(row);
+
+		expect(setSelectedTabSpy).toHaveBeenCalledWith("ExR");
+		expect(setSelectedExRTabIdSpy).toHaveBeenCalledWith(ExRTabId.GeneralTab);
+		expect(setHighlightedExROptionIdSpy).toHaveBeenCalledWith(uniqueId);
+
+		// setTimeout の処理待ち
+		await vi.waitFor(
+			() => {
+				expect(scrollIntoViewMock).toHaveBeenCalled();
+			},
+			{ timeout: 500 },
+		);
+	});
+});


### PR DESCRIPTION
This PR implements the ExROptionViewer component in the right panel, which displays the current settings for ExR's General Tab.

Key features:
- **General Tab Display**: Shows all active categories and options from the ExR General Tab.
- **Preset Name Integration**: Displays custom preset names stored in LocalStorage.
- **Min-Max Grouping**: Automatically groups options with "Min" and "Max" suffixes into a single "Min-Max" display row.
- **Navigation**: Double-clicking an option in the viewer navigates to the corresponding setting in the main view, with a brief highlight effect.
- **Dynamic Visibility**: Only shows categories and options that are currently active.

---
*PR created automatically by Jules for task [17266516370436741031](https://jules.google.com/task/17266516370436741031) started by @yukieiji*