### PR TITLE
E2Eテストの修正とtestid/id排除

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -32,11 +32,8 @@ test("ExR Option Accordion behavior", async ({ page }) => {
 	await expect(accordionButton).toBeVisible();
 
 	// 初期状態では閉じている
-	const accordionItem = page
-		.locator("div.border.border-gray-700")
-		.filter({ hasText: categoryName });
-	const contentContainer = accordionItem.getByTestId("accordion-content");
-	await expect(contentContainer).toHaveClass(/grid-rows-\[0fr\]/);
+	// aria-expandedで状態を確認する
+	await expect(accordionButton).toHaveAttribute("aria-expanded", "false");
 
 	// 閉じているときはオプション名が表示されていない（lazy rendering）
 	const optionName = page.getByText("強力なシャッフルを使用する");
@@ -44,7 +41,7 @@ test("ExR Option Accordion behavior", async ({ page }) => {
 
 	// アコーディオンを開く
 	await accordionButton.click();
-	await expect(contentContainer).toHaveClass(/grid-rows-\[1fr\]/);
+	await expect(accordionButton).toHaveAttribute("aria-expanded", "true");
 	await expect(optionName).toBeVisible();
 
 	// タブを切り替えてもアコーディオンの状態が維持されることを確認
@@ -69,6 +66,6 @@ test("ExR Option Accordion behavior", async ({ page }) => {
 
 	// アコーディオンを閉じる
 	await accordionButton.click();
-	await expect(contentContainer).toHaveClass(/grid-rows-\[0fr\]/);
+	await expect(accordionButton).toHaveAttribute("aria-expanded", "false");
 	await expect(optionName).not.toBeAttached();
 });

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -37,7 +37,8 @@ test("has sidebar and au option editor", async ({ page }) => {
 	await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible();
 
 	// アコーディオンが表示されていることを確認 (JSON preはなくなった)
-	await expect(page.getByTestId("category-list")).toBeVisible();
+	// data-testidを使わず、中に含まれるはずのカテゴリボタンで確認する
+	await expect(page.locator("main").getByText("map")).toBeVisible();
 
 	// ExR Options に切り替え
 	await sidebar.getByRole("button", { name: "ExR Options" }).click();

--- a/e2e/au-options.spec.ts
+++ b/e2e/au-options.spec.ts
@@ -30,7 +30,7 @@ test.describe("Au Option Interactions", () => {
 		await expect(page.locator("main").getByText("map")).toBeVisible();
 
 		// Map is now a direct dropdown (select element)
-		await expect(page.getByRole("combobox")).toBeVisible();
+await expect(page.locator("main").getByRole("combobox")).toBeVisible();
 	});
 
 	test("should display accordion for other general tab categories", async ({

--- a/e2e/au-options.spec.ts
+++ b/e2e/au-options.spec.ts
@@ -69,7 +69,7 @@ test.describe("Au Option Interactions", () => {
 		await expect(category.getByLabel("数")).toBeVisible();
 
 		// Accordion button should be disabled when chance is 0
-		const toggleButton = category.getByRole("button").first();
+const toggleButton = category.getByRole("button", { name: "科学者" });
 		await expect(toggleButton).toBeDisabled();
 	});
 

--- a/e2e/au-options.spec.ts
+++ b/e2e/au-options.spec.ts
@@ -13,38 +13,41 @@ test.beforeEach(async ({ page }) => {
 
 	// Au Options タブに切り替え
 	await page.getByRole("button", { name: "Au Options" }).click();
-	await page.waitForSelector('[data-testid="category-list"]');
+	await expect(page.locator("main").getByText("map")).toBeVisible();
 });
 
 test.describe("Au Option Interactions", () => {
 	test("should display dropdown for map category in general tab", async ({
 		page,
 	}) => {
-		// Tab 0 (General)
-		await page.getByRole("button", { name: "0", exact: true }).click();
+		// Tab 0
+		await page
+			.locator("main")
+			.getByRole("button", { name: "0", exact: true })
+			.click();
 
-		const category = page.getByTestId("au-category-0");
-		// In our new MapDropDown component, the title is displayed directly
-		await expect(category.getByText("map")).toBeVisible();
+		// "map" option title should be visible
+		await expect(page.locator("main").getByText("map")).toBeVisible();
 
 		// Map is now a direct dropdown (select element)
-		await expect(category.getByRole("combobox")).toBeVisible();
+		await expect(page.getByRole("combobox")).toBeVisible();
 	});
 
 	test("should display accordion for other general tab categories", async ({
 		page,
 	}) => {
-		// Tab 0 (General)
-		await page.getByRole("button", { name: "0", exact: true }).click();
+		// Tab 0
+		await page
+			.locator("main")
+			.getByRole("button", { name: "0", exact: true })
+			.click();
 
-		// index 1 category should still be an accordion
-		const category = page.getByTestId("au-category-1");
 		// "インポスター" is the title of the second category in mock data
-		await expect(category.getByText("インポスター")).toBeVisible();
+		await expect(page.locator("main").getByText("インポスター")).toBeVisible();
 
 		// Should be an accordion (button)
 		await expect(
-			category.getByRole("button", { name: "インポスター" }),
+			page.locator("main").getByRole("button", { name: "インポスター" }),
 		).toBeVisible();
 	});
 
@@ -52,26 +55,38 @@ test.describe("Au Option Interactions", () => {
 		page,
 	}) => {
 		// Tab 1
-		await page.getByRole("button", { name: "1", exact: true }).click();
+		await page
+			.locator("main")
+			.getByRole("button", { name: "1", exact: true })
+			.click();
 
-		// Initially chance is probably 0, so it's disabled
-		const category = page.getByTestId("category-list").locator("> div").first();
-		await expect(category.getByTestId("spawn-rate-control")).toBeVisible();
-		await expect(category.getByTestId("spawn-count-control")).toBeVisible();
+		// First category container (科学者)
+		const category = page
+			.locator("main")
+			.locator("div.border.border-gray-700")
+			.filter({ hasText: "科学者" });
+		await expect(category.getByLabel("レート")).toBeVisible();
+		await expect(category.getByLabel("数")).toBeVisible();
 
 		// Accordion button should be disabled when chance is 0
-		const toggleButton = category.locator("button").first();
+		const toggleButton = category.getByRole("button").first();
 		await expect(toggleButton).toBeDisabled();
 	});
 
 	test("should synchronize chance and max count in Au roles", async ({
 		page,
 	}) => {
-		await page.getByRole("button", { name: "1", exact: true }).click();
+		await page
+			.locator("main")
+			.getByRole("button", { name: "1", exact: true })
+			.click();
 
-		const category = page.getByTestId("category-list").locator("> div").first();
-		const chanceControl = category.getByTestId("spawn-rate-control");
-		const countControl = category.getByTestId("spawn-count-control");
+		const category = page
+			.locator("main")
+			.locator("div.border.border-gray-700")
+			.filter({ hasText: "科学者" });
+		const chanceControl = category.getByLabel("レート");
+		const countControl = category.getByLabel("数");
 
 		const chanceInput = chanceControl.locator('input[type="text"]');
 		const countInput = countControl.locator('input[type="text"]');
@@ -102,14 +117,20 @@ test.describe("Au Option Interactions", () => {
 	test("expanding role accordion should show other options", async ({
 		page,
 	}) => {
-		await page.getByRole("button", { name: "1", exact: true }).click();
+		await page
+			.locator("main")
+			.getByRole("button", { name: "1", exact: true })
+			.click();
 
-		const category = page.getByTestId("category-list").locator("> div").first();
-		const toggleButton = category.locator("button").first();
+		const category = page
+			.locator("main")
+			.locator("div.border.border-gray-700")
+			.filter({ hasText: "科学者" });
+		const toggleButton = category.getByRole("button").first();
 
 		// Set chance to 100% to enable accordion
 		await category
-			.getByTestId("spawn-rate-control")
+			.getByLabel("レート")
 			.locator('input[type="range"]')
 			.fill("10");
 

--- a/e2e/auRoleViewer.spec.ts
+++ b/e2e/auRoleViewer.spec.ts
@@ -26,8 +26,10 @@ test.describe("Au Role Viewer in Right Panel", () => {
 		await expect(imposterRolesSection).toBeVisible();
 
 		// 3. 役職の内容を確認
-		const roleRow = rightPanel.getByTestId(/^right-panel-role-/).first();
-		await expect(roleRow).toContainText("シェイプシフター");
+		const roleRow = rightPanel.getByRole("button", {
+			name: /シェイプシフター/,
+		});
+		await expect(roleRow).toBeVisible();
 		// 50% / 15 のような表示形式
 		await expect(roleRow).toContainText("50%");
 		await expect(roleRow).toContainText("15");

--- a/e2e/auTab0Navigation.spec.ts
+++ b/e2e/auTab0Navigation.spec.ts
@@ -40,7 +40,9 @@ test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 			await imposterCategory.click();
 		}
 
-		const impCountSetting = page.getByTestId("right-panel-option-10200");
+		const impCountSetting = page
+			.getByLabel("右フローティングパネル")
+			.getByRole("button", { name: "インポスター数" });
 		// スクロールが必要な場合がある
 		await impCountSetting.scrollIntoViewIfNeeded();
 		await expect(impCountSetting).toBeVisible({ timeout: 15000 });
@@ -74,6 +76,7 @@ test.describe("AmongUs Tab 0 Navigation from Right Panel", () => {
 		await expect(impCountRow).toHaveClass(/ring-blue-500/);
 
 		// 7. 数秒後にハイライトが消えることを確認
-		await expect(impCountRow).not.toHaveClass(/ring-2/, { timeout: 15000 });
+		// ハイライトが消えるのを待つためにタイムアウトを長めに設定
+		await expect(impCountRow).not.toHaveClass(/ring-2/, { timeout: 30000 });
 	});
 });

--- a/e2e/au_role_accordion_auto_open.spec.ts
+++ b/e2e/au_role_accordion_auto_open.spec.ts
@@ -16,19 +16,23 @@ test.describe("Au Role Accordion Auto Open", () => {
 	test("should open accordion when role is enabled by chance or max count", async ({
 		page,
 	}) => {
-		// Au Options の 役職タブ（タブ 1）に移動
-		await page.getByRole("button", { name: "1", exact: true }).first().click();
+		// Au Options の 役職タブ（インポスター）に移動
+		await page
+			.locator("main")
+			.getByRole("button", { name: "1", exact: true })
+			.click();
 
 		// 科学者 (Scientist)
 		const category = page
-			.getByTestId("role-category")
+			.locator("main")
+			.locator("div.border.border-gray-700")
 			.filter({ hasText: "科学者" });
 		const toggleButton = category.getByRole("button").first();
 		const chanceSlider = category
-			.getByTestId("spawn-rate-control")
+			.getByLabel("レート")
 			.locator('input[type="range"]');
 		const countSlider = category
-			.getByTestId("spawn-count-control")
+			.getByLabel("数")
 			.locator('input[type="range"]');
 
 		// 初期状態：閉じていて無効

--- a/e2e/exr_role_accordion_disabled.spec.ts
+++ b/e2e/exr_role_accordion_disabled.spec.ts
@@ -16,7 +16,9 @@ test.beforeEach(async ({ page }) => {
 
 	// ExR Options タブに切り替え
 	await page.getByRole("button", { name: "ExR Options" }).click();
-	await page.waitForSelector('[data-testid="category-list"]');
+	await expect(
+		page.getByRole("button", { name: "グローバル設定" }),
+	).toBeVisible();
 });
 
 test.describe("ExR Role Accordion Disabled State", () => {
@@ -26,24 +28,23 @@ test.describe("ExR Role Accordion Disabled State", () => {
 			.click();
 
 		const sheriffCategory = page
-			.getByTestId("role-category")
+			.locator("div.border.border-gray-700")
 			.filter({ hasText: "シェリフ" });
 		const toggleButton = sheriffCategory.getByRole("button", {
 			name: "シェリフ",
 		});
 		const rateSlider = sheriffCategory
-			.getByTestId("spawn-rate-control")
+			.getByLabel("レート")
 			.locator('input[type="range"]');
 
 		// 1. まずレートを 10% にすると、自動的に開くことを確認
 		await rateSlider.fill("1"); // 10%
-		const content = sheriffCategory.getByTestId("accordion-content");
-		await expect(content).toBeVisible();
-		await expect(content).toHaveClass(/grid-rows-\[1fr\]/);
+		await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+		await expect(sheriffCategory.locator(".bg-gray-900")).toBeVisible();
 
 		// 2. レートを 0% にするとアコーディオンが閉じ、無効化されることを確認
 		await rateSlider.fill("0"); // 0%
-		await expect(content).not.toBeVisible();
+		await expect(toggleButton).toHaveAttribute("aria-expanded", "false");
 		await expect(toggleButton).toBeDisabled();
 
 		// 3. アイコンがドット「・」になっていることを確認
@@ -56,15 +57,14 @@ test.describe("ExR Role Accordion Disabled State", () => {
 		await expect(toggleButton.locator("svg")).toBeVisible();
 		await expect(toggleButton.getByText("・")).not.toBeVisible();
 		await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
-		await expect(content).toBeVisible();
-		await expect(content).toHaveClass(/grid-rows-\[1fr\]/);
+		await expect(sheriffCategory.locator(".bg-gray-900")).toBeVisible();
 
 		// 5. 一旦閉じてから数を変更しても自動的に開くことを確認
 		await toggleButton.click();
 		await expect(toggleButton).toHaveAttribute("aria-expanded", "false");
 
 		const countSlider = sheriffCategory
-			.getByTestId("spawn-count-control")
+			.getByLabel("数")
 			.locator('input[type="range"]');
 
 		// 既にレートが10%なので、数を変更しても自動では開かないはず（今回の要件は「0から有効になった時」）
@@ -75,7 +75,6 @@ test.describe("ExR Role Accordion Disabled State", () => {
 		await countSlider.fill("2"); // 数を2にする（0から0以外へ）
 		await expect(toggleButton).toBeEnabled();
 		await expect(toggleButton).toHaveAttribute("aria-expanded", "true");
-		await expect(content).toBeVisible();
-		await expect(content).toHaveClass(/grid-rows-\[1fr\]/);
+		await expect(sheriffCategory.locator(".bg-gray-900")).toBeVisible();
 	});
 });

--- a/e2e/exr_role_spawn_options.spec.ts
+++ b/e2e/exr_role_spawn_options.spec.ts
@@ -16,7 +16,9 @@ test.beforeEach(async ({ page }) => {
 
 	// ExR Options タブに切り替え
 	await page.getByRole("button", { name: "ExR Options" }).click();
-	await page.waitForSelector('[data-testid="category-list"]');
+	await expect(
+		page.getByRole("button", { name: "グローバル設定" }),
+	).toBeVisible();
 });
 
 test.describe("ExR Role Spawn Options in Header", () => {
@@ -30,14 +32,10 @@ test.describe("ExR Role Spawn Options in Header", () => {
 
 		// カテゴリ（シェリフ）のヘッダーに「レート」と「数」が表示されていることを確認
 		const sheriffCategory = page
-			.getByTestId("role-category")
+			.locator("div.border.border-gray-700")
 			.filter({ hasText: "シェリフ" });
-		await expect(
-			sheriffCategory.getByTestId("spawn-rate-control"),
-		).toBeVisible();
-		await expect(
-			sheriffCategory.getByTestId("spawn-count-control"),
-		).toBeVisible();
+		await expect(sheriffCategory.getByLabel("レート")).toBeVisible();
+		await expect(sheriffCategory.getByLabel("数")).toBeVisible();
 	});
 
 	test("should synchronize spawn rate and count", async ({ page }) => {
@@ -46,10 +44,10 @@ test.describe("ExR Role Spawn Options in Header", () => {
 			.click();
 
 		const sheriffCategory = page
-			.getByTestId("role-category")
+			.locator("div.border.border-gray-700")
 			.filter({ hasText: "シェリフ" });
-		const rateControl = sheriffCategory.getByTestId("spawn-rate-control");
-		const countControl = sheriffCategory.getByTestId("spawn-count-control");
+		const rateControl = sheriffCategory.getByLabel("レート");
+		const countControl = sheriffCategory.getByLabel("数");
 
 		const rateInput = rateControl.locator('input[type="text"]');
 		const countInput = countControl.locator('input[type="text"]');
@@ -91,7 +89,7 @@ test.describe("ExR Role Spawn Options in Header", () => {
 			.click();
 
 		const sheriffCategory = page
-			.getByTestId("role-category")
+			.locator("div.border.border-gray-700")
 			.filter({ hasText: "シェリフ" });
 		const content = sheriffCategory.locator(".bg-gray-900"); // Body area
 
@@ -100,7 +98,7 @@ test.describe("ExR Role Spawn Options in Header", () => {
 
 		// レートを 0% から 10% に変更（アコーディオンを有効化 -> 自動で開く）
 		const rateSlider = sheriffCategory
-			.getByTestId("spawn-rate-control")
+			.getByLabel("レート")
 			.locator('input[type="range"]');
 		await rateSlider.fill("1");
 
@@ -117,7 +115,7 @@ test.describe("ExR Role Spawn Options in Header", () => {
 
 		// 数も操作してみる
 		const countSlider = sheriffCategory
-			.getByTestId("spawn-count-control")
+			.getByLabel("数")
 			.locator('input[type="range"]');
 		await countSlider.fill("2");
 
@@ -137,12 +135,12 @@ test.describe("ExR Role Spawn Options in Header", () => {
 			.click();
 
 		const sheriffCategory = page
-			.getByTestId("role-category")
+			.locator("div.border.border-gray-700")
 			.filter({ hasText: "シェリフ" });
 
 		// レートを 10% に変更（アコーディオンを有効化 -> 自動で開く）
 		await sheriffCategory
-			.getByTestId("spawn-rate-control")
+			.getByLabel("レート")
 			.locator('input[type="range"]')
 			.fill("1");
 

--- a/e2e/exr_toggle.spec.ts
+++ b/e2e/exr_toggle.spec.ts
@@ -32,7 +32,7 @@ test("ExR toggle switch should be visible and functional", async ({ page }) => {
 	await categoryAccordion.click();
 
 	// '強力なシャッフルを使用する' オプションの横にあるトグルを確認
-	const toggle = page.getByTestId("option-toggle").first(); // 最初のトグルを取得
+	const toggle = page.getByRole("switch").first(); // 最初のトグルを取得
 	await expect(toggle).toBeVisible();
 
 	// 初期状態は オフ (Selection 0)

--- a/e2e/exr_toggle.spec.ts
+++ b/e2e/exr_toggle.spec.ts
@@ -32,7 +32,7 @@ test("ExR toggle switch should be visible and functional", async ({ page }) => {
 	await categoryAccordion.click();
 
 	// '強力なシャッフルを使用する' オプションの横にあるトグルを確認
-	const toggle = page.getByRole("switch").first(); // 最初のトグルを取得
+const toggle = page.locator("div").filter({ hasText: "強力なシャッフルを使用する" }).getByRole("switch");
 	await expect(toggle).toBeVisible();
 
 	// 初期状態は オフ (Selection 0)

--- a/e2e/loading.spec.ts
+++ b/e2e/loading.spec.ts
@@ -45,8 +45,9 @@ test("ExRタブ切り替え時にカテゴリリストが表示されること",
 		timeout: 15000,
 	});
 
-	const categoryList = page.getByTestId("category-list");
-	await expect(categoryList).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: "グローバル設定" }),
+	).toBeVisible();
 
 	const tabs = page.locator("button.px-4.py-2.rounded-t-lg");
 	const secondTab = tabs.nth(1);
@@ -56,6 +57,9 @@ test("ExRタブ切り替え時にカテゴリリストが表示されること",
 	// 別タブのコンテンツが表示されることを確認（暗黙的にローディング待ちが含まれる）
 	if (secondTabName) {
 		// タブ名が変更されているか、あるいはリストが再描画されていることを確認
-		await expect(categoryList).toBeVisible();
+		// カテゴリリストの代わりに、その中の要素が表示されることを確認
+		await expect(
+			page.getByRole("button").filter({ hasText: "設定" }).first(),
+		).toBeVisible();
 	}
 });

--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -46,7 +46,7 @@ test("Options interaction behavior", async ({ page }) => {
 	await expect(shuffleOption).toBeVisible({ timeout: 3000 });
 
 	// トグルスイッチに変更されたので、トグルを操作する
-	const toggle = page.getByTestId("option-toggle").first();
+	const toggle = page.getByRole("switch").first();
 	await expect(toggle).toHaveAttribute("aria-checked", "false");
 	await expect(page.getByText("オフ")).toBeVisible();
 

--- a/e2e/sync.spec.ts
+++ b/e2e/sync.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
 	await page.request.post("/mock/reset", { maxRetries: 5 });
 	await page.goto("/");
 	// wait for main content instead of just "Loading data..." absence
-	await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible({
+	await expect(page.getByText("map")).toBeVisible({
 		timeout: 15000,
 	});
 });
@@ -21,16 +21,14 @@ test("synchronization updates data and preserves UI state", async ({
 		page.getByRole("heading", { name: "ExR Options" }),
 	).toBeVisible();
 
-	// Use test-id which seems more stable
-	const category = page.getByTestId("exr-category-1");
+	// Use category button
+	const category = page.getByRole("button", { name: "乱数に関する設定" });
 	await expect(category).toBeVisible();
 	await category.click();
 
 	// Check if category content is visible
 	// Let's use a more robust check for content inside accordion
-	await expect(page.getByTestId("category-list")).toContainText(
-		"乱数に関する設定",
-	);
+	await expect(page.getByText("強力なシャッフルを使用する")).toBeVisible();
 
 	// 3. Perform synchronization
 	// Set artificial delay for sync to see the loading overlay


### PR DESCRIPTION
E2Eテストが失敗していた問題を修正し、同時に `AGENTS.md` の方針に従って `testid` や `id` を使用しない形式にリファクタリングしました。

主な変更点:
- `getByTestId` を全て削除し、アクセシビリティに基づいたロケーター（`getByRole`, `getByLabel` 等）に変更。
- アコーディオンの開閉状態の確認をクラス名ではなく `aria-expanded` 属性で行うように修正。
- モックデータの変更（タブ名やカテゴリ名の日本語化など）に合わせてテストケースを更新。
- タイムアウトや待機条件の微調整によるテストの安定化。

---
*PR created automatically by Jules for task [10289815227349715162](https://jules.google.com/task/10289815227349715162) started by @yukieiji*