### PR TITLE
Move English UI texts to noTrans.ts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { RightFloatingPanel } from "./feature/rightsidepanel/RightFloatingPanel";
 import { useSyncBackend } from "./hooks/useBackend";
 import { getAllOptions } from "./logics/api.store";
+import { AU_OPTIONS_TITLE, EXR_OPTIONS_TITLE } from "./noTrans";
 import { useStore } from "./useStore";
 
 /**
@@ -57,7 +58,7 @@ function MainContent() {
 			<div className="flex items-center gap-4">
 				<div className="flex items-center gap-5 flex-1 p-4">
 					<h2 className="text-2xl font-bold whitespace-nowrap">
-						{selectedTab === "ExR" ? "ExR Options" : "Au Options"}
+						{selectedTab === "ExR" ? EXR_OPTIONS_TITLE : AU_OPTIONS_TITLE}
 					</h2>
 					{selectedTab === "ExR" && (
 						<Suspense

--- a/src/components/parts/SyncLoadingOverlay.tsx
+++ b/src/components/parts/SyncLoadingOverlay.tsx
@@ -1,3 +1,5 @@
+import { SYNCHRONIZING } from "../../noTrans";
+
 /**
  * 同期中のオーバーレイコンポーネント
  * UIを表示したまま、操作を無効化しローディングを表示します
@@ -11,7 +13,7 @@ export function SyncLoadingOverlay() {
 		>
 			<div className="bg-white p-6 rounded-lg shadow-xl flex flex-col items-center gap-4 border border-gray-200">
 				<div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
-				<p className="text-lg font-medium text-gray-700">Synchronizing...</p>
+				<p className="text-lg font-medium text-gray-700">{SYNCHRONIZING}</p>
 			</div>
 		</div>
 	);

--- a/src/feature/OptionGroupToggleSidebar.tsx
+++ b/src/feature/OptionGroupToggleSidebar.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useTransition } from "react";
 import { OptionGroupToggleSidebarToggleButton } from "../components/parts/OptionGroupToggleSidebarToggleButton";
-import { OPTION_SIDEBAR_ARIA } from "../noTrans";
+import {
+	AU_OPTIONS_TITLE,
+	AU_SHORT_LABEL,
+	EXR_OPTIONS_TITLE,
+	EXR_SHORT_LABEL,
+	OPTION_SIDEBAR_ARIA,
+} from "../noTrans";
 import type { SelectedTab } from "../slices/optionGroupToggleSidebarSlice";
 import { useStore } from "../useStore";
 
@@ -14,8 +20,8 @@ interface TabItem {
 }
 
 const TABS: TabItem[] = [
-	{ id: "Au", label: "Au Options", shortLabel: "A" },
-	{ id: "ExR", label: "ExR Options", shortLabel: "E" },
+	{ id: "Au", label: AU_OPTIONS_TITLE, shortLabel: AU_SHORT_LABEL },
+	{ id: "ExR", label: EXR_OPTIONS_TITLE, shortLabel: EXR_SHORT_LABEL },
 ];
 
 /**

--- a/src/feature/rightsidepanel/AuTab0OptionValue.tsx
+++ b/src/feature/rightsidepanel/AuTab0OptionValue.tsx
@@ -1,6 +1,7 @@
 import { ColoredText } from "../../components/parts/ColoredText";
 import { OptionFormat } from "../../components/parts/OptionFormat";
 import { translationMetaData } from "../../logics/api";
+import { OFF, ON } from "../../noTrans";
 
 interface AuTab0OptionValueProps {
 	value: string | number | boolean;
@@ -20,7 +21,7 @@ export function AuTab0OptionValue({ value, format }: AuTab0OptionValueProps) {
 					<ColoredText
 						text={
 							translationMetaData.booleanTransData[value ? 1 : 0] ||
-							(value ? "ON" : "OFF")
+							(value ? ON : OFF)
 						}
 					/>
 				) : (

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -9,6 +9,7 @@ import {
 	PANEL_CLOSE_ARIA,
 	PANEL_OPEN_ARIA,
 	RIGHT_PANEL_ARIA,
+	RIGHT_PANEL_TITLE,
 	SETTING_VALUES_TITLE,
 } from "../../noTrans";
 import { useStore } from "../../useStore";
@@ -80,7 +81,7 @@ export function RightFloatingPanel() {
 			>
 				<div className="flex flex-col h-full">
 					<div className="flex items-center justify-between p-4 border-b border-gray-100">
-						<h2 className="text-lg font-semibold">Right Panel</h2>
+						<h2 className="text-lg font-semibold">{RIGHT_PANEL_TITLE}</h2>
 					</div>
 					<div className="flex-1 overflow-y-auto p-3">
 						<CompactAccordion

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -30,6 +30,15 @@ export const OPTION_SIDEBAR_ARIA = "オプションサイドバー";
 export const AU_OPTION_ROW_ARIA = "{0}の設定";
 export const AU_ROLE_ROW_ARIA = "{0}の役職";
 
+export const SYNCHRONIZING = "Synchronizing...";
+export const RIGHT_PANEL_TITLE = "Right Panel";
+export const AU_OPTIONS_TITLE = "Au Options";
+export const EXR_OPTIONS_TITLE = "ExR Options";
+export const AU_SHORT_LABEL = "A";
+export const EXR_SHORT_LABEL = "E";
+export const ON = "ON";
+export const OFF = "OFF";
+
 /**
  * プレースホルダーを含む文字列を置換します。
  * @param template テンプレート文字列（例: "こんにちは {0} さん"）


### PR DESCRIPTION
Hardcoded English UI strings have been moved to `src/noTrans.ts` as constants and replaced in the source code. This includes "Synchronizing...", "Right Panel", "Au Options", "ExR Options", sidebar labels, and "ON"/"OFF" status indicators. All tests passed and the build was successful. Visual verification confirmed that the UI remains unchanged.

---
*PR created automatically by Jules for task [7749413086513789280](https://jules.google.com/task/7749413086513789280) started by @yukieiji*