### PR TITLE
Role Filterのスキーマ更新とE2Eテストの追加

### DIFF
--- a/e2e/role_filter.spec.ts
+++ b/e2e/role_filter.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Role Filter Tab', () => {
+  test.beforeEach(async ({ page }) => {
+    // モックを使用する設定でページを開く
+    await page.goto('http://localhost:5173/');
+    // データの読み込みを待つ
+    await page.waitForSelector('text=Au Options');
+  });
+
+  test('should display Role Filter data when the tab is selected', async ({ page }) => {
+    // Role Filter タブをクリック (ショートカット 'R')
+    const roleFilterTab = page.getByRole('button', { name: 'Role Filter' });
+    if (await roleFilterTab.isVisible()) {
+        await roleFilterTab.click();
+    } else {
+        await page.getByTitle('Role Filter').click();
+    }
+
+    // Role Filter のタイトルが表示されていることを確認
+    await expect(page.getByRole('heading', { name: 'Role Filter' })).toBeVisible();
+
+    // JSONデータが表示されていることを確認 (PREタグ内)
+    const preElement = page.locator('pre');
+    await expect(preElement).toBeVisible();
+
+    const content = await preElement.textContent();
+    expect(content).toContain('FilterSet');
+    expect(content).toContain('c521f29a-4a3d-4896-a642-8fc8a22aa8e6');
+    expect(content).toContain('Bakary');
+    expect(content).toContain('Opener');
+    expect(content).toContain('Carpenter');
+  });
+});

--- a/e2e/role_filter.spec.ts
+++ b/e2e/role_filter.spec.ts
@@ -1,34 +1,38 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Role Filter Tab', () => {
-  test.beforeEach(async ({ page }) => {
-    // モックを使用する設定でページを開く
-    await page.goto('http://localhost:5173/');
-    // データの読み込みを待つ
-    await page.waitForSelector('text=Au Options');
-  });
+test.describe("Role Filter Tab", () => {
+	test.beforeEach(async ({ page }) => {
+		// モックを使用する設定でページを開く
+		await page.goto("http://localhost:5173/");
+		// データの読み込みを待つ
+		await page.waitForSelector("text=Au Options");
+	});
 
-  test('should display Role Filter data when the tab is selected', async ({ page }) => {
-    // Role Filter タブをクリック (ショートカット 'R')
-    const roleFilterTab = page.getByRole('button', { name: 'Role Filter' });
-    if (await roleFilterTab.isVisible()) {
-        await roleFilterTab.click();
-    } else {
-        await page.getByTitle('Role Filter').click();
-    }
+	test("should display Role Filter data when the tab is selected", async ({
+		page,
+	}) => {
+		// Role Filter タブをクリック (ショートカット 'R')
+		const roleFilterTab = page.getByRole("button", { name: "Role Filter" });
+		if (await roleFilterTab.isVisible()) {
+			await roleFilterTab.click();
+		} else {
+			await page.getByTitle("Role Filter").click();
+		}
 
-    // Role Filter のタイトルが表示されていることを確認
-    await expect(page.getByRole('heading', { name: 'Role Filter' })).toBeVisible();
+		// Role Filter のタイトルが表示されていることを確認
+		await expect(
+			page.getByRole("heading", { name: "Role Filter" }),
+		).toBeVisible();
 
-    // JSONデータが表示されていることを確認 (PREタグ内)
-    const preElement = page.locator('pre');
-    await expect(preElement).toBeVisible();
+		// JSONデータが表示されていることを確認 (PREタグ内)
+		const preElement = page.locator("pre");
+		await expect(preElement).toBeVisible();
 
-    const content = await preElement.textContent();
-    expect(content).toContain('FilterSet');
-    expect(content).toContain('c521f29a-4a3d-4896-a642-8fc8a22aa8e6');
-    expect(content).toContain('Bakary');
-    expect(content).toContain('Opener');
-    expect(content).toContain('Carpenter');
-  });
+		const content = await preElement.textContent();
+		expect(content).toContain("FilterSet");
+		expect(content).toContain("c521f29a-4a3d-4896-a642-8fc8a22aa8e6");
+		expect(content).toContain("Bakary");
+		expect(content).toContain("Opener");
+		expect(content).toContain("Carpenter");
+	});
 });

--- a/e2e/role_filter.spec.ts
+++ b/e2e/role_filter.spec.ts
@@ -3,9 +3,17 @@ import { expect, test } from "@playwright/test";
 test.describe("Role Filter Tab", () => {
 	test.beforeEach(async ({ page }) => {
 		// モックを使用する設定でページを開く
-		await page.goto("http://localhost:5173/");
-		// データの読み込みを待つ
-		await page.waitForSelector("text=Au Options");
+		await page.goto("/");
+
+		// ローディング画面が消えるのを待つ
+		await expect(page.getByText("Loading data...")).not.toBeVisible({
+			timeout: 30000,
+		});
+
+		// サイドバーが表示されるまで待機（アプリケーションがインタラクティブになったことの確認）
+		await expect(page.getByLabel("オプションサイドバー")).toBeVisible({
+			timeout: 30000,
+		});
 	});
 
 	test("should display Role Filter data when the tab is selected", async ({

--- a/e2e/role_filter.spec.ts
+++ b/e2e/role_filter.spec.ts
@@ -20,12 +20,11 @@ test.describe("Role Filter Tab", () => {
 		page,
 	}) => {
 		// Role Filter タブをクリック (ショートカット 'R')
-		const roleFilterTab = page.getByRole("button", { name: "Role Filter" });
-		if (await roleFilterTab.isVisible()) {
-			await roleFilterTab.click();
-		} else {
-			await page.getByTitle("Role Filter").click();
-		}
+		// サイドバーが開いている場合(button)と閉じている場合(titleのみ)の両方に対応
+		await page
+			.getByRole("button", { name: "Role Filter" })
+			.or(page.getByTitle("Role Filter"))
+			.click();
 
 		// Role Filter のタイトルが表示されていることを確認
 		await expect(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: process.env.CI,
+  forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */

--- a/src/type.ts
+++ b/src/type.ts
@@ -378,16 +378,25 @@ export interface TranslationMetaDataRecords {
 
 export interface RoleAssignFilterSetDto {
 	AssignNum: number;
-	FilterNormalId: Record<number, number>;
-	FilterCombinationId: Record<number, number>;
-	FilterGhostRoleId: Record<number, number>;
+	FilterNormalId: Record<number, number | string>;
+	FilterCombinationId: Record<number, number | string>;
+	FilterGhostRoleId: Record<number, number | string>;
 }
 
 export const RoleAssignFilterSetDtoSchema = z.object({
 	AssignNum: z.number().int(),
-	FilterNormalId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
-	FilterCombinationId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
-	FilterGhostRoleId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
+	FilterNormalId: z.record(
+		z.coerce.number(),
+		z.union([z.number().int(), z.string()]),
+	),
+	FilterCombinationId: z.record(
+		z.coerce.number(),
+		z.union([z.number().int(), z.string()]),
+	),
+	FilterGhostRoleId: z.record(
+		z.coerce.number(),
+		z.union([z.number().int(), z.string()]),
+	),
 });
 
 export interface RoleAssignFilterDto {
@@ -401,7 +410,16 @@ export interface RoleAssignFilterDto {
 export const RoleAssignFilterDtoSchema = z.object({
 	FilterSet: z.record(z.string(), RoleAssignFilterSetDtoSchema),
 	FilterRoleId: z.array(z.number().int()),
-	NormalRoleId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
-	CombinationId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
-	GhostRoleId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
+	NormalRoleId: z.record(
+		z.coerce.number(),
+		z.union([z.number().int(), z.string()]),
+	),
+	CombinationId: z.record(
+		z.coerce.number(),
+		z.union([z.number().int(), z.string()]),
+	),
+	GhostRoleId: z.record(
+		z.coerce.number(),
+		z.union([z.number().int(), z.string()]),
+	),
 });

--- a/src/type.ts
+++ b/src/type.ts
@@ -376,13 +376,6 @@ export interface TranslationMetaDataRecords {
 	[key: string | number]: string | string[] | undefined;
 }
 
-export interface RoleAssignFilterSetDto {
-	AssignNum: number;
-	FilterNormalId: Record<number, number | string>;
-	FilterCombinationId: Record<number, number | string>;
-	FilterGhostRoleId: Record<number, number | string>;
-}
-
 export const RoleAssignFilterSetDtoSchema = z.object({
 	AssignNum: z.number().int(),
 	FilterNormalId: z.record(
@@ -399,13 +392,7 @@ export const RoleAssignFilterSetDtoSchema = z.object({
 	),
 });
 
-export interface RoleAssignFilterDto {
-	FilterSet: Record<string, RoleAssignFilterSetDto>;
-	FilterRoleId: number[];
-	NormalRoleId: Record<number, number | string>;
-	CombinationId: Record<number, number | string>;
-	GhostRoleId: Record<number, number | string>;
-}
+export type RoleAssignFilterSetDto = z.infer<typeof RoleAssignFilterSetDtoSchema>;
 
 export const RoleAssignFilterDtoSchema = z.object({
 	FilterSet: z.record(z.string(), RoleAssignFilterSetDtoSchema),
@@ -423,3 +410,5 @@ export const RoleAssignFilterDtoSchema = z.object({
 		z.union([z.number().int(), z.string()]),
 	),
 });
+
+export type RoleAssignFilterDto = z.infer<typeof RoleAssignFilterDtoSchema>;

--- a/src/type.ts
+++ b/src/type.ts
@@ -392,7 +392,9 @@ export const RoleAssignFilterSetDtoSchema = z.object({
 	),
 });
 
-export type RoleAssignFilterSetDto = z.infer<typeof RoleAssignFilterSetDtoSchema>;
+export type RoleAssignFilterSetDto = z.infer<
+	typeof RoleAssignFilterSetDtoSchema
+>;
 
 export const RoleAssignFilterDtoSchema = z.object({
 	FilterSet: z.record(z.string(), RoleAssignFilterSetDtoSchema),

--- a/src/type.ts
+++ b/src/type.ts
@@ -385,23 +385,23 @@ export interface RoleAssignFilterSetDto {
 
 export const RoleAssignFilterSetDtoSchema = z.object({
 	AssignNum: z.number().int(),
-	FilterNormalId: z.record(z.coerce.number(), z.number().int()),
-	FilterCombinationId: z.record(z.coerce.number(), z.number().int()),
-	FilterGhostRoleId: z.record(z.coerce.number(), z.number().int()),
+	FilterNormalId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
+	FilterCombinationId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
+	FilterGhostRoleId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
 });
 
 export interface RoleAssignFilterDto {
 	FilterSet: Record<string, RoleAssignFilterSetDto>;
 	FilterRoleId: number[];
-	NormalRoleId: Record<number, number>;
-	CombinationId: Record<number, number>;
-	GhostRoleId: Record<number, number>;
+	NormalRoleId: Record<number, number | string>;
+	CombinationId: Record<number, number | string>;
+	GhostRoleId: Record<number, number | string>;
 }
 
 export const RoleAssignFilterDtoSchema = z.object({
 	FilterSet: z.record(z.string(), RoleAssignFilterSetDtoSchema),
 	FilterRoleId: z.array(z.number().int()),
-	NormalRoleId: z.record(z.coerce.number(), z.number().int()),
-	CombinationId: z.record(z.coerce.number(), z.number().int()),
-	GhostRoleId: z.record(z.coerce.number(), z.number().int()),
+	NormalRoleId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
+	CombinationId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
+	GhostRoleId: z.record(z.coerce.number(), z.union([z.number().int(), z.string()])),
 });


### PR DESCRIPTION
Role Filterのデータ形式変更（IDが数値から文字列/Enumへ）に対応するため、ZodスキーマとTypeScriptの型定義を更新しました。また、Role Filterタブの表示を検証するE2Eテストを新規追加し、正常に動作することを確認しました。

---
*PR created automatically by Jules for task [2470757351691496324](https://jules.google.com/task/2470757351691496324) started by @yukieiji*