### PR TITLE
Add ExR preset display to right sidebar

### DIFF
--- a/e2e/exr_preset_sidebar.spec.ts
+++ b/e2e/exr_preset_sidebar.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	// モックサーバーの状態をリセット
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	// すべてのテストで API の遅延を設定可能にする
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 100;
+	});
+
+	await page.goto("/");
+
+	// ローディング画面が消えるのを待つ
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+});
+
+test("ExR preset display in right sidebar and navigation", async ({ page }) => {
+	// 1. 右パネルを開く
+	const openButton = page.getByLabel("パネルを開く");
+	await openButton.click();
+
+	// 右パネルが表示されていることを確認
+	const rightPanel = page.getByLabel("右フローティングパネル");
+	await expect(rightPanel).toBeVisible({ timeout: 10000 });
+
+	// 2. ExRの設定セクションを確認 (初期状態では開いている想定だが、必要ならスクロールして開く)
+	const exrSettingsTitle = page.getByText("ExRの設定");
+	await exrSettingsTitle.scrollIntoViewIfNeeded();
+
+	// プリセット名が表示されていることを確認。モックデータでは初期値 "1"
+	// ViewerOptionRow はボタンとして実装されている
+	const presetRow = page.getByRole("button", { name: "使用するプリセット 1" });
+	await expect(presetRow).toBeVisible();
+
+	// 3. ダブルクリックでナビゲーションを確認
+	await presetRow.dblclick();
+
+	// 右パネルが閉じていることを確認 (navigateToExROption 内で setRightPanelOpen(false) しているため)
+	// translate-x-full が適用されているはず。Playwright の toBeVisible は視覚的に見えなくなっても要素がDOMにあれば true を返す場合がある（特に transform の場合）
+	// ここでは、クラスの変化や aria-hidden などを確認するか、単に少し待つ
+	await expect(rightPanel).toHaveClass(/translate-x-full/);
+
+	// ExR タブが選択されていることを確認
+	const exrTabButton = page.getByRole("button", { name: "ExR Options" });
+	await expect(exrTabButton).toHaveClass(/bg-blue-500/);
+
+	// プリセットセレクターがハイライトされていることを確認
+	// HighlightWrapper は data-testid は持っていないが、ID を付与している
+	// ID は `exr-option-${PRESET_OPTION_UNIQUE_ID}`
+	// PRESET_OPTION_UNIQUE_ID は getUniqueOptionId(0, 0, 0) で 0
+	const highlightedElement = page.locator("#exr-option-0");
+
+	// ハイライトクラス (ring-2 ring-blue-500 など) が適用されているか確認
+	await expect(highlightedElement).toHaveClass(/ring-2/);
+});
+
+test("Updating preset name reflects in right sidebar", async ({ page }) => {
+	// 1. ExR タブに切り替え
+	const sidebar = page.getByLabel("オプションサイドバー");
+	await sidebar.getByRole("button", { name: "ExR Options" }).click();
+
+	// 2. プリセット名を変更
+	const presetInput = page.getByPlaceholder("プリセット名を入力...");
+	await presetInput.fill("New Custom Preset");
+	await presetInput.press("Enter");
+
+	// 3. 右パネルを開いて確認
+	const openButton = page.getByLabel("パネルを開く");
+	if (await openButton.isVisible()) {
+		await openButton.click();
+	}
+
+	const exrSettingsTitle = page.getByText("ExRの設定");
+	await exrSettingsTitle.scrollIntoViewIfNeeded();
+
+	// 変更後の名前が表示されていることを確認
+	const presetRow = page.getByRole("button", {
+		name: "使用するプリセット New Custom Preset",
+	});
+	await expect(presetRow).toBeVisible();
+});

--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -34,7 +34,10 @@ test("Options interaction behavior", async ({ page }) => {
 
 	// ドロップダウンを開いて名前が反映されているか確認
 	await page.getByRole("button", { name: "プリセットを選択" }).click();
-	await expect(page.getByText("Test Preset")).toBeVisible();
+	// ドロップダウン内の項目を特定するため、より具体的なロケータを使用（サイドバーにも同じテキストが表示されるため）
+	await expect(
+		page.getByRole("button", { name: "Test Preset" }).first(),
+	).toBeVisible();
 
 	// 別のカテゴリの操作を確認
 	const shuffleCategory = page.getByRole("button", {

--- a/src/feature/exr/PresetSelector.tsx
+++ b/src/feature/exr/PresetSelector.tsx
@@ -122,7 +122,7 @@ export function PresetSelector() {
 		<HighlightWrapper
 			id={`exr-option-${PRESET_OPTION_UNIQUE_ID}`}
 			isHighlighted={isHighlighted}
-			className="rounded"
+			isInset={false}
 		>
 			<div className="relative flex items-center gap-2" ref={dropdownRef}>
 				<div className="relative flex items-center bg-gray-800 border border-gray-700 rounded overflow-hidden focus-within:bg-gray-600">

--- a/src/feature/exr/PresetSelector.tsx
+++ b/src/feature/exr/PresetSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { HighlightWrapper } from "../../components/parts/HighlightWrapper";
 import { useBackendUpdate } from "../../hooks/useBackend";
 import { useOptionData } from "../../hooks/useOptionData";
@@ -40,13 +40,9 @@ export function PresetSelector() {
 		return state.setPresetDropdownOpen;
 	});
 	const setBlockDialog = useStore((state) => state.openBlockDialog);
-	const highlightedExROptionId = useStore(
-		(state) => state.highlightedExROptionId,
-	);
-
-	const isHighlighted = useMemo(() => {
-		return highlightedExROptionId === PRESET_OPTION_UNIQUE_ID;
-	}, [highlightedExROptionId]);
+	const isHighlighted = useStore((state) => {
+		return state.highlightedExROptionId === PRESET_OPTION_UNIQUE_ID;
+	});
 
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);

--- a/src/feature/exr/PresetSelector.tsx
+++ b/src/feature/exr/PresetSelector.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { HighlightWrapper } from "../../components/parts/HighlightWrapper";
 import { useBackendUpdate } from "../../hooks/useBackend";
 import { useOptionData } from "../../hooks/useOptionData";
 import { updateExrOption } from "../../logics/api";
@@ -39,6 +40,13 @@ export function PresetSelector() {
 		return state.setPresetDropdownOpen;
 	});
 	const setBlockDialog = useStore((state) => state.openBlockDialog);
+	const highlightedExROptionId = useStore(
+		(state) => state.highlightedExROptionId,
+	);
+
+	const isHighlighted = useMemo(() => {
+		return highlightedExROptionId === PRESET_OPTION_UNIQUE_ID;
+	}, [highlightedExROptionId]);
 
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -115,69 +123,75 @@ export function PresetSelector() {
 	};
 
 	return (
-		<div className="relative flex items-center gap-2" ref={dropdownRef}>
-			<div className="relative flex items-center bg-gray-800 border border-gray-700 rounded overflow-hidden focus-within:bg-gray-600">
-				<input
-					ref={inputRef}
-					type="text"
-					key={currentSelection}
-					defaultValue={currentPresetName}
-					onBlur={handleBlur}
-					onKeyDown={handleKeyDown}
-					className="px-3 py-1.5 text-sm bg-transparent text-gray-200 outline-none w-48"
-					placeholder={PRESET_INPUT_PLACEHOLDER}
-				/>
-				<button
-					type="button"
-					onClick={toggleDropdown}
-					className="px-2 py-1.5 bg-gray-700 hover:bg-gray-600 border-l border-gray-600 transition-colors"
-					aria-label={PRESET_SELECT_ARIA}
-				>
-					<svg
-						className={`w-4 h-4 text-gray-400 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
-						fill="none"
-						stroke="currentColor"
-						viewBox="0 0 24 24"
-						aria-hidden="true"
+		<HighlightWrapper
+			id={`exr-option-${PRESET_OPTION_UNIQUE_ID}`}
+			isHighlighted={isHighlighted}
+			className="rounded"
+		>
+			<div className="relative flex items-center gap-2" ref={dropdownRef}>
+				<div className="relative flex items-center bg-gray-800 border border-gray-700 rounded overflow-hidden focus-within:bg-gray-600">
+					<input
+						ref={inputRef}
+						type="text"
+						key={currentSelection}
+						defaultValue={currentPresetName}
+						onBlur={handleBlur}
+						onKeyDown={handleKeyDown}
+						className="px-3 py-1.5 text-sm bg-transparent text-gray-200 outline-none w-48"
+						placeholder={PRESET_INPUT_PLACEHOLDER}
+					/>
+					<button
+						type="button"
+						onClick={toggleDropdown}
+						className="px-2 py-1.5 bg-gray-700 hover:bg-gray-600 border-l border-gray-600 transition-colors"
+						aria-label={PRESET_SELECT_ARIA}
 					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							strokeWidth={2}
-							d="M19 9l-7 7-7-7"
-						/>
-					</svg>
-				</button>
-			</div>
+						<svg
+							className={`w-4 h-4 text-gray-400 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M19 9l-7 7-7-7"
+							/>
+						</svg>
+					</button>
+				</div>
 
-			{isDropdownOpen && (
-				<div className="absolute top-full left-0 w-full bg-gray-800 border border-gray-700 rounded shadow-xl z-50 max-h-60 overflow-y-auto">
-					{presetValues.map((val, index) => {
-						const name = presetNames[index] ?? String(val);
-						const isSelected = index === currentSelection;
-						return (
-							<button
-								key={`preset-${val}`}
-								type="button"
-								onClick={() => {
-									handlePresetSelect(index);
-								}}
-								className={`
+				{isDropdownOpen && (
+					<div className="absolute top-full left-0 w-full bg-gray-800 border border-gray-700 rounded shadow-xl z-50 max-h-60 overflow-y-auto">
+						{presetValues.map((val, index) => {
+							const name = presetNames[index] ?? String(val);
+							const isSelected = index === currentSelection;
+							return (
+								<button
+									key={`preset-${val}`}
+									type="button"
+									onClick={() => {
+										handlePresetSelect(index);
+									}}
+									className={`
                   w-full text-left px-3 py-2 text-sm transition-colors
                   ${isSelected ? "bg-blue-600 text-white" : "text-gray-300 hover:bg-gray-700"}
                 `}
-							>
-								<div className="flex justify-between items-center">
-									<span>{name}</span>
-									{name !== String(val) && (
-										<span className="text-xs opacity-50 ml-2">({val})</span>
-									)}
-								</div>
-							</button>
-						);
-					})}
-				</div>
-			)}
-		</div>
+								>
+									<div className="flex justify-between items-center">
+										<span>{name}</span>
+										{name !== String(val) && (
+											<span className="text-xs opacity-50 ml-2">({val})</span>
+										)}
+									</div>
+								</button>
+							);
+						})}
+					</div>
+				)}
+			</div>
+		</HighlightWrapper>
 	);
 }

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -1,0 +1,42 @@
+import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
+import { useExRNavigation } from "../../hooks/useExRNavigation";
+import { useOptionData } from "../../hooks/useOptionData";
+import { exrOptionMetaData } from "../../logics/api";
+import { PRESET_OPTION_UNIQUE_ID } from "../../logics/optionUtils";
+import { useStore } from "../../useStore";
+
+/**
+ * ExRの設定内容を右パネルに表示するコンポーネント
+ */
+export function ExROptionViewer() {
+	const presetOption = useOptionData(PRESET_OPTION_UNIQUE_ID);
+	const presetNames = useStore((state) => state.presetNames);
+	const { navigateToExROption } = useExRNavigation();
+
+	if (!presetOption) {
+		return null;
+	}
+
+	const currentSelection = presetOption.selection ?? 0;
+	const presetValues = presetOption.values as (number | string)[];
+	const currentPresetValue = presetValues[currentSelection];
+	const currentPresetName =
+		presetNames[currentSelection] ?? String(currentPresetValue);
+
+	const optionMeta =
+		exrOptionMetaData.options[PRESET_OPTION_UNIQUE_ID]?.metaData;
+
+	return (
+		<div className="flex flex-col gap-0.5">
+			<div className="border-white border-b">
+				<ViewerOptionRow
+					title={optionMeta?.translatedName ?? "Preset"}
+					value={currentPresetName}
+					onDoubleClick={() => {
+						navigateToExROption(0, 0, PRESET_OPTION_UNIQUE_ID);
+					}}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -4,7 +4,6 @@ import { getAllOptions } from "../../logics/api.store";
 import {
 	AU_SETTINGS_TITLE,
 	CLOSE,
-	EXR_CONTENT_TEMP,
 	EXR_SETTINGS_TITLE,
 	PANEL_CLOSE_ARIA,
 	PANEL_OPEN_ARIA,
@@ -14,6 +13,7 @@ import {
 } from "../../noTrans";
 import { useStore } from "../../useStore";
 import { AuOptionViewer } from "./AuOptionViewer";
+import { ExROptionViewer } from "./ExROptionViewer";
 
 /**
  * 右フローティングパネルコンポーネント
@@ -102,7 +102,7 @@ export function RightFloatingPanel() {
 									isOpen={isExrSettingsOpen}
 									onToggle={toggleExrSettings}
 								>
-									<p className="text-gray-400 text-sm">{EXR_CONTENT_TEMP}</p>
+									<ExROptionViewer />
 								</CompactAccordion>
 							</div>
 						</CompactAccordion>

--- a/src/hooks/useAuNavigation.ts
+++ b/src/hooks/useAuNavigation.ts
@@ -38,9 +38,11 @@ export function useAuNavigation() {
 		setHighlightedAuOptionId(optionId);
 
 		setTimeout(() => {
-			const element = document.getElementById(`au-option-${optionId}`);
-			if (element) {
-				element.scrollIntoView({ behavior: "smooth", block: "center" });
+			if (typeof document !== "undefined") {
+				const element = document.getElementById(`au-option-${optionId}`);
+				if (element) {
+					element.scrollIntoView({ behavior: "smooth", block: "center" });
+				}
 			}
 			setTimeout(() => {
 				setHighlightedAuOptionId(null);

--- a/src/hooks/useExRNavigation.ts
+++ b/src/hooks/useExRNavigation.ts
@@ -1,0 +1,52 @@
+import type { ExRTabId, UniqueOptionId } from "../type";
+import { useStore } from "../useStore";
+
+/**
+ * ExRの設定項目をダブルクリックした際のナビゲーションとハイライトを行うフック
+ */
+export function useExRNavigation() {
+	const setSelectedTab = useStore((state) => {
+		return state.setSelectedTab;
+	});
+	const setSelectedExRTabId = useStore((state) => {
+		return state.setSelectedExRTabId;
+	});
+	const toggleExRCategory = useStore((state) => {
+		return state.toggleExRCategory;
+	});
+	const openedExRCategoryIds = useStore((state) => {
+		return state.openedExRCategoryIds;
+	});
+	const setHighlightedExROptionId = useStore((state) => {
+		return state.setHighlightedExROptionId;
+	});
+	const setRightPanelOpen = useStore((state) => {
+		return state.setRightPanelOpen;
+	});
+
+	const navigateToExROption = (
+		tabId: ExRTabId,
+		categoryId: number,
+		uniqueOptionId: UniqueOptionId,
+	) => {
+		setRightPanelOpen(false);
+		setSelectedTab("ExR");
+		setSelectedExRTabId(tabId);
+		if (!openedExRCategoryIds[categoryId]) {
+			toggleExRCategory(categoryId);
+		}
+		setHighlightedExROptionId(uniqueOptionId);
+
+		setTimeout(() => {
+			const element = document.getElementById(`exr-option-${uniqueOptionId}`);
+			if (element) {
+				element.scrollIntoView({ behavior: "smooth", block: "center" });
+			}
+			setTimeout(() => {
+				setHighlightedExROptionId(null);
+			}, 2000);
+		}, 100);
+	};
+
+	return { navigateToExROption };
+}

--- a/src/hooks/useExRNavigation.ts
+++ b/src/hooks/useExRNavigation.ts
@@ -38,9 +38,11 @@ export function useExRNavigation() {
 		setHighlightedExROptionId(uniqueOptionId);
 
 		setTimeout(() => {
-			const element = document.getElementById(`exr-option-${uniqueOptionId}`);
-			if (element) {
-				element.scrollIntoView({ behavior: "smooth", block: "center" });
+			if (typeof document !== "undefined") {
+				const element = document.getElementById(`exr-option-${uniqueOptionId}`);
+				if (element) {
+					element.scrollIntoView({ behavior: "smooth", block: "center" });
+				}
 			}
 			setTimeout(() => {
 				setHighlightedExROptionId(null);

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -24,6 +24,7 @@ export interface ExROptionViewerSlice {
 	isPresetDropdownOpen: boolean;
 	exrValue: Record<UniqueOptionId, ExROptionValueData>;
 	isExROptionActive: Record<UniqueOptionId, boolean>;
+	highlightedExROptionId: UniqueOptionId | null;
 	setSelectedExRTabId: (id: ExRTabId) => void;
 	setIsExRTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
@@ -31,6 +32,7 @@ export interface ExROptionViewerSlice {
 	updateExROption: (updateOptions: (UpdatedOptions | null)[]) => void;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
+	setHighlightedExROptionId: (id: UniqueOptionId | null) => void;
 	resetViewer: () => void;
 	setExROptions: (
 		valueData: Record<UniqueOptionId, ExROptionValueData>,
@@ -52,6 +54,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		openedExROptionIds: {},
 		exrValue: {},
 		isExROptionActive: {},
+		highlightedExROptionId: null,
 		presetNames: loadPresetNamesFromLocalStorage(),
 		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: ExRTabId) => {
@@ -136,6 +139,9 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		},
 		setPresetDropdownOpen: (isOpen: boolean) => {
 			set({ isPresetDropdownOpen: isOpen });
+		},
+		setHighlightedExROptionId: (id) => {
+			set({ highlightedExROptionId: id });
 		},
 		setExROptions: (
 			valueData: Record<number, ExROptionValueData>,


### PR DESCRIPTION
This PR adds the currently selected ExR preset name to the right sidebar's ExR section.

Key changes:
- **State Management**: Added `highlightedExROptionId` and corresponding actions to `ExROptionViewerSlice` to manage temporary visual feedback when navigating to an option.
- **Navigation**: Created a new `useExRNavigation` hook that handles switching to the ExR tab, opening the necessary category, and scrolling the target option into view with a highlight effect.
- **Sidebar UI**: Added `ExROptionViewer` component which displays the current preset name. It supports double-click interaction to jump to the preset configuration in the main view.
- **Main UI**: Wrapped the `PresetSelector` in a `HighlightWrapper` so it can visually react when navigated to from the sidebar.

---
*PR created automatically by Jules for task [10999737589801328111](https://jules.google.com/task/10999737589801328111) started by @yukieiji*