### PR TITLE
Make right sidebar resizable and persistent

### DIFF
--- a/e2e/right_sidebar_resize.spec.ts
+++ b/e2e/right_sidebar_resize.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.goto("/");
+	// ローディング画面が消えるのを待つ
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+});
+
+test("isResizing state is correctly managed", async ({ page }) => {
+	const rightPanel = page.getByLabel("右フローティングパネル");
+	const toggleButton = page.getByRole("button", { name: "パネルを開く" });
+
+	await toggleButton.click();
+	await expect(rightPanel).toBeVisible();
+
+	const handle = page.locator("div.cursor-ew-resize").first();
+	await expect(handle).toBeVisible();
+	const handleBox = await handle.boundingBox();
+	if (!handleBox) {
+		throw new Error("Handle box not found");
+	}
+
+	// ドラッグ開始
+	await page.mouse.move(
+		handleBox.x + handleBox.width / 2,
+		handleBox.y + handleBox.height / 2,
+	);
+	await page.mouse.down();
+
+	// リサイズ中は transition が none であることを確認 (style属性を確認)
+	const style = await rightPanel.getAttribute("style");
+	expect(style).toContain("transition: none");
+
+	// body のカーソルが ew-resize であることを確認
+	await expect(page.locator("body")).toHaveCSS("cursor", "ew-resize");
+
+	await page.mouse.up();
+
+	// リサイズ終了後は transition が復活することを確認
+	const styleAfter = await rightPanel.getAttribute("style");
+	expect(styleAfter).toContain("transition: transform 300ms ease-in-out");
+
+	// body のカーソルが元に戻ることを確認
+	await expect(page.locator("body")).toHaveCSS("cursor", "auto");
+});
+
+test("right sidebar can be resized", async ({ page }) => {
+	const rightPanel = page.getByLabel("右フローティングパネル");
+	const toggleButton = page.getByRole("button", { name: "パネルを開く" });
+
+	await toggleButton.click();
+	await expect(rightPanel).toBeVisible();
+
+	const initialBox = await rightPanel.boundingBox();
+	expect(initialBox?.width).toBe(320);
+
+	const handle = page.locator("div.cursor-ew-resize").first();
+	const handleBox = await handle.boundingBox();
+	if (!handleBox) {
+		throw new Error("Handle box not found");
+	}
+
+	// 左にドラッグしてリサイズ
+	await page.mouse.move(
+		handleBox.x + handleBox.width / 2,
+		handleBox.y + handleBox.height / 2,
+	);
+	await page.mouse.down();
+	await page.mouse.move(handleBox.x - 100, handleBox.y + handleBox.height / 2);
+	await page.mouse.up();
+
+	const resizedBox = await rightPanel.boundingBox();
+	expect(resizedBox?.width).toBeGreaterThan(400);
+});

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -1,4 +1,4 @@
-import { use, useEffect } from "react";
+import { use, useEffect, useState, useCallback } from "react";
 import { CompactAccordion } from "../../components/blocks/CompactAccordion";
 import { RightPanelGroupColumnLayout } from "../../components/parts/RightPanelGroupColumnLayout";
 import { getAllOptions } from "../../logics/api.store";
@@ -30,6 +30,8 @@ export function RightFloatingPanel() {
 	const setRightPanelOpen = useStore((state) => {
 		return state.setRightPanelOpen;
 	});
+	const rightPanelWidth = useStore((state) => state.rightPanelWidth);
+	const setRightPanelWidth = useStore((state) => state.setRightPanelWidth);
 
 	const isSettingsOpen = useStore((state) => state.isSettingsOpen);
 	const toggleSettings = useStore((state) => state.toggleSettings);
@@ -37,6 +39,52 @@ export function RightFloatingPanel() {
 	const toggleAuSettings = useStore((state) => state.toggleAuSettings);
 	const isExrSettingsOpen = useStore((state) => state.isExrSettingsOpen);
 	const toggleExrSettings = useStore((state) => state.toggleExrSettings);
+
+	const [isResizing, setIsResizing] = useState(false);
+	const MIN_WIDTH = 320;
+
+	const handleMouseDown = useCallback((e: React.MouseEvent) => {
+		e.preventDefault();
+		setIsResizing(true);
+	}, []);
+
+	const handleMouseMove = useCallback(
+		(e: MouseEvent) => {
+			if (!isResizing) return;
+
+			const newWidth = window.innerWidth - e.clientX;
+			const maxWidth = window.innerWidth * 0.8;
+
+			if (newWidth >= MIN_WIDTH && newWidth <= maxWidth) {
+				setRightPanelWidth(newWidth);
+			}
+		},
+		[isResizing, setRightPanelWidth],
+	);
+
+	const handleMouseUp = useCallback(() => {
+		if (isResizing) {
+			setIsResizing(false);
+			localStorage.setItem("rightPanelWidth", rightPanelWidth.toString());
+		}
+	}, [isResizing, rightPanelWidth]);
+
+	useEffect(() => {
+		if (isResizing) {
+			document.body.style.cursor = "ew-resize";
+			window.addEventListener("mousemove", handleMouseMove);
+			window.addEventListener("mouseup", handleMouseUp);
+		} else {
+			document.body.style.cursor = "";
+			window.removeEventListener("mousemove", handleMouseMove);
+			window.removeEventListener("mouseup", handleMouseUp);
+		}
+
+		return () => {
+			window.removeEventListener("mousemove", handleMouseMove);
+			window.removeEventListener("mouseup", handleMouseUp);
+		};
+	}, [isResizing, handleMouseMove, handleMouseUp]);
 
 	// Escapeキーでパネルを閉じるためのグローバルリスナー
 	useEffect(() => {
@@ -60,10 +108,15 @@ export function RightFloatingPanel() {
 				onClick={toggleRightPanel}
 				className={`
           fixed top-0 z-50 h-full w-6 bg-blue-600 text-white shadow-md
-          hover:bg-blue-700 transition-all duration-300 ease-in-out flex items-center justify-center
+          hover:bg-blue-700 flex items-center justify-center
           cursor-pointer
-          ${isRightPanelOpen ? "right-80" : "right-0"}
         `}
+				style={{
+					right: isRightPanelOpen ? rightPanelWidth : 0,
+					transition: isResizing
+						? "none"
+						: "right 300ms ease-in-out, background-color 300ms ease-in-out",
+				}}
 				aria-label={isRightPanelOpen ? PANEL_CLOSE_ARIA : PANEL_OPEN_ARIA}
 			>
 				<span className="text-sm font-bold">
@@ -74,12 +127,26 @@ export function RightFloatingPanel() {
 			{/* パネル本体 */}
 			<aside
 				className={`
-          fixed right-0 top-0 h-full w-80 bg-white border-l border-gray-200 shadow-2xl z-40
-          transition-transform duration-300 ease-in-out transform
+          fixed right-0 top-0 h-full bg-white border-l border-gray-200 shadow-2xl z-40
+          transform
           ${isRightPanelOpen ? "translate-x-0" : "translate-x-full"}
         `}
+				style={{
+					width: rightPanelWidth,
+					transition: isResizing
+						? "none"
+						: "transform 300ms ease-in-out, width 300ms ease-in-out",
+				}}
 				aria-label={RIGHT_PANEL_ARIA}
 			>
+				{/* リサイズハンドル */}
+				{isRightPanelOpen && (
+					<div
+						onMouseDown={handleMouseDown}
+						className="absolute left-0 top-0 h-full w-1 cursor-ew-resize hover:bg-blue-400 transition-colors z-50"
+						aria-hidden="true"
+					/>
+				)}
 				<div className="flex flex-col h-full">
 					<div className="flex items-center justify-between p-4 border-b border-gray-100">
 						<h2 className="text-lg font-semibold">{RIGHT_PANEL_TITLE}</h2>

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -1,4 +1,4 @@
-import { use, useEffect, useState, useCallback } from "react";
+import { use, useCallback, useEffect } from "react";
 import { CompactAccordion } from "../../components/blocks/CompactAccordion";
 import { RightPanelGroupColumnLayout } from "../../components/parts/RightPanelGroupColumnLayout";
 import { getAllOptions } from "../../logics/api.store";
@@ -32,6 +32,8 @@ export function RightFloatingPanel() {
 	});
 	const rightPanelWidth = useStore((state) => state.rightPanelWidth);
 	const setRightPanelWidth = useStore((state) => state.setRightPanelWidth);
+	const isResizing = useStore((state) => state.isResizing);
+	const setIsResizing = useStore((state) => state.setIsResizing);
 
 	const isSettingsOpen = useStore((state) => state.isSettingsOpen);
 	const toggleSettings = useStore((state) => state.toggleSettings);
@@ -40,17 +42,21 @@ export function RightFloatingPanel() {
 	const isExrSettingsOpen = useStore((state) => state.isExrSettingsOpen);
 	const toggleExrSettings = useStore((state) => state.toggleExrSettings);
 
-	const [isResizing, setIsResizing] = useState(false);
 	const MIN_WIDTH = 320;
 
-	const handleMouseDown = useCallback((e: React.MouseEvent) => {
-		e.preventDefault();
-		setIsResizing(true);
-	}, []);
+	const handleMouseDown = useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			setIsResizing(true);
+		},
+		[setIsResizing],
+	);
 
 	const handleMouseMove = useCallback(
 		(e: MouseEvent) => {
-			if (!isResizing) return;
+			if (!isResizing) {
+				return;
+			}
 
 			const newWidth = window.innerWidth - e.clientX;
 			const maxWidth = window.innerWidth * 0.8;
@@ -67,7 +73,7 @@ export function RightFloatingPanel() {
 			setIsResizing(false);
 			localStorage.setItem("rightPanelWidth", rightPanelWidth.toString());
 		}
-	}, [isResizing, rightPanelWidth]);
+	}, [isResizing, rightPanelWidth, setIsResizing]);
 
 	useEffect(() => {
 		if (isResizing) {

--- a/src/slices/rightFloatingPanelSlice.ts
+++ b/src/slices/rightFloatingPanelSlice.ts
@@ -20,6 +20,8 @@ export interface RightFloatingPanelSlice {
 	toggleAuCrewmateRoles: () => void;
 	isAuImpostorRolesOpen: boolean;
 	toggleAuImpostorRoles: () => void;
+	rightPanelWidth: number;
+	setRightPanelWidth: (width: number) => void;
 }
 
 /**
@@ -28,6 +30,9 @@ export interface RightFloatingPanelSlice {
 export const createRightFloatingPanelSlice: StateCreator<
 	RightFloatingPanelSlice
 > = (set) => {
+	const savedWidth = localStorage.getItem("rightPanelWidth");
+	const initialWidth = savedWidth ? Number.parseInt(savedWidth, 10) : 320;
+
 	return {
 		isRightPanelOpen: false, // デフォルトクローズ
 		toggleRightPanel: () => {
@@ -74,6 +79,10 @@ export const createRightFloatingPanelSlice: StateCreator<
 		isAuImpostorRolesOpen: true,
 		toggleAuImpostorRoles: () => {
 			set((state) => ({ isAuImpostorRolesOpen: !state.isAuImpostorRolesOpen }));
+		},
+		rightPanelWidth: initialWidth,
+		setRightPanelWidth: (width) => {
+			set({ rightPanelWidth: width });
 		},
 	};
 };

--- a/src/slices/rightFloatingPanelSlice.ts
+++ b/src/slices/rightFloatingPanelSlice.ts
@@ -22,6 +22,8 @@ export interface RightFloatingPanelSlice {
 	toggleAuImpostorRoles: () => void;
 	rightPanelWidth: number;
 	setRightPanelWidth: (width: number) => void;
+	isResizing: boolean;
+	setIsResizing: (isResizing: boolean) => void;
 }
 
 /**
@@ -83,6 +85,10 @@ export const createRightFloatingPanelSlice: StateCreator<
 		rightPanelWidth: initialWidth,
 		setRightPanelWidth: (width) => {
 			set({ rightPanelWidth: width });
+		},
+		isResizing: false,
+		setIsResizing: (isResizing) => {
+			set({ isResizing });
 		},
 	};
 };

--- a/tests/rightFloatingPanelStore.test.ts
+++ b/tests/rightFloatingPanelStore.test.ts
@@ -9,6 +9,8 @@ describe("RightFloatingPanelStore", () => {
 			isSettingsOpen: true,
 			isAuSettingsOpen: true,
 			isExrSettingsOpen: true,
+			rightPanelWidth: 320,
+			isResizing: false,
 		});
 	});
 
@@ -18,6 +20,8 @@ describe("RightFloatingPanelStore", () => {
 		expect(state.isSettingsOpen).toBe(true);
 		expect(state.isAuSettingsOpen).toBe(true);
 		expect(state.isExrSettingsOpen).toBe(true);
+		expect(state.rightPanelWidth).toBe(320);
+		expect(state.isResizing).toBe(false);
 	});
 
 	it("toggleRightPanel で isRightPanelOpen が切り替わること", () => {
@@ -58,5 +62,18 @@ describe("RightFloatingPanelStore", () => {
 
 		useStore.getState().toggleExrSettings();
 		expect(useStore.getState().isExrSettingsOpen).toBe(true);
+	});
+
+	it("setRightPanelWidth で rightPanelWidth が変更されること", () => {
+		useStore.getState().setRightPanelWidth(400);
+		expect(useStore.getState().rightPanelWidth).toBe(400);
+	});
+
+	it("setIsResizing で isResizing が変更されること", () => {
+		useStore.getState().setIsResizing(true);
+		expect(useStore.getState().isResizing).toBe(true);
+
+		useStore.getState().setIsResizing(false);
+		expect(useStore.getState().isResizing).toBe(false);
 	});
 });


### PR DESCRIPTION
This PR implements the requested feature to make the right sidebar resizable. 
Key changes:
1.  **State Management**: Updated `rightFloatingPanelSlice` to manage `rightPanelWidth`. The width is initialized from `localStorage` and updated via `setRightPanelWidth`.
2.  **Interaction**: Added `onMouseDown`, `onMouseMove`, and `onMouseUp` handlers in `RightFloatingPanel` to handle the drag-to-resize interaction.
3.  **UI**:
    - Added a resize handle line at the left edge of the sidebar.
    - Switched from fixed Tailwind width classes (e.g., `w-80`) to inline styles for dynamic width.
    - Updated the toggle button's position to stay aligned with the dynamic sidebar width.
4.  **Constraints**: Minimum width is set to 320px, and maximum width is capped at 80% of the window width.
5.  **Persistence**: The width is saved to `localStorage` when the user finishes resizing (on mouse up).
6.  **UX**: Transitions are disabled during resizing to ensure smooth dragging, but remain enabled for opening/closing the panel.

---
*PR created automatically by Jules for task [17374221957344374691](https://jules.google.com/task/17374221957344374691) started by @yukieiji*