### PR TITLE
Refactor Role Filter data storage

### DIFF
--- a/e2e/role_filter.spec.ts
+++ b/e2e/role_filter.spec.ts
@@ -36,7 +36,7 @@ test.describe("Role Filter Tab", () => {
 		await expect(preElement).toBeVisible();
 
 		const content = await preElement.textContent();
-		expect(content).toContain("FilterSet");
+		expect(content).not.toContain("FilterSet");
 		expect(content).toContain("c521f29a-4a3d-4896-a642-8fc8a22aa8e6");
 		expect(content).toContain("Bakary");
 		expect(content).toContain("Opener");

--- a/src/feature/exr/RoleFilterViewer.tsx
+++ b/src/feature/exr/RoleFilterViewer.tsx
@@ -4,11 +4,11 @@ import { useStore } from "../../useStore";
  * Role Filter のデータをJSON形式で表示するコンポーネント
  */
 export function RoleFilterViewer() {
-	const roleFilterData = useStore((state) => {
-		return state.roleFilterData;
+	const roleFilterSet = useStore((state) => {
+		return state.roleFilterSet;
 	});
 
-	if (!roleFilterData) {
+	if (!roleFilterSet) {
 		return (
 			<div className="p-4 bg-gray-100 rounded-md">
 				<p className="text-gray-500">No role filter data available.</p>
@@ -18,7 +18,7 @@ export function RoleFilterViewer() {
 
 	return (
 		<div className="p-4 bg-gray-900 text-green-400 rounded-md overflow-auto font-mono text-sm max-h-[calc(100vh-200px)]">
-			<pre>{JSON.stringify(roleFilterData, null, 2)}</pre>
+			<pre>{JSON.stringify(roleFilterSet, null, 2)}</pre>
 		</div>
 	);
 }

--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -12,7 +12,6 @@ import {
 	createExROptionMetaData,
 	fetchRoleFilterData,
 	fetchTranslationMetaData,
-	roleFilterMetaData,
 	updateAuOption,
 	updateExrOption,
 } from "./api";
@@ -91,10 +90,6 @@ async function createAuOptionMetaDataWithStore(): Promise<void> {
 async function fetchRoleFilterDataWithStore(): Promise<void> {
 	await waitDelay();
 	const data = await fetchRoleFilterData();
-	roleFilterMetaData.FilterRoleId = data.FilterRoleId;
-	roleFilterMetaData.NormalRoleId = data.NormalRoleId;
-	roleFilterMetaData.CombinationId = data.CombinationId;
-	roleFilterMetaData.GhostRoleId = data.GhostRoleId;
 	useStore.getState().setRoleFilterSet(data.FilterSet);
 }
 

--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -12,6 +12,7 @@ import {
 	createExROptionMetaData,
 	fetchRoleFilterData,
 	fetchTranslationMetaData,
+	roleFilterMetaData,
 	updateAuOption,
 	updateExrOption,
 } from "./api";
@@ -90,7 +91,11 @@ async function createAuOptionMetaDataWithStore(): Promise<void> {
 async function fetchRoleFilterDataWithStore(): Promise<void> {
 	await waitDelay();
 	const data = await fetchRoleFilterData();
-	useStore.getState().setRoleFilterData(data);
+	roleFilterMetaData.FilterRoleId = data.FilterRoleId;
+	roleFilterMetaData.NormalRoleId = data.NormalRoleId;
+	roleFilterMetaData.CombinationId = data.CombinationId;
+	roleFilterMetaData.GhostRoleId = data.GhostRoleId;
+	useStore.getState().setRoleFilterSet(data.FilterSet);
 }
 
 export function useUpdateAuOptionSelection(): (

--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -90,7 +90,7 @@ async function createAuOptionMetaDataWithStore(): Promise<void> {
 async function fetchRoleFilterDataWithStore(): Promise<void> {
 	await waitDelay();
 	const data = await fetchRoleFilterData();
-	useStore.getState().setRoleFilterSet(data.FilterSet);
+	useStore.getState().setRoleFilterSet(data);
 }
 
 export function useUpdateAuOptionSelection(): (

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -7,6 +7,7 @@ import type {
 	ExROptionValueData,
 	ExRTabMetaData,
 	RoleAssignFilterDto,
+	RoleFilterMetaData,
 	TranslationMetaDataRecords,
 	UniqueOptionId,
 	UpdatedOptions,
@@ -53,6 +54,13 @@ export const auOptionMetaData: AuOptionMetaDataRecords = {
 	options: {},
 };
 
+export const roleFilterMetaData: RoleFilterMetaData = {
+	FilterRoleId: [],
+	NormalRoleId: {},
+	CombinationId: {},
+	GhostRoleId: {},
+};
+
 /**
  * ExRオプションのメタデータをリセットする（テスト用）
  */
@@ -71,6 +79,16 @@ export function resetAuOptionMetaData() {
 	auOptionMetaData.tabCategoryMap = {};
 	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};
+}
+
+/**
+ * RoleFilterのメタデータをリセットする（テスト用）
+ */
+export function resetRoleFilterMetaData() {
+	roleFilterMetaData.FilterRoleId = [];
+	roleFilterMetaData.NormalRoleId = {};
+	roleFilterMetaData.CombinationId = {};
+	roleFilterMetaData.GhostRoleId = {};
 }
 
 interface ExRinitializeData {

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -373,7 +373,14 @@ export async function fetchRoleFilterData(): Promise<RoleAssignFilterDto> {
 	}
 
 	const jsonData = await res.json();
-	return await RoleAssignFilterDtoSchema.parseAsync(jsonData);
+	const data = await RoleAssignFilterDtoSchema.parseAsync(jsonData);
+
+	roleFilterMetaData.FilterRoleId = data.FilterRoleId;
+	roleFilterMetaData.NormalRoleId = data.NormalRoleId;
+	roleFilterMetaData.CombinationId = data.CombinationId;
+	roleFilterMetaData.GhostRoleId = data.GhostRoleId;
+
+	return data;
 }
 
 export async function updateAuOption(

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -6,7 +6,7 @@ import type {
 	ExROptionMetaDataRecords,
 	ExROptionValueData,
 	ExRTabMetaData,
-	RoleAssignFilterDto,
+	RoleAssignFilterSetDto,
 	RoleFilterMetaData,
 	TranslationMetaDataRecords,
 	UniqueOptionId,
@@ -366,7 +366,9 @@ export async function updateExrOption(
 	return await UpdatedOptionsSchema.parseAsync(jsonData);
 }
 
-export async function fetchRoleFilterData(): Promise<RoleAssignFilterDto> {
+export async function fetchRoleFilterData(): Promise<
+	Record<string, RoleAssignFilterSetDto>
+> {
 	const res = await fetch(EXR_ROLE_FILTER_URL);
 	if (!res.ok) {
 		throw new Error(`Failed to fetch role filter data: ${res.statusText}`);
@@ -380,7 +382,7 @@ export async function fetchRoleFilterData(): Promise<RoleAssignFilterDto> {
 	roleFilterMetaData.CombinationId = data.CombinationId;
 	roleFilterMetaData.GhostRoleId = data.GhostRoleId;
 
-	return data;
+	return data.FilterSet;
 }
 
 export async function updateAuOption(

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -8,7 +8,7 @@ import {
 import type {
 	ExROptionValueData,
 	ExRTabId,
-	RoleAssignFilterDto,
+	RoleAssignFilterSetDto,
 	UniqueOptionId,
 	UpdatedOptions,
 } from "../type";
@@ -26,7 +26,7 @@ export interface ExROptionViewerSlice {
 	exrValue: Record<UniqueOptionId, ExROptionValueData>;
 	isExROptionActive: Record<UniqueOptionId, boolean>;
 	highlightedExROptionId: UniqueOptionId | null;
-	roleFilterData: RoleAssignFilterDto | null;
+	roleFilterSet: Record<string, RoleAssignFilterSetDto> | null;
 	setSelectedExRTabId: (id: ExRTabId) => void;
 	setIsExRTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
@@ -40,7 +40,7 @@ export interface ExROptionViewerSlice {
 		valueData: Record<UniqueOptionId, ExROptionValueData>,
 		optionActiveData: Record<UniqueOptionId, boolean>,
 	) => void;
-	setRoleFilterData: (data: RoleAssignFilterDto) => void;
+	setRoleFilterSet: (data: Record<string, RoleAssignFilterSetDto>) => void;
 	validateOpenedIds: () => void;
 }
 
@@ -58,7 +58,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		exrValue: {},
 		isExROptionActive: {},
 		highlightedExROptionId: null,
-		roleFilterData: null,
+		roleFilterSet: null,
 		presetNames: loadPresetNamesFromLocalStorage(),
 		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: ExRTabId) => {
@@ -156,8 +156,8 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 				isExROptionActive: optionActiveData,
 			});
 		},
-		setRoleFilterData: (data: RoleAssignFilterDto) => {
-			set({ roleFilterData: data });
+		setRoleFilterSet: (data: Record<string, RoleAssignFilterSetDto>) => {
+			set({ roleFilterSet: data });
 		},
 		validateOpenedIds: () => {
 			set((state) => {

--- a/src/type.ts
+++ b/src/type.ts
@@ -414,3 +414,10 @@ export const RoleAssignFilterDtoSchema = z.object({
 });
 
 export type RoleAssignFilterDto = z.infer<typeof RoleAssignFilterDtoSchema>;
+
+export interface RoleFilterMetaData {
+	FilterRoleId: number[];
+	NormalRoleId: Record<number, number | string>;
+	CombinationId: Record<number, number | string>;
+	GhostRoleId: Record<number, number | string>;
+}

--- a/src/type.ts
+++ b/src/type.ts
@@ -417,7 +417,7 @@ export type RoleAssignFilterDto = z.infer<typeof RoleAssignFilterDtoSchema>;
 
 export interface RoleFilterMetaData {
 	FilterRoleId: number[];
-	NormalRoleId: Record<number, number | string>;
-	CombinationId: Record<number, number | string>;
-	GhostRoleId: Record<number, number | string>;
+	NormalRoleId: Record<string, number | string>;
+	CombinationId: Record<string, number | string>;
+	GhostRoleId: Record<string, number | string>;
 }


### PR DESCRIPTION
This PR refactors how Role Filter data is handled in the application.

Following the requirements:
1.  **Metadata Separation**: "FilterRoleId", "GhostRoleId", "CombinationId", and "NormalRoleId" are now fetched once and stored in a global `roleFilterMetaData` variable in `src/logics/api.ts`, similar to how other metadata is handled.
2.  **Zustand Store Optimization**: The Zustand store now only keeps the `FilterSet` data, renamed to `roleFilterSet` for clarity.
3.  **UI Update**: The `RoleFilterViewer` component was updated to reflect these changes, displaying only the filter set data from the store.
4.  **Testing Support**: A `resetRoleFilterMetaData` function was added to ensure the global metadata can be reset during tests.

All existing tests passed successfully.

---
*PR created automatically by Jules for task [5251570646105673828](https://jules.google.com/task/5251570646105673828) started by @yukieiji*