### PR TITLE
ExROptionViewerへのExR GeneralTab情報の追加

### DIFF
--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -28,18 +28,23 @@ test("ExR Option Accordion behavior", async ({ page }) => {
 
 	// プリセットカテゴリは非表示になったため、別のカテゴリ「乱数に関する設定」を使用する
 	const categoryName = "乱数に関する設定";
-	const accordionButton = page.getByRole("button", { name: categoryName });
+	const accordionButton = page
+		.getByTestId("category-list")
+		.getByRole("button", { name: categoryName });
 	await expect(accordionButton).toBeVisible();
 
 	// 初期状態では閉じている
 	const accordionItem = page
+		.getByTestId("category-list")
 		.locator("div.border.border-gray-700")
 		.filter({ hasText: categoryName });
 	const contentContainer = accordionItem.getByTestId("accordion-content");
 	await expect(contentContainer).toHaveClass(/grid-rows-\[0fr\]/);
 
 	// 閉じているときはオプション名が表示されていない（lazy rendering）
-	const optionName = page.getByText("強力なシャッフルを使用する");
+	const optionName = page
+		.getByTestId("category-list")
+		.getByText("強力なシャッフルを使用する");
 	await expect(optionName).not.toBeAttached();
 
 	// アコーディオンを開く
@@ -50,12 +55,14 @@ test("ExR Option Accordion behavior", async ({ page }) => {
 	// タブを切り替えてもアコーディオンの状態が維持されることを確認
 	await page
 		.getByRole("button", { name: "ゴーストニュートラル役職設定", exact: false })
+		.filter({ hasText: "ゴーストニュートラル役職設定" }) // タブボタンを特定
 		.click();
 	await expect(page.getByRole("button", { name: "フォラス" })).toBeVisible();
 
 	// グローバル設定タブに戻る
 	await page
 		.getByRole("button", { name: "グローバル設定", exact: false })
+		.filter({ hasText: "グローバル設定" }) // タブボタンを特定
 		.click();
 	// アコーディオンがまだ開いていることを確認
 	await expect(optionName).toBeVisible();

--- a/e2e/exr_toggle.spec.ts
+++ b/e2e/exr_toggle.spec.ts
@@ -28,7 +28,9 @@ test("ExR toggle switch should be visible and functional", async ({ page }) => {
 		.click();
 
 	// '乱数に関する設定' アコーディオンを開く
-	const categoryAccordion = page.getByText("乱数に関する設定");
+	const categoryAccordion = page
+		.getByTestId("category-list")
+		.getByText("乱数に関する設定");
 	await categoryAccordion.click();
 
 	// '強力なシャッフルを使用する' オプションの横にあるトグルを確認
@@ -37,17 +39,23 @@ test("ExR toggle switch should be visible and functional", async ({ page }) => {
 
 	// 初期状態は オフ (Selection 0)
 	await expect(toggle).toHaveAttribute("aria-checked", "false");
-	await expect(page.getByText("オフ")).toBeVisible();
+	await expect(
+		page.getByTestId("category-list").getByText("オフ"),
+	).toBeVisible();
 
 	// クリックして オン にする
 	await toggle.click();
 
 	// 状態が オン (Selection 1) になったことを確認
 	await expect(toggle).toHaveAttribute("aria-checked", "true");
-	await expect(page.getByText("オン", { exact: true })).toBeVisible();
+	await expect(
+		page.getByTestId("category-list").getByText("オン", { exact: true }),
+	).toBeVisible();
 
 	// 再度クリックして オフ に戻す
 	await toggle.click();
 	await expect(toggle).toHaveAttribute("aria-checked", "false");
-	await expect(page.getByText("オフ")).toBeVisible();
+	await expect(
+		page.getByTestId("category-list").getByText("オフ"),
+	).toBeVisible();
 });

--- a/e2e/exr_viewer.spec.ts
+++ b/e2e/exr_viewer.spec.ts
@@ -46,9 +46,17 @@ test("ExR option double-click navigates to main settings", async ({ page }) => {
 	const presetRow = page.getByText("使用するプリセット");
 	await presetRow.dblclick();
 
-	// Navigation should happen. In the main view, the ExR tab should be selected.
-	// Since we are already in ExR tab (likely), let's check if the option is highlighted.
-	// The navigation logic usually sets the highlighted option.
+	// Navigation should happen. The right sidebar should be closed.
+	// Since the sidebar uses translate-x-full to hide, we check for that class.
+	await expect(page.getByLabel("右フローティングパネル")).toHaveClass(
+		/translate-x-full/,
+	);
 
-	// We can check if the main view's category is expanded or if it's visible.
+	// In the main view, the ExR option should be visible.
+	// PRESET_OPTION_UNIQUE_ID is 0.
+	const mainOption = page.locator("#exr-option-0");
+	await expect(mainOption).toBeVisible();
+
+	// Check if it's highlighted (has ring-blue-500 class)
+	await expect(mainOption).toHaveClass(/ring-blue-500/);
 });

--- a/e2e/exr_viewer.spec.ts
+++ b/e2e/exr_viewer.spec.ts
@@ -26,7 +26,9 @@ test("ExR options are displayed in the right sidebar", async ({ page }) => {
 test("ExR category can be toggled in the right sidebar", async ({ page }) => {
 	await page.getByRole("button", { name: "パネルを開く" }).click();
 
-	const categoryAccordion = page.getByRole("button", { name: "乱数に関する設定" });
+	const categoryAccordion = page.getByRole("button", {
+		name: "乱数に関する設定",
+	});
 	await expect(categoryAccordion).toBeVisible();
 
 	// Click to open

--- a/e2e/exr_viewer.spec.ts
+++ b/e2e/exr_viewer.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.goto("/");
+	// Wait for loading to complete
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+});
+
+test("ExR options are displayed in the right sidebar", async ({ page }) => {
+	// Open right sidebar
+	await page.getByRole("button", { name: "パネルを開く" }).click();
+
+	// Check if ExR Setting exists
+	const exrSettings = page.getByRole("button", { name: "ExRの設定" });
+	await expect(exrSettings).toBeVisible();
+
+	// Initially Preset should be visible
+	await expect(page.getByText("使用するプリセット")).toBeVisible();
+
+	// "乱数に関する設定" is active by default in the mock data
+	await expect(page.getByText("乱数に関する設定")).toBeVisible();
+});
+
+test("ExR category can be toggled in the right sidebar", async ({ page }) => {
+	await page.getByRole("button", { name: "パネルを開く" }).click();
+
+	const categoryAccordion = page.getByRole("button", { name: "乱数に関する設定" });
+	await expect(categoryAccordion).toBeVisible();
+
+	// Click to open
+	await categoryAccordion.click();
+	await expect(categoryAccordion).toHaveAttribute("aria-expanded", "true");
+
+	// Check if option inside is visible
+	await expect(page.getByText("強力なシャッフルを使用する")).toBeVisible();
+});
+
+test("ExR option double-click navigates to main settings", async ({ page }) => {
+	await page.getByRole("button", { name: "パネルを開く" }).click();
+
+	// Double click "使用するプリセット" (the Preset option)
+	const presetRow = page.getByText("使用するプリセット");
+	await presetRow.dblclick();
+
+	// Navigation should happen. In the main view, the ExR tab should be selected.
+	// Since we are already in ExR tab (likely), let's check if the option is highlighted.
+	// The navigation logic usually sets the highlighted option.
+
+	// We can check if the main view's category is expanded or if it's visible.
+});

--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -40,21 +40,29 @@ test("Options interaction behavior", async ({ page }) => {
 	).toBeVisible();
 
 	// 別のカテゴリの操作を確認
-	const shuffleCategory = page.getByRole("button", {
-		name: "乱数に関する設定",
-	});
+	const shuffleCategory = page
+		.getByTestId("category-list")
+		.getByRole("button", {
+			name: "乱数に関する設定",
+		});
 	await shuffleCategory.click();
 
-	const shuffleOption = page.getByText("強力なシャッフルを使用する");
+	const shuffleOption = page
+		.getByTestId("category-list")
+		.getByText("強力なシャッフルを使用する");
 	await expect(shuffleOption).toBeVisible({ timeout: 3000 });
 
 	// トグルスイッチに変更されたので、トグルを操作する
 	const toggle = page.getByTestId("option-toggle").first();
 	await expect(toggle).toHaveAttribute("aria-checked", "false");
-	await expect(page.getByText("オフ")).toBeVisible();
+	await expect(
+		page.getByTestId("category-list").getByText("オフ"),
+	).toBeVisible();
 
 	// トグルを切り替え
 	await toggle.click();
 	await expect(toggle).toHaveAttribute("aria-checked", "true");
-	await expect(page.getByText("オン", { exact: true })).toBeVisible();
+	await expect(
+		page.getByTestId("category-list").getByText("オン", { exact: true }),
+	).toBeVisible();
 });

--- a/src/feature/exr/ExRCategoryList.tsx
+++ b/src/feature/exr/ExRCategoryList.tsx
@@ -1,7 +1,7 @@
 import { useShallow } from "zustand/react/shallow";
 import { CategoryContainer } from "../../components/blocks/CategoryContainer";
 import { exrOptionMetaData } from "../../logics/api";
-import { PRESET_OPTION_UNIQUE_ID } from "../../logics/optionUtils";
+import { filterVisibleCategoryIds } from "../../logics/exrOptionUtils";
 import { ExRTabId } from "../../type";
 import { useStore } from "../../useStore";
 import { ExRRoleCategoryItem } from "./ExRRoleCategoryItem";
@@ -19,24 +19,7 @@ function ExRStandardCategoryList({ categoryIds }: CategoryListProps) {
 	const visibleCategories = useStore(
 		useShallow((state) =>
 			categoryIds
-				? categoryIds.filter((categoryId) => {
-						const categoryUniqueOptions =
-							exrOptionMetaData.globalCategoryIdTopLevelMap[categoryId];
-						if (!categoryUniqueOptions) {
-							return false;
-						}
-
-						const filterdUniqueOptions =
-							categoryId === 0
-								? categoryUniqueOptions.filter((optionId) => {
-										return optionId !== PRESET_OPTION_UNIQUE_ID; // プリセット設定（OptionId 0）を除外
-									})
-								: categoryUniqueOptions;
-						return (
-							filterdUniqueOptions.length > 0 &&
-							filterdUniqueOptions.some((id) => state.isExROptionActive[id])
-						);
-					})
+				? filterVisibleCategoryIds(categoryIds, state.isExROptionActive)
 				: [],
 		),
 	);

--- a/src/feature/exr/ExRStandardCategoryItem.tsx
+++ b/src/feature/exr/ExRStandardCategoryItem.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { OptionEditorAccordion } from "../../components/blocks/OptionEditorAccordion";
 import { ColoredText } from "../../components/parts/ColoredText";
 import { exrOptionMetaData } from "../../logics/api";
-import { PRESET_OPTION_UNIQUE_ID } from "../../logics/optionUtils";
+import { filterVisibleTopLevelOptionIds } from "../../logics/exrOptionUtils";
 import { useStore } from "../../useStore";
 import { ExRCategoryOptionList } from "./ExRCategoryOptionList";
 
@@ -29,10 +29,8 @@ export function ExRStandardCategoryItem({
 		if (!uniqueOptions) {
 			return [];
 		}
-		return uniqueOptions.filter((uniqueId) => {
-			return uniqueId !== PRESET_OPTION_UNIQUE_ID;
-		});
-	}, [uniqueOptions]);
+		return filterVisibleTopLevelOptionIds(categoryId, uniqueOptions);
+	}, [categoryId, uniqueOptions]);
 
 	if (filteredOptions.length === 0) {
 		return null;

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -1,10 +1,15 @@
+import { useShallow } from "zustand/react/shallow";
+import { RightPanelGroupColumnLayout } from "../../components/parts/RightPanelGroupColumnLayout";
 import { RightPanelItemColumnLayout } from "../../components/parts/RightPanelItemColumnLayout";
 import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
 import { useExRNavigation } from "../../hooks/useExRNavigation";
 import { useOptionData } from "../../hooks/useOptionData";
 import { exrOptionMetaData } from "../../logics/api";
+import { filterVisibleCategoryIds } from "../../logics/exrOptionUtils";
 import { PRESET_OPTION_UNIQUE_ID } from "../../logics/optionUtils";
+import { ExRTabId } from "../../type";
 import { useStore } from "../../useStore";
+import { ExRTab0GeneralCategory } from "./ExRTab0GeneralCategory";
 
 /**
  * ExRの設定内容を右パネルに表示するコンポーネント
@@ -13,6 +18,14 @@ export function ExROptionViewer() {
 	const presetOption = useOptionData(PRESET_OPTION_UNIQUE_ID);
 	const presetNames = useStore((state) => state.presetNames);
 	const { navigateToExROption } = useExRNavigation();
+
+	const visibleCategoryIds = useStore(
+		useShallow((state) => {
+			const categoryIds =
+				exrOptionMetaData.tabs[ExRTabId.GeneralTab]?.categoryIds ?? [];
+			return filterVisibleCategoryIds(categoryIds, state.isExROptionActive);
+		}),
+	);
 
 	if (!presetOption) {
 		return null;
@@ -28,14 +41,19 @@ export function ExROptionViewer() {
 		exrOptionMetaData.options[PRESET_OPTION_UNIQUE_ID]?.metaData;
 
 	return (
-		<RightPanelItemColumnLayout>
-			<ViewerOptionRow
-				title={optionMeta?.translatedName ?? "Preset"}
-				value={currentPresetName}
-				onDoubleClick={() => {
-					navigateToExROption(0, 0, PRESET_OPTION_UNIQUE_ID);
-				}}
-			/>
-		</RightPanelItemColumnLayout>
+		<RightPanelGroupColumnLayout>
+			<RightPanelItemColumnLayout>
+				<ViewerOptionRow
+					title={optionMeta?.translatedName ?? "Preset"}
+					value={currentPresetName}
+					onDoubleClick={() => {
+						navigateToExROption(0, 0, PRESET_OPTION_UNIQUE_ID);
+					}}
+				/>
+			</RightPanelItemColumnLayout>
+			{visibleCategoryIds.map((categoryId) => (
+				<ExRTab0GeneralCategory key={categoryId} categoryId={categoryId} />
+			))}
+		</RightPanelGroupColumnLayout>
 	);
 }

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -1,4 +1,6 @@
 import { useShallow } from "zustand/react/shallow";
+import { CompactAccordion } from "../../components/blocks/CompactAccordion";
+import { ColoredText } from "../../components/parts/ColoredText";
 import { RightPanelGroupColumnLayout } from "../../components/parts/RightPanelGroupColumnLayout";
 import { RightPanelItemColumnLayout } from "../../components/parts/RightPanelItemColumnLayout";
 import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
@@ -26,6 +28,10 @@ export function ExROptionViewer() {
 			return filterVisibleCategoryIds(categoryIds, state.isExROptionActive);
 		}),
 	);
+	const isPresetOpen = useStore(
+		(state) => state.openedExRCategoryIds[0] ?? true,
+	);
+	const toggleExRCategory = useStore((state) => state.toggleExRCategory);
 
 	if (!presetOption) {
 		return null;
@@ -42,15 +48,27 @@ export function ExROptionViewer() {
 
 	return (
 		<RightPanelGroupColumnLayout>
-			<RightPanelItemColumnLayout>
-				<ViewerOptionRow
-					title={optionMeta?.translatedName ?? "Preset"}
-					value={currentPresetName}
-					onDoubleClick={() => {
-						navigateToExROption(0, 0, PRESET_OPTION_UNIQUE_ID);
-					}}
-				/>
-			</RightPanelItemColumnLayout>
+			<CompactAccordion
+				title={
+					<span className="text-base">
+						<ColoredText text={exrOptionMetaData.categories[0]?.name ?? ""} />
+					</span>
+				}
+				isOpen={isPresetOpen}
+				onToggle={() => toggleExRCategory(0)}
+			>
+				<RightPanelItemColumnLayout>
+					<ViewerOptionRow
+						title={
+							<ColoredText text={optionMeta?.translatedName ?? "Preset"} />
+						}
+						value={currentPresetName}
+						onDoubleClick={() => {
+							navigateToExROption(0, 0, PRESET_OPTION_UNIQUE_ID);
+						}}
+					/>
+				</RightPanelItemColumnLayout>
+			</CompactAccordion>
 			{visibleCategoryIds.map((categoryId) => (
 				<ExRTab0GeneralCategory key={categoryId} categoryId={categoryId} />
 			))}

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -25,7 +25,11 @@ export function ExROptionViewer() {
 		useShallow((state) => {
 			const categoryIds =
 				exrOptionMetaData.tabs[ExRTabId.GeneralTab]?.categoryIds ?? [];
-			return filterVisibleCategoryIds(categoryIds, state.isExROptionActive);
+			// カテゴリ0（プリセット）は手動でレンダリングするため、リストからは除外する
+			return filterVisibleCategoryIds(
+				categoryIds,
+				state.isExROptionActive,
+			).filter((id) => id !== 0);
 		}),
 	);
 	const isPresetOpen = useStore(

--- a/src/feature/rightsidepanel/ExRTab0GeneralCategory.tsx
+++ b/src/feature/rightsidepanel/ExRTab0GeneralCategory.tsx
@@ -4,7 +4,7 @@ import { ColoredText } from "../../components/parts/ColoredText";
 import { exrOptionMetaData } from "../../logics/api";
 import { filterVisibleTopLevelOptionIds } from "../../logics/exrOptionUtils";
 import { useStore } from "../../useStore";
-import { ExRTab0OptionRow } from "./ExRTab0OptionRow";
+import { ExRTab0OptionItem } from "./ExRTab0OptionItem";
 
 interface ExRTab0GeneralCategoryProps {
 	categoryId: number;
@@ -53,7 +53,7 @@ export function ExRTab0GeneralCategory({
 		>
 			<RightPanelContainer arr={filteredOptions}>
 				{(uniqueOptionId) => (
-					<ExRTab0OptionRow uniqueOptionId={uniqueOptionId} />
+					<ExRTab0OptionItem uniqueOptionId={uniqueOptionId} />
 				)}
 			</RightPanelContainer>
 		</CompactAccordion>

--- a/src/feature/rightsidepanel/ExRTab0GeneralCategory.tsx
+++ b/src/feature/rightsidepanel/ExRTab0GeneralCategory.tsx
@@ -1,0 +1,61 @@
+import { CompactAccordion } from "../../components/blocks/CompactAccordion";
+import { RightPanelContainer } from "../../components/blocks/RightPanelContainer";
+import { ColoredText } from "../../components/parts/ColoredText";
+import { exrOptionMetaData } from "../../logics/api";
+import { filterVisibleTopLevelOptionIds } from "../../logics/exrOptionUtils";
+import { useStore } from "../../useStore";
+import { ExRTab0OptionRow } from "./ExRTab0OptionRow";
+
+interface ExRTab0GeneralCategoryProps {
+	categoryId: number;
+}
+
+/**
+ * ExR一般カテゴリコンポーネント
+ */
+export function ExRTab0GeneralCategory({
+	categoryId,
+}: ExRTab0GeneralCategoryProps) {
+	const categoryMeta = exrOptionMetaData.categories[categoryId];
+	const isOpen = useStore((state) => {
+		return state.openedExRCategoryIds[categoryId] ?? false;
+	});
+	const toggleExRCategory = useStore((state) => {
+		return state.toggleExRCategory;
+	});
+
+	const uniqueOptions =
+		exrOptionMetaData.globalCategoryIdTopLevelMap[categoryId];
+	if (!categoryMeta || !uniqueOptions) {
+		return null;
+	}
+
+	const filteredOptions = filterVisibleTopLevelOptionIds(
+		categoryId,
+		uniqueOptions,
+	);
+
+	if (filteredOptions.length === 0) {
+		return null;
+	}
+
+	return (
+		<CompactAccordion
+			title={
+				<span className="text-base">
+					<ColoredText text={categoryMeta.name} />
+				</span>
+			}
+			isOpen={isOpen}
+			onToggle={() => {
+				toggleExRCategory(categoryId);
+			}}
+		>
+			<RightPanelContainer arr={filteredOptions}>
+				{(uniqueOptionId) => (
+					<ExRTab0OptionRow uniqueOptionId={uniqueOptionId} />
+				)}
+			</RightPanelContainer>
+		</CompactAccordion>
+	);
+}

--- a/src/feature/rightsidepanel/ExRTab0OptionItem.tsx
+++ b/src/feature/rightsidepanel/ExRTab0OptionItem.tsx
@@ -1,0 +1,49 @@
+import { useShallow } from "zustand/react/shallow";
+import { useExROptionActive } from "../../hooks/useExROptionActive";
+import { exrOptionMetaData } from "../../logics/api";
+import type { UniqueOptionId } from "../../type";
+import { useStore } from "../../useStore";
+import { ExRTab0OptionRecursiveRow } from "./ExRTab0OptionRecursiveRow";
+import { ExRTab0OptionRow } from "./ExRTab0OptionRow";
+
+interface ExRTab0OptionItemProps {
+	uniqueOptionId: UniqueOptionId;
+	depth?: number;
+}
+
+/**
+ * ExRオプションの表示単位を制御するコンポーネント（再帰か単一行か）
+ */
+export function ExRTab0OptionItem({
+	uniqueOptionId,
+	depth = 0,
+}: ExRTab0OptionItemProps) {
+	const isActive = useExROptionActive(uniqueOptionId);
+	const childIds = exrOptionMetaData.options[uniqueOptionId]?.childOptionIds;
+	const hasActiveChildren = useStore(
+		useShallow((state) => {
+			if (!childIds) {
+				return false;
+			}
+			return (
+				childIds.length > 0 &&
+				childIds.some((id) => state.isExROptionActive[id])
+			);
+		}),
+	);
+
+	if (!isActive) {
+		return null;
+	}
+
+	if (hasActiveChildren) {
+		return (
+			<ExRTab0OptionRecursiveRow
+				uniqueOptionId={uniqueOptionId}
+				depth={depth}
+			/>
+		);
+	}
+
+	return <ExRTab0OptionRow uniqueOptionId={uniqueOptionId} />;
+}

--- a/src/feature/rightsidepanel/ExRTab0OptionRecursiveRow.tsx
+++ b/src/feature/rightsidepanel/ExRTab0OptionRecursiveRow.tsx
@@ -1,0 +1,45 @@
+import { useShallow } from "zustand/react/shallow";
+import { RightPanelContainer } from "../../components/blocks/RightPanelContainer";
+import { exrOptionMetaData } from "../../logics/api";
+import type { UniqueOptionId } from "../../type";
+import { useStore } from "../../useStore";
+import { ExRTab0OptionItem } from "./ExRTab0OptionItem";
+import { ExRTab0OptionRow } from "./ExRTab0OptionRow";
+
+interface ExRTab0OptionRecursiveRowProps {
+	uniqueOptionId: UniqueOptionId;
+	depth?: number;
+}
+
+/**
+ * 子・孫オプションを再帰的に表示するコンポーネント
+ */
+export function ExRTab0OptionRecursiveRow({
+	uniqueOptionId,
+	depth = 0,
+}: ExRTab0OptionRecursiveRowProps) {
+	const childIds = exrOptionMetaData.options[uniqueOptionId]?.childOptionIds;
+	const activeChildIds = useStore(
+		useShallow((state) => {
+			if (!childIds) {
+				return [];
+			}
+			return childIds.filter((id) => state.isExROptionActive[id]);
+		}),
+	);
+
+	return (
+		<div className="flex flex-col">
+			<ExRTab0OptionRow uniqueOptionId={uniqueOptionId} />
+			{activeChildIds.length > 0 && (
+				<div className="pl-3 border-l border-gray-100 ml-1 mt-1 flex flex-col gap-1">
+					<RightPanelContainer arr={activeChildIds}>
+						{(childId) => (
+							<ExRTab0OptionItem uniqueOptionId={childId} depth={depth + 1} />
+						)}
+					</RightPanelContainer>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/feature/rightsidepanel/ExRTab0OptionRow.tsx
+++ b/src/feature/rightsidepanel/ExRTab0OptionRow.tsx
@@ -1,0 +1,47 @@
+import { ColoredText } from "../../components/parts/ColoredText";
+import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
+import { useExRNavigation } from "../../hooks/useExRNavigation";
+import { exrOptionMetaData } from "../../logics/api";
+import { parseUniqueOptionId } from "../../logics/optionUtils";
+import type { UniqueOptionId } from "../../type";
+import { useStore } from "../../useStore";
+import { ExRTab0OptionValue } from "./ExRTab0OptionValue";
+
+interface ExRTab0OptionRowProps {
+	uniqueOptionId: UniqueOptionId;
+}
+
+/**
+ * ExR各設定項目の行コンポーネント
+ */
+export function ExRTab0OptionRow({ uniqueOptionId }: ExRTab0OptionRowProps) {
+	const selection = useStore((state) => {
+		return state.exrValue[uniqueOptionId]?.selection ?? 0;
+	});
+	const isActive = useStore((state) => {
+		return state.isExROptionActive[uniqueOptionId];
+	});
+	const { navigateToExROption } = useExRNavigation();
+
+	const optionMeta = exrOptionMetaData.options[uniqueOptionId]?.metaData;
+	const values = exrOptionMetaData.options[uniqueOptionId]
+		? useStore.getState().exrValue[uniqueOptionId]?.values
+		: null;
+
+	if (!optionMeta || !isActive || !values) {
+		return null;
+	}
+
+	const { tabId, categoryId, optionId } = parseUniqueOptionId(uniqueOptionId);
+	const value = values[selection] ?? 0;
+
+	return (
+		<ViewerOptionRow
+			title={<ColoredText text={optionMeta.translatedName} />}
+			value={<ExRTab0OptionValue value={value} format={optionMeta.format} />}
+			onDoubleClick={() => {
+				navigateToExROption(tabId, categoryId, uniqueOptionId);
+			}}
+		/>
+	);
+}

--- a/src/feature/rightsidepanel/ExRTab0OptionRow.tsx
+++ b/src/feature/rightsidepanel/ExRTab0OptionRow.tsx
@@ -32,7 +32,7 @@ export function ExRTab0OptionRow({ uniqueOptionId }: ExRTab0OptionRowProps) {
 		return null;
 	}
 
-	const { tabId, categoryId, optionId } = parseUniqueOptionId(uniqueOptionId);
+	const { tabId, categoryId } = parseUniqueOptionId(uniqueOptionId);
 	const value = values[selection] ?? 0;
 
 	return (

--- a/src/feature/rightsidepanel/ExRTab0OptionRow.tsx
+++ b/src/feature/rightsidepanel/ExRTab0OptionRow.tsx
@@ -1,10 +1,11 @@
 import { ColoredText } from "../../components/parts/ColoredText";
 import { ViewerOptionRow } from "../../components/parts/ViewerOptionRow";
 import { useExRNavigation } from "../../hooks/useExRNavigation";
+import { useExROptionActive } from "../../hooks/useExROptionActive";
+import { useOptionData } from "../../hooks/useOptionData";
 import { exrOptionMetaData } from "../../logics/api";
 import { parseUniqueOptionId } from "../../logics/optionUtils";
 import type { UniqueOptionId } from "../../type";
-import { useStore } from "../../useStore";
 import { ExRTab0OptionValue } from "./ExRTab0OptionValue";
 
 interface ExRTab0OptionRowProps {
@@ -15,30 +16,24 @@ interface ExRTab0OptionRowProps {
  * ExR各設定項目の行コンポーネント
  */
 export function ExRTab0OptionRow({ uniqueOptionId }: ExRTab0OptionRowProps) {
-	const selection = useStore((state) => {
-		return state.exrValue[uniqueOptionId]?.selection ?? 0;
-	});
-	const isActive = useStore((state) => {
-		return state.isExROptionActive[uniqueOptionId];
-	});
+	const optionData = useOptionData(uniqueOptionId);
+	const isActive = useExROptionActive(uniqueOptionId);
 	const { navigateToExROption } = useExRNavigation();
 
-	const optionMeta = exrOptionMetaData.options[uniqueOptionId]?.metaData;
-	const values = exrOptionMetaData.options[uniqueOptionId]
-		? useStore.getState().exrValue[uniqueOptionId]?.values
-		: null;
+	const meta = exrOptionMetaData.options[uniqueOptionId]?.metaData;
 
-	if (!optionMeta || !isActive || !values) {
+	if (!meta || !isActive || !optionData) {
 		return null;
 	}
 
 	const { tabId, categoryId } = parseUniqueOptionId(uniqueOptionId);
-	const value = values[selection] ?? 0;
+	const selection = optionData.selection ?? 0;
+	const value = optionData.values[selection] ?? 0;
 
 	return (
 		<ViewerOptionRow
-			title={<ColoredText text={optionMeta.translatedName} />}
-			value={<ExRTab0OptionValue value={value} format={optionMeta.format} />}
+			title={<ColoredText text={meta.translatedName} />}
+			value={<ExRTab0OptionValue value={value} format={meta.format} />}
 			onDoubleClick={() => {
 				navigateToExROption(tabId, categoryId, uniqueOptionId);
 			}}

--- a/src/feature/rightsidepanel/ExRTab0OptionValue.tsx
+++ b/src/feature/rightsidepanel/ExRTab0OptionValue.tsx
@@ -1,0 +1,41 @@
+import { ColoredText } from "../../components/parts/ColoredText";
+import { OptionFormat } from "../../components/parts/OptionFormat";
+import { translationMetaData } from "../../logics/api";
+import { OFF, ON } from "../../noTrans";
+
+interface ExRTab0OptionValueProps {
+	value: string | number | boolean;
+	format: string;
+}
+
+/**
+ * ExRのタブ0の設定値を表示するコンポーネント
+ */
+export function ExRTab0OptionValue({ value, format }: ExRTab0OptionValueProps) {
+	const isBoolean = typeof value === "boolean";
+	const isString = typeof value === "string";
+
+	return (
+		<div className="flex items-center gap-1 shrink-0">
+			<span className="text-sm text-blue-400 font-medium text-right">
+				{isBoolean ? (
+					<ColoredText
+						text={
+							translationMetaData.booleanTransData[value ? 1 : 0] ||
+							(value ? ON : OFF)
+						}
+					/>
+				) : isString ? (
+					<ColoredText text={value} />
+				) : (
+					value.toString()
+				)}
+			</span>
+			{!isBoolean && !isString && (
+				<div className="text-[10px] scale-90 origin-right">
+					<OptionFormat format={format} />
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/hooks/useExROptionActive.ts
+++ b/src/hooks/useExROptionActive.ts
@@ -1,0 +1,15 @@
+import { useCallback } from "react";
+import type { UniqueOptionId } from "../type";
+import { useStore } from "../useStore";
+
+/**
+ * 指定されたExRオプションがアクティブかどうかを返すカスタムフック
+ */
+export function useExROptionActive(uniqueOptionId: UniqueOptionId): boolean {
+	return useStore(
+		useCallback(
+			(state) => state.isExROptionActive[uniqueOptionId],
+			[uniqueOptionId],
+		),
+	);
+}

--- a/src/logics/exrOptionUtils.ts
+++ b/src/logics/exrOptionUtils.ts
@@ -1,0 +1,49 @@
+import { exrOptionMetaData } from "./api";
+import { PRESET_OPTION_UNIQUE_ID } from "./optionUtils";
+import type { UniqueOptionId } from "../type";
+
+/**
+ * 表示対象のカテゴリIDをフィルタリングします。
+ * 1. プリセット設定以外のトップレベルオプションが存在すること
+ * 2. そのトップレベルオプションのうち、少なくとも1つがアクティブであること
+ */
+export function filterVisibleCategoryIds(
+	categoryIds: number[],
+	isExROptionActive: Record<UniqueOptionId, boolean>,
+): number[] {
+	return categoryIds.filter((categoryId) => {
+		const categoryUniqueOptions =
+			exrOptionMetaData.globalCategoryIdTopLevelMap[categoryId];
+		if (!categoryUniqueOptions) {
+			return false;
+		}
+
+		const filteredUniqueOptions =
+			categoryId === 0
+				? categoryUniqueOptions.filter((optionId) => {
+						return optionId !== PRESET_OPTION_UNIQUE_ID;
+					})
+				: categoryUniqueOptions;
+
+		return (
+			filteredUniqueOptions.length > 0 &&
+			filteredUniqueOptions.some((id) => isExROptionActive[id])
+		);
+	});
+}
+
+/**
+ * カテゴリ内の表示対象のトップレベルオプションIDをフィルタリングします。
+ * プリセット設定（OptionId 0）を除外します。
+ */
+export function filterVisibleTopLevelOptionIds(
+	categoryId: number,
+	uniqueOptionIds: UniqueOptionId[],
+): UniqueOptionId[] {
+	if (categoryId !== 0) {
+		return uniqueOptionIds;
+	}
+	return uniqueOptionIds.filter((uniqueId) => {
+		return uniqueId !== PRESET_OPTION_UNIQUE_ID;
+	});
+}

--- a/src/logics/exrOptionUtils.ts
+++ b/src/logics/exrOptionUtils.ts
@@ -1,6 +1,6 @@
+import type { UniqueOptionId } from "../type";
 import { exrOptionMetaData } from "./api";
 import { PRESET_OPTION_UNIQUE_ID } from "./optionUtils";
-import type { UniqueOptionId } from "../type";
 
 /**
  * 表示対象のカテゴリIDをフィルタリングします。

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -35,7 +35,13 @@ describe("ExROptionViewer Component", () => {
 		// Setup General Tab
 		exrOptionMetaData.tabs[ExRTabId.GeneralTab] = {
 			name: "General",
-			categoryIds: [1, 2],
+			categoryIds: [0, 1, 2],
+		};
+
+		// Category 0: Preset
+		exrOptionMetaData.categories[0] = {
+			name: "Preset Category",
+			tabId: ExRTabId.GeneralTab,
 		};
 
 		// Category 1: Active
@@ -79,7 +85,10 @@ describe("ExROptionViewer Component", () => {
 	it("renders preset and active categories from General Tab", () => {
 		render(<ExROptionViewer />);
 
-		// Should render Preset
+		// Should render Preset Category title
+		expect(screen.getByText("Preset Category")).toBeInTheDocument();
+
+		// Should render Preset Option
 		expect(screen.getByText("Preset")).toBeInTheDocument();
 		expect(screen.getByText("Default")).toBeInTheDocument();
 

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ExROptionViewer } from "../src/feature/rightsidepanel/ExROptionViewer";
+import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import { getUniqueOptionId, PRESET_OPTION_UNIQUE_ID } from "../src/logics/optionUtils";
+import { ExRTabId } from "../src/type";
+import { useStore } from "../src/useStore";
+
+// Mock the navigation hook
+vi.mock("../src/hooks/useExRNavigation", () => ({
+	useExRNavigation: () => ({
+		navigateToExROption: vi.fn(),
+	}),
+}));
+
+describe("ExROptionViewer Component", () => {
+	beforeEach(() => {
+		resetExrOptionMetaData();
+		useStore.getState().resetViewer();
+
+		// Setup Preset Option (OptionId 0, CategoryId 0, TabId 0)
+		const presetUniqueId = PRESET_OPTION_UNIQUE_ID;
+		exrOptionMetaData.options[presetUniqueId] = {
+			metaData: {
+				translatedName: "Preset",
+				format: "{0}",
+				type: "Int32",
+			},
+			childOptionIds: [],
+		};
+
+		// Setup General Tab
+		exrOptionMetaData.tabs[ExRTabId.GeneralTab] = {
+			name: "General",
+			categoryIds: [1, 2],
+		};
+
+		// Category 1: Active
+		exrOptionMetaData.categories[1] = { name: "Active Cat", tabId: ExRTabId.GeneralTab };
+		const opt1 = getUniqueOptionId(ExRTabId.GeneralTab, 1, 101);
+		exrOptionMetaData.globalCategoryIdTopLevelMap[1] = [opt1];
+		exrOptionMetaData.options[opt1] = {
+			metaData: { translatedName: "Opt 1", format: "{0}", type: "Int32" },
+			childOptionIds: [],
+		};
+
+		// Category 2: Inactive
+		exrOptionMetaData.categories[2] = { name: "Inactive Cat", tabId: ExRTabId.GeneralTab };
+		const opt2 = getUniqueOptionId(ExRTabId.GeneralTab, 2, 102);
+		exrOptionMetaData.globalCategoryIdTopLevelMap[2] = [opt2];
+		exrOptionMetaData.options[opt2] = {
+			metaData: { translatedName: "Opt 2", format: "{0}", type: "Int32" },
+			childOptionIds: [],
+		};
+
+		useStore.getState().setExROptions(
+			{
+				[presetUniqueId]: { selection: 0, values: ["Default"] },
+				[opt1]: { selection: 0, values: [123] },
+				[opt2]: { selection: 0, values: [456] },
+			},
+			{
+				[presetUniqueId]: true,
+				[opt1]: true,
+				[opt2]: false,
+			},
+		);
+	});
+
+	it("renders preset and active categories from General Tab", () => {
+		render(<ExROptionViewer />);
+
+		// Should render Preset
+		expect(screen.getByText("Preset")).toBeInTheDocument();
+		expect(screen.getByText("Default")).toBeInTheDocument();
+
+		// Should render Active Category
+		expect(screen.getByText("Active Cat")).toBeInTheDocument();
+
+		// Should NOT render Inactive Category
+		expect(screen.queryByText("Inactive Cat")).not.toBeInTheDocument();
+	});
+
+	it("renders options within active category when opened", () => {
+		// Open the category
+		useStore.getState().toggleExRCategory(1);
+
+		render(<ExROptionViewer />);
+
+		// Should render Option 1
+		expect(screen.getByText("Opt 1")).toBeInTheDocument();
+		expect(screen.getByText("123")).toBeInTheDocument();
+	});
+});

--- a/tests/ExROptionViewer.test.tsx
+++ b/tests/ExROptionViewer.test.tsx
@@ -2,7 +2,10 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ExROptionViewer } from "../src/feature/rightsidepanel/ExROptionViewer";
 import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
-import { getUniqueOptionId, PRESET_OPTION_UNIQUE_ID } from "../src/logics/optionUtils";
+import {
+	getUniqueOptionId,
+	PRESET_OPTION_UNIQUE_ID,
+} from "../src/logics/optionUtils";
 import { ExRTabId } from "../src/type";
 import { useStore } from "../src/useStore";
 
@@ -36,7 +39,10 @@ describe("ExROptionViewer Component", () => {
 		};
 
 		// Category 1: Active
-		exrOptionMetaData.categories[1] = { name: "Active Cat", tabId: ExRTabId.GeneralTab };
+		exrOptionMetaData.categories[1] = {
+			name: "Active Cat",
+			tabId: ExRTabId.GeneralTab,
+		};
 		const opt1 = getUniqueOptionId(ExRTabId.GeneralTab, 1, 101);
 		exrOptionMetaData.globalCategoryIdTopLevelMap[1] = [opt1];
 		exrOptionMetaData.options[opt1] = {
@@ -45,7 +51,10 @@ describe("ExROptionViewer Component", () => {
 		};
 
 		// Category 2: Inactive
-		exrOptionMetaData.categories[2] = { name: "Inactive Cat", tabId: ExRTabId.GeneralTab };
+		exrOptionMetaData.categories[2] = {
+			name: "Inactive Cat",
+			tabId: ExRTabId.GeneralTab,
+		};
 		const opt2 = getUniqueOptionId(ExRTabId.GeneralTab, 2, 102);
 		exrOptionMetaData.globalCategoryIdTopLevelMap[2] = [opt2];
 		exrOptionMetaData.options[opt2] = {

--- a/tests/exrOptionUtils.test.ts
+++ b/tests/exrOptionUtils.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { filterVisibleCategoryIds, filterVisibleTopLevelOptionIds } from "../src/logics/exrOptionUtils";
 import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
-import { getUniqueOptionId, PRESET_OPTION_UNIQUE_ID } from "../src/logics/optionUtils";
+import {
+	filterVisibleCategoryIds,
+	filterVisibleTopLevelOptionIds,
+} from "../src/logics/exrOptionUtils";
+import {
+	getUniqueOptionId,
+	PRESET_OPTION_UNIQUE_ID,
+} from "../src/logics/optionUtils";
 
 describe("exrOptionUtils", () => {
 	describe("filterVisibleCategoryIds", () => {

--- a/tests/exrOptionUtils.test.ts
+++ b/tests/exrOptionUtils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { filterVisibleCategoryIds, filterVisibleTopLevelOptionIds } from "../src/logics/exrOptionUtils";
+import { exrOptionMetaData, resetExrOptionMetaData } from "../src/logics/api";
+import { getUniqueOptionId, PRESET_OPTION_UNIQUE_ID } from "../src/logics/optionUtils";
+
+describe("exrOptionUtils", () => {
+	describe("filterVisibleCategoryIds", () => {
+		it("filters out categories with no active options", () => {
+			resetExrOptionMetaData();
+			const opt1 = getUniqueOptionId(0, 1, 101);
+			const opt2 = getUniqueOptionId(0, 2, 102);
+
+			exrOptionMetaData.globalCategoryIdTopLevelMap[1] = [opt1];
+			exrOptionMetaData.globalCategoryIdTopLevelMap[2] = [opt2];
+
+			const isExROptionActive = {
+				[opt1]: true,
+				[opt2]: false,
+			};
+
+			const result = filterVisibleCategoryIds([1, 2], isExROptionActive);
+			expect(result).toEqual([1]);
+		});
+
+		it("filters out preset option from category 0", () => {
+			resetExrOptionMetaData();
+			const opt0 = PRESET_OPTION_UNIQUE_ID;
+			const opt1 = getUniqueOptionId(0, 0, 101);
+
+			exrOptionMetaData.globalCategoryIdTopLevelMap[0] = [opt0, opt1];
+
+			const isExROptionActive = {
+				[opt0]: true,
+				[opt1]: false,
+			};
+
+			// opt1 is inactive, and opt0 (preset) should be ignored for visibility check
+			const result = filterVisibleCategoryIds([0], isExROptionActive);
+			expect(result).toEqual([]);
+
+			// Now make opt1 active
+			isExROptionActive[opt1] = true;
+			const result2 = filterVisibleCategoryIds([0], isExROptionActive);
+			expect(result2).toEqual([0]);
+		});
+	});
+
+	describe("filterVisibleTopLevelOptionIds", () => {
+		it("filters out preset option from category 0", () => {
+			const opt0 = PRESET_OPTION_UNIQUE_ID;
+			const opt1 = getUniqueOptionId(0, 0, 101);
+
+			const result = filterVisibleTopLevelOptionIds(0, [opt0, opt1]);
+			expect(result).toEqual([opt1]);
+		});
+
+		it("does not filter anything from other categories", () => {
+			const opt1 = getUniqueOptionId(0, 1, 101);
+			const result = filterVisibleTopLevelOptionIds(1, [opt1]);
+			expect(result).toEqual([opt1]);
+		});
+	});
+});


### PR DESCRIPTION
ExROptionViewerにExRのGeneralTabの情報を表示するように変更しました。
主な変更点は以下の通りです：

1. `ExROptionViewer` を更新し、プリセット設定の下にGeneralTabのカテゴリを表示するようにしました。
2. 非アクティブなオプションや、アクティブなオプションを持たないカテゴリを非表示にするフィルタリングロジックを実装しました。
3. カテゴリとオプションの表示ロジックを `src/logics/exrOptionUtils.ts` に集約し、既存の `ExRCategoryList` と共有するようにリファクタリングしました。
4. 各オプション行をダブルクリックすることで、メイン設定画面の該当箇所へ遷移する機能を実装しました。
5. ユニットテスト (`tests/ExROptionViewer.test.tsx`, `tests/exrOptionUtils.test.ts`) およびE2Eテスト (`e2e/exr_viewer.spec.ts`) を追加しました。

---
*PR created automatically by Jules for task [6020824422083358098](https://jules.google.com/task/6020824422083358098) started by @yukieiji*