### PR TITLE
Refactor Role Filter UI to display as cards and pins

### DIFF
--- a/src/components/parts/RolePin.tsx
+++ b/src/components/parts/RolePin.tsx
@@ -1,0 +1,16 @@
+import { ColoredText } from "./ColoredText";
+
+interface RolePinProps {
+	name: string;
+}
+
+/**
+ * 役職を表示するピン（バッジ）コンポーネント
+ */
+export function RolePin({ name }: RolePinProps) {
+	return (
+		<span className="inline-block bg-blue-50 text-blue-700 px-3 py-1 rounded-full text-sm font-medium border border-blue-200">
+			<ColoredText text={name} />
+		</span>
+	);
+}

--- a/src/feature/exr/RoleFilterCard.tsx
+++ b/src/feature/exr/RoleFilterCard.tsx
@@ -1,0 +1,29 @@
+import { RolePin } from "../../components/parts/RolePin";
+import type { RoleFilterItem } from "../../type";
+
+interface RoleFilterCardProps {
+	filter: RoleFilterItem;
+}
+
+/**
+ * 各フィルター設定を表示するカードコンポーネント
+ */
+export function RoleFilterCard({ filter }: RoleFilterCardProps) {
+	return (
+		<div className="bg-white border border-gray-200 rounded-xl shadow-sm p-5 flex flex-col gap-4">
+			<div className="flex items-center justify-between border-b border-gray-100 pb-3">
+				<span className="text-sm font-semibold text-gray-500 uppercase tracking-wider">
+					AssignNum
+				</span>
+				<span className="text-2xl font-bold text-gray-900">
+					{filter.assignNum}
+				</span>
+			</div>
+			<div className="flex flex-wrap gap-2">
+				{filter.roles.map((role) => (
+					<RolePin key={`${role.type}-${role.id}`} name={role.name} />
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/feature/exr/RoleFilterViewer.tsx
+++ b/src/feature/exr/RoleFilterViewer.tsx
@@ -1,14 +1,15 @@
 import { useStore } from "../../useStore";
+import { RoleFilterCard } from "./RoleFilterCard";
 
 /**
- * Role Filter のデータをJSON形式で表示するコンポーネント
+ * Role Filter のデータをカード形式で表示するコンポーネント
  */
 export function RoleFilterViewer() {
-	const roleFilterSet = useStore((state) => {
-		return state.roleFilterSet;
+	const roleFilterList = useStore((state) => {
+		return state.roleFilterList;
 	});
 
-	if (!roleFilterSet) {
+	if (!roleFilterList) {
 		return (
 			<div className="p-4 bg-gray-100 rounded-md">
 				<p className="text-gray-500">No role filter data available.</p>
@@ -17,8 +18,10 @@ export function RoleFilterViewer() {
 	}
 
 	return (
-		<div className="p-4 bg-gray-900 text-green-400 rounded-md overflow-auto font-mono text-sm max-h-[calc(100vh-200px)]">
-			<pre>{JSON.stringify(roleFilterSet, null, 2)}</pre>
+		<div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 p-4 overflow-auto max-h-[calc(100vh-200px)]">
+			{roleFilterList.map((filter) => (
+				<RoleFilterCard key={filter.guid} filter={filter} />
+			))}
 		</div>
 	);
 }

--- a/src/feature/rightsidepanel/ExROptionRowView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowView.tsx
@@ -1,4 +1,3 @@
-import { ColoredText } from "../../components/parts/ColoredText";
 import type { UniqueOptionId } from "../../type";
 import { ExROptionRowViewContent } from "./ExROptionRowViewContent";
 
@@ -10,7 +9,6 @@ interface ExROptionRowViewProps {
 
 export function ExROptionRowView({
 	uniqueOptionId,
-	depth = 0,
 	isLeaf = false,
 }: ExROptionRowViewProps) {
 	return isLeaf ? (

--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -90,7 +90,7 @@ async function createAuOptionMetaDataWithStore(): Promise<void> {
 async function fetchRoleFilterDataWithStore(): Promise<void> {
 	await waitDelay();
 	const data = await fetchRoleFilterData();
-	useStore.getState().setRoleFilterSet(data);
+	useStore.getState().setRoleFilterList(data);
 }
 
 export function useUpdateAuOptionSelection(): (

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -6,7 +6,6 @@ import type {
 	ExROptionMetaDataRecords,
 	ExROptionValueData,
 	ExRTabMetaData,
-	RoleAssignFilterSetDto,
 	RoleFilterMetaData,
 	TranslationMetaDataRecords,
 	UniqueOptionId,
@@ -361,9 +360,9 @@ export async function updateExrOption(
 	return await UpdatedOptionsSchema.parseAsync(jsonData);
 }
 
-export async function fetchRoleFilterData(): Promise<
-	Record<string, RoleAssignFilterSetDto>
-> {
+import type { RoleFilterItem, RoleFilterRole } from "../type";
+
+export async function fetchRoleFilterData(): Promise<RoleFilterItem[]> {
 	const res = await fetch(EXR_ROLE_FILTER_URL);
 	if (!res.ok) {
 		throw new Error(`Failed to fetch role filter data: ${res.statusText}`);
@@ -377,7 +376,44 @@ export async function fetchRoleFilterData(): Promise<
 	roleFilterMetaData.CombinationId = data.CombinationId;
 	roleFilterMetaData.GhostRoleId = data.GhostRoleId;
 
-	return data.FilterSet;
+	const filterList: RoleFilterItem[] = Object.entries(data.FilterSet).map(
+		([guid, filterSet]) => {
+			const roles: RoleFilterRole[] = [
+				...Object.entries(filterSet.FilterNormalId).map(
+					([id, name]) =>
+						({
+							id: Number(id),
+							name: String(name),
+							type: "Normal",
+						}) as RoleFilterRole,
+				),
+				...Object.entries(filterSet.FilterCombinationId).map(
+					([id, name]) =>
+						({
+							id: Number(id),
+							name: String(name),
+							type: "Combination",
+						}) as RoleFilterRole,
+				),
+				...Object.entries(filterSet.FilterGhostRoleId).map(
+					([id, name]) =>
+						({
+							id: Number(id),
+							name: String(name),
+							type: "Ghost",
+						}) as RoleFilterRole,
+				),
+			];
+
+			return {
+				guid,
+				assignNum: filterSet.AssignNum,
+				roles,
+			};
+		},
+	);
+
+	return filterList;
 }
 
 export async function updateAuOption(

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -8,9 +8,9 @@ import {
 import type {
 	ExROptionValueData,
 	ExRTabId,
+	RoleFilterItem,
 	UniqueOptionId,
 	UpdatedOptions,
-	RoleFilterItem,
 } from "../type";
 
 /**

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -8,9 +8,9 @@ import {
 import type {
 	ExROptionValueData,
 	ExRTabId,
-	RoleAssignFilterSetDto,
 	UniqueOptionId,
 	UpdatedOptions,
+	RoleFilterItem,
 } from "../type";
 
 /**
@@ -26,7 +26,7 @@ export interface ExROptionViewerSlice {
 	exrValue: Record<UniqueOptionId, ExROptionValueData>;
 	isExROptionActive: Record<UniqueOptionId, boolean>;
 	highlightedExROptionId: UniqueOptionId | null;
-	roleFilterSet: Record<string, RoleAssignFilterSetDto> | null;
+	roleFilterList: RoleFilterItem[] | null;
 	setSelectedExRTabId: (id: ExRTabId) => void;
 	setIsExRTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
@@ -40,7 +40,7 @@ export interface ExROptionViewerSlice {
 		valueData: Record<UniqueOptionId, ExROptionValueData>,
 		optionActiveData: Record<UniqueOptionId, boolean>,
 	) => void;
-	setRoleFilterSet: (data: Record<string, RoleAssignFilterSetDto>) => void;
+	setRoleFilterList: (data: RoleFilterItem[]) => void;
 	validateOpenedIds: () => void;
 }
 
@@ -58,7 +58,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		exrValue: {},
 		isExROptionActive: {},
 		highlightedExROptionId: null,
-		roleFilterSet: null,
+		roleFilterList: null,
 		presetNames: loadPresetNamesFromLocalStorage(),
 		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: ExRTabId) => {
@@ -156,8 +156,8 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 				isExROptionActive: optionActiveData,
 			});
 		},
-		setRoleFilterSet: (data: Record<string, RoleAssignFilterSetDto>) => {
-			set({ roleFilterSet: data });
+		setRoleFilterList: (data: RoleFilterItem[]) => {
+			set({ roleFilterList: data });
 		},
 		validateOpenedIds: () => {
 			set((state) => {

--- a/src/type.ts
+++ b/src/type.ts
@@ -396,6 +396,24 @@ export type RoleAssignFilterSetDto = z.infer<
 	typeof RoleAssignFilterSetDtoSchema
 >;
 
+/**
+ * 役職フィルターの個別の役職情報
+ */
+export interface RoleFilterRole {
+	id: number;
+	name: string;
+	type: "Normal" | "Combination" | "Ghost";
+}
+
+/**
+ * UIで表示するための役職フィルター項目の情報
+ */
+export interface RoleFilterItem {
+	guid: string;
+	assignNum: number;
+	roles: RoleFilterRole[];
+}
+
 export const RoleAssignFilterDtoSchema = z.object({
 	FilterSet: z.record(z.string(), RoleAssignFilterSetDtoSchema),
 	FilterRoleId: z.array(z.number().int()),

--- a/tests/RoleFilter.test.tsx
+++ b/tests/RoleFilter.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RolePin } from "../src/components/parts/RolePin";
+import { RoleFilterCard } from "../src/feature/exr/RoleFilterCard";
+import { RoleFilterViewer } from "../src/feature/exr/RoleFilterViewer";
+import { useStore } from "../src/useStore";
+import type { RoleFilterItem } from "../src/type";
+
+vi.mock("../src/useStore");
+
+describe("RolePin", () => {
+	it("renders the role name", () => {
+		render(<RolePin name="Sheriff" />);
+		expect(screen.getByText("Sheriff")).toBeDefined();
+	});
+
+	it("renders with color tags", () => {
+		render(<RolePin name="<color=#FF0000>Red Role</color>" />);
+		const span = screen.getByText("Red Role");
+		expect(span).toBeDefined();
+		expect(span.getAttribute("style")).toContain("color: rgb(255, 0, 0)");
+	});
+});
+
+describe("RoleFilterCard", () => {
+	const mockFilter: RoleFilterItem = {
+		guid: "test-guid",
+		assignNum: 2,
+		roles: [
+			{ id: 1, name: "Sheriff", type: "Normal" },
+			{ id: 2, name: "Lover", type: "Combination" },
+		],
+	};
+
+	it("renders assignNum and roles", () => {
+		render(<RoleFilterCard filter={mockFilter} />);
+		expect(screen.getByText("2")).toBeDefined();
+		expect(screen.getByText("Sheriff")).toBeDefined();
+		expect(screen.getByText("Lover")).toBeDefined();
+	});
+});
+
+describe("RoleFilterViewer", () => {
+	it("renders 'No data' message when roleFilterList is null", () => {
+		vi.mocked(useStore).mockReturnValue(null);
+		render(<RoleFilterViewer />);
+		expect(screen.getByText("No role filter data available.")).toBeDefined();
+	});
+
+	it("renders list of cards when roleFilterList is provided", () => {
+		const mockList: RoleFilterItem[] = [
+			{
+				guid: "guid-1",
+				assignNum: 1,
+				roles: [{ id: 1, name: "Role 1", type: "Normal" }],
+			},
+			{
+				guid: "guid-2",
+				assignNum: 3,
+				roles: [{ id: 2, name: "Role 2", type: "Normal" }],
+			},
+		];
+		vi.mocked(useStore).mockReturnValue(mockList);
+		render(<RoleFilterViewer />);
+		expect(screen.getByText("Role 1")).toBeDefined();
+		expect(screen.getByText("Role 2")).toBeDefined();
+		expect(screen.getAllByText("AssignNum")).toHaveLength(2);
+	});
+});

--- a/tests/RoleFilter.test.tsx
+++ b/tests/RoleFilter.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 import { RolePin } from "../src/components/parts/RolePin";
 import { RoleFilterCard } from "../src/feature/exr/RoleFilterCard";
 import { RoleFilterViewer } from "../src/feature/exr/RoleFilterViewer";
-import { useStore } from "../src/useStore";
 import type { RoleFilterItem } from "../src/type";
+import { useStore } from "../src/useStore";
 
 vi.mock("../src/useStore");
 


### PR DESCRIPTION
This PR improves the Role Filter UI by replacing the raw JSON display with a card-based layout. Each filter set is shown as a card containing its `AssignNum` and a list of roles represented as badge-like "pins". The data structure was also refactored to be more UI-friendly, facilitating future features like adding or deleting filters.

---
*PR created automatically by Jules for task [8731629922902800255](https://jules.google.com/task/8731629922902800255) started by @yukieiji*