### PR TITLE
Synchronize right panel and toggle button animations

### DIFF
--- a/src/components/blocks/ViewerGroupAccordion.tsx
+++ b/src/components/blocks/ViewerGroupAccordion.tsx
@@ -31,7 +31,10 @@ export function ViewerGroupAccordion({
 					{title}
 				</div>
 			</button>
-			<AccordionContentContainer isOpen={isOpen}>
+			<AccordionContentContainer
+				isOpen={isOpen}
+				data-testid="right-panel-accordion-content"
+			>
 				<div className="min-h-0">
 					{isOpen && (
 						<div className="py-2 px-1.5 bg-gray-900 border-gray-700">

--- a/src/components/parts/AccordionContentContainer.tsx
+++ b/src/components/parts/AccordionContentContainer.tsx
@@ -3,15 +3,17 @@ import type { ReactNode } from "react";
 export interface AccordionContentContainerProps {
 	isOpen: boolean;
 	children: ReactNode;
+	"data-testid"?: string;
 }
 
 export function AccordionContentContainer({
 	isOpen,
 	children,
+	"data-testid": testId = "accordion-content",
 }: AccordionContentContainerProps) {
 	return (
 		<div
-			data-testid="accordion-content"
+			data-testid={testId}
 			className={`grid transition-[grid-template-rows] duration-200 ease-in-out overflow-hidden ${
 				isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
 			}`}

--- a/src/feature/rightsidepanel/ExROptionRowView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowView.tsx
@@ -1,16 +1,13 @@
-import { ColoredText } from "../../components/parts/ColoredText";
 import type { UniqueOptionId } from "../../type";
 import { ExROptionRowViewContent } from "./ExROptionRowViewContent";
 
 interface ExROptionRowViewProps {
 	uniqueOptionId: UniqueOptionId;
-	depth?: number;
 	isLeaf?: boolean;
 }
 
 export function ExROptionRowView({
 	uniqueOptionId,
-	depth = 0,
 	isLeaf = false,
 }: ExROptionRowViewProps) {
 	return isLeaf ? (

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -1,4 +1,4 @@
-import { use, useCallback, useEffect, useState } from "react";
+import { use, useCallback, useEffect } from "react";
 import { ViewerGroupAccordion } from "../../components/blocks/ViewerGroupAccordion";
 import { RightPanelGroupColumnLayout } from "../../components/parts/RightPanelGroupColumnLayout";
 import { getAllOptions } from "../../logics/api.store";
@@ -24,7 +24,12 @@ export function RightFloatingPanel() {
 	const isRightPanelOpen = useStore((state) => {
 		return state.isRightPanelOpen;
 	});
-	const [shouldRenderContent, setShouldRenderContent] = useState(isRightPanelOpen);
+	const shouldRenderContent = useStore(
+		(state) => state.shouldRenderRightPanelContent,
+	);
+	const setShouldRenderContent = useStore(
+		(state) => state.setShouldRenderRightPanelContent,
+	);
 
 	useEffect(() => {
 		if (isRightPanelOpen) {
@@ -34,7 +39,7 @@ export function RightFloatingPanel() {
 			const timer = setTimeout(() => setShouldRenderContent(false), 350);
 			return () => clearTimeout(timer);
 		}
-	}, [isRightPanelOpen]);
+	}, [isRightPanelOpen, setShouldRenderContent]);
 
 	const toggleRightPanel = useStore((state) => {
 		return state.toggleRightPanel;

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -1,4 +1,4 @@
-import { use, useCallback, useEffect } from "react";
+import { use, useCallback, useEffect, useState } from "react";
 import { ViewerGroupAccordion } from "../../components/blocks/ViewerGroupAccordion";
 import { RightPanelGroupColumnLayout } from "../../components/parts/RightPanelGroupColumnLayout";
 import { getAllOptions } from "../../logics/api.store";
@@ -24,6 +24,18 @@ export function RightFloatingPanel() {
 	const isRightPanelOpen = useStore((state) => {
 		return state.isRightPanelOpen;
 	});
+	const [shouldRenderContent, setShouldRenderContent] = useState(isRightPanelOpen);
+
+	useEffect(() => {
+		if (isRightPanelOpen) {
+			setShouldRenderContent(true);
+		} else {
+			// アニメーション時間(300ms)より少し長くして、確実にアニメーションが終わってから消す
+			const timer = setTimeout(() => setShouldRenderContent(false), 350);
+			return () => clearTimeout(timer);
+		}
+	}, [isRightPanelOpen]);
+
 	const toggleRightPanel = useStore((state) => {
 		return state.toggleRightPanel;
 	});
@@ -108,45 +120,39 @@ export function RightFloatingPanel() {
 
 	return (
 		<>
-			{/* トグルボタン (縦全体のストリップ) */}
-			<button
-				type="button"
-				onClick={toggleRightPanel}
-				className={`
-          fixed top-0 z-50 h-full w-6 bg-blue-600 text-white shadow-md
-          hover:bg-blue-700 flex items-center justify-center
-          cursor-pointer
-        `}
-				style={{
-					right: 0,
-					transform: isRightPanelOpen
-						? `translateX(-${rightPanelWidth}px)`
-						: "translateX(0)",
-					transition: isResizing
-						? "none"
-						: "transform 300ms ease-in-out, background-color 300ms ease-in-out",
-				}}
-				aria-label={isRightPanelOpen ? PANEL_CLOSE_ARIA : PANEL_OPEN_ARIA}
-			>
-				<span className="text-sm font-bold">
-					{isRightPanelOpen ? "▶" : "◀"}
-				</span>
-			</button>
-
 			{/* パネル本体 */}
 			<aside
 				className={`
           fixed right-0 top-0 h-full bg-white border-l border-gray-200 shadow-2xl z-40
-          ${isRightPanelOpen ? "translate-x-0" : "translate-x-full"}
         `}
 				style={{
 					width: rightPanelWidth,
+					transform: isRightPanelOpen ? "translateX(0)" : "translateX(100%)",
 					transition: isResizing
 						? "none"
 						: "transform 300ms ease-in-out, width 300ms ease-in-out",
 				}}
 				aria-label={RIGHT_PANEL_ARIA}
 			>
+				{/* トグルボタン (Asideの子要素にすることで、Asideの移動と完全に同期させる) */}
+				<button
+					type="button"
+					onClick={toggleRightPanel}
+					className={`
+            absolute top-0 right-full h-full w-6 bg-blue-600 text-white shadow-md
+            hover:bg-blue-700 flex items-center justify-center
+            cursor-pointer
+          `}
+					style={{
+						transition: "background-color 300ms ease-in-out",
+					}}
+					aria-label={isRightPanelOpen ? PANEL_CLOSE_ARIA : PANEL_OPEN_ARIA}
+				>
+					<span className="text-sm font-bold">
+						{isRightPanelOpen ? "▶" : "◀"}
+					</span>
+				</button>
+
 				{/* リサイズハンドル */}
 				{isRightPanelOpen && (
 					<div
@@ -155,33 +161,35 @@ export function RightFloatingPanel() {
 						aria-hidden="true"
 					/>
 				)}
-				<div className="flex flex-col h-full">
+				<div className="flex flex-col h-full" aria-hidden={!isRightPanelOpen}>
 					<div className="flex items-center justify-between p-4 border-b border-gray-100">
 						<h2 className="text-lg font-semibold">{RIGHT_PANEL_TITLE}</h2>
 					</div>
 					<div className="flex-1 overflow-y-auto p-3">
-						<ViewerGroupAccordion
-							title={SETTING_VALUES_TITLE}
-							isOpen={isSettingsOpen}
-							onToggle={toggleSettings}
-						>
-							<RightPanelGroupColumnLayout>
-								<ViewerGroupAccordion
-									title={AU_SETTINGS_TITLE}
-									isOpen={isAuSettingsOpen}
-									onToggle={toggleAuSettings}
-								>
-									<AuOptionViewer />
-								</ViewerGroupAccordion>
-								<ViewerGroupAccordion
-									title={EXR_SETTINGS_TITLE}
-									isOpen={isExrSettingsOpen}
-									onToggle={toggleExrSettings}
-								>
-									<ExROptionViewer />
-								</ViewerGroupAccordion>
-							</RightPanelGroupColumnLayout>
-						</ViewerGroupAccordion>
+						{shouldRenderContent && (
+							<ViewerGroupAccordion
+								title={SETTING_VALUES_TITLE}
+								isOpen={isSettingsOpen}
+								onToggle={toggleSettings}
+							>
+								<RightPanelGroupColumnLayout>
+									<ViewerGroupAccordion
+										title={AU_SETTINGS_TITLE}
+										isOpen={isAuSettingsOpen}
+										onToggle={toggleAuSettings}
+									>
+										<AuOptionViewer />
+									</ViewerGroupAccordion>
+									<ViewerGroupAccordion
+										title={EXR_SETTINGS_TITLE}
+										isOpen={isExrSettingsOpen}
+										onToggle={toggleExrSettings}
+									>
+										<ExROptionViewer />
+									</ViewerGroupAccordion>
+								</RightPanelGroupColumnLayout>
+							</ViewerGroupAccordion>
+						)}
 					</div>
 				</div>
 			</aside>

--- a/src/feature/rightsidepanel/RightFloatingPanel.tsx
+++ b/src/feature/rightsidepanel/RightFloatingPanel.tsx
@@ -118,10 +118,13 @@ export function RightFloatingPanel() {
           cursor-pointer
         `}
 				style={{
-					right: isRightPanelOpen ? rightPanelWidth : 0,
+					right: 0,
+					transform: isRightPanelOpen
+						? `translateX(-${rightPanelWidth}px)`
+						: "translateX(0)",
 					transition: isResizing
 						? "none"
-						: "right 300ms ease-in-out, background-color 300ms ease-in-out",
+						: "transform 300ms ease-in-out, background-color 300ms ease-in-out",
 				}}
 				aria-label={isRightPanelOpen ? PANEL_CLOSE_ARIA : PANEL_OPEN_ARIA}
 			>
@@ -134,7 +137,6 @@ export function RightFloatingPanel() {
 			<aside
 				className={`
           fixed right-0 top-0 h-full bg-white border-l border-gray-200 shadow-2xl z-40
-          transform
           ${isRightPanelOpen ? "translate-x-0" : "translate-x-full"}
         `}
 				style={{

--- a/src/slices/rightFloatingPanelSlice.ts
+++ b/src/slices/rightFloatingPanelSlice.ts
@@ -31,6 +31,8 @@ export interface RightFloatingPanelSlice {
 	toggleCategoryIdRightFloatingPanel: (categoryId: number) => void;
 	openedExROptionRightFloatingPanel: Record<UniqueOptionId, boolean>;
 	toggleExROptionRightFloatingPanel: (optionId: UniqueOptionId) => void;
+	shouldRenderRightPanelContent: boolean;
+	setShouldRenderRightPanelContent: (shouldRender: boolean) => void;
 }
 
 /**
@@ -138,6 +140,10 @@ export const createRightFloatingPanelSlice: StateCreator<
 					},
 				};
 			});
+		},
+		shouldRenderRightPanelContent: false,
+		setShouldRenderRightPanelContent: (shouldRender) => {
+			set({ shouldRenderRightPanelContent: shouldRender });
 		},
 	};
 };


### PR DESCRIPTION
Synchronized the animations of the right side panel and its toggle button by switching both to use `transform: translateX` instead of mixing layout and composite properties. This ensures they move together perfectly during open/close transitions.

---
*PR created automatically by Jules for task [2575296873130466558](https://jules.google.com/task/2575296873130466558) started by @yukieiji*