### PR TITLE
Add CSV import button next to SyncButton

### DIFF
--- a/e2e/import.spec.ts
+++ b/e2e/import.spec.ts
@@ -9,7 +9,9 @@ test.beforeEach(async ({ page }) => {
 	});
 });
 
-test("CSV import flow shows confirmation and calls API", async ({ page }) => {
+test("CSV import flow shows confirmation and triggers sync", async ({
+	page,
+}) => {
 	// 1. Check if Import Button is visible
 	const importButton = page.getByLabel("CSVファイルをインポート");
 	await expect(importButton).toBeVisible();
@@ -33,7 +35,7 @@ test("CSV import flow shows confirmation and calls API", async ({ page }) => {
 	// 4. Confirm import
 	await page.getByRole("button", { name: "OK" }).click();
 
-	// 5. Verify sync overlay appears
+	// 5. Verify sync overlay appears (it should because we use backendUpdater)
 	await expect(page.getByText("Synchronizing...")).toBeVisible();
 	await expect(page.getByText("Synchronizing...")).not.toBeVisible({
 		timeout: 10000,

--- a/e2e/import.spec.ts
+++ b/e2e/import.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	await page.goto("/");
+	// wait for main content instead of just "Loading data..." absence
+	await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible({
+		timeout: 15000,
+	});
+});
+
+test("CSV import flow shows confirmation and calls API", async ({ page }) => {
+	// 1. Check if Import Button is visible
+	const importButton = page.getByLabel("CSVファイルをインポート");
+	await expect(importButton).toBeVisible();
+
+	// 2. Mock file selection
+	const fileChooserPromise = page.waitForEvent("filechooser");
+	await importButton.click();
+	const fileChooser = await fileChooserPromise;
+	await fileChooser.setFiles({
+		name: "test.csv",
+		mimeType: "text/csv",
+		buffer: Buffer.from("test,csv,content"),
+	});
+
+	// 3. Check for confirmation dialog
+	await expect(page.getByText("インポートの確認")).toBeVisible();
+	await expect(
+		page.getByText("CSVファイルをインポートして設定を上書きしますか？"),
+	).toBeVisible();
+
+	// 4. Confirm import
+	await page.getByRole("button", { name: "OK" }).click();
+
+	// 5. Verify sync overlay appears
+	await expect(page.getByText("Synchronizing...")).toBeVisible();
+	await expect(page.getByText("Synchronizing...")).not.toBeVisible({
+		timeout: 10000,
+	});
+});

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -197,6 +197,17 @@ export const handlers = [
   }),
 
   /**
+   * POST /exr/option/csv/ のハンドラー
+   */
+  http.post('/exr/option/csv/', async ({ request }) => {
+    const body = await request.json() as { CsvBody: string };
+    if (body.CsvBody === 'TRIGGER_ERROR') {
+      return new HttpResponse(null, { status: 500 });
+    }
+    return new HttpResponse(null, { status: 200 });
+  }),
+
+  /**
    * モックデータをリセットするハンドラー
    */
   http.post('/mock/reset', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Suspense, use } from "react";
 import { LoadingView } from "./components/blocks/LoadingView";
+import { ImportButton } from "./components/parts/ImportButton";
 import { SyncButton } from "./components/parts/SyncButton";
 import { AuOptionEditor } from "./feature/amongus/AuOptionEditor";
 import { BlockableDialog } from "./feature/BlockableDialog";
@@ -9,11 +10,14 @@ import { PresetSelector } from "./feature/exr/PresetSelector";
 import { RoleFilterViewer } from "./feature/exr/RoleFilterViewer";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { RightFloatingPanel } from "./feature/rightsidepanel/RightFloatingPanel";
-import { useSyncBackend } from "./hooks/useBackend";
+import { useBackendUpdate, useSyncBackend } from "./hooks/useBackend";
+import { postExrCsv } from "./logics/api";
 import { getAllOptions } from "./logics/api.store";
 import {
 	AU_OPTIONS_TITLE,
 	EXR_OPTIONS_TITLE,
+	IMPORT_CONFIRM_MESSAGE,
+	IMPORT_CONFIRM_TITLE,
 	ROLE_FILTER_TITLE,
 } from "./noTrans";
 import { useStore } from "./useStore";
@@ -57,6 +61,18 @@ function MainContent() {
 	});
 
 	const syncer = useSyncBackend();
+	const backendUpdater = useBackendUpdate();
+	const openDialog = useStore((state) => state.openBlockDialog);
+
+	const handleImport = (csvBody: string) => {
+		openDialog({
+			title: IMPORT_CONFIRM_TITLE,
+			message: IMPORT_CONFIRM_MESSAGE,
+			onConfirm: () => {
+				backendUpdater(() => postExrCsv(csvBody));
+			},
+		});
+	};
 
 	const titleMap = {
 		Au: AU_OPTIONS_TITLE,
@@ -87,6 +103,7 @@ function MainContent() {
 						<div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
 					)}
 				</div>
+				<ImportButton onImport={handleImport} />
 				<SyncButton onClick={syncer} />
 			</div>
 			<Suspense

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Suspense, use } from "react";
 import { LoadingView } from "./components/blocks/LoadingView";
-import { ImportButton } from "./components/parts/ImportButton";
 import { ExportButton } from "./components/parts/ExportButton";
+import { ImportButton } from "./components/parts/ImportButton";
 import { SyncButton } from "./components/parts/SyncButton";
 import { AuOptionEditor } from "./feature/amongus/AuOptionEditor";
 import { BlockableDialog } from "./feature/BlockableDialog";
@@ -11,7 +11,11 @@ import { PresetSelector } from "./feature/exr/PresetSelector";
 import { RoleFilterViewer } from "./feature/exr/RoleFilterViewer";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { RightFloatingPanel } from "./feature/rightsidepanel/RightFloatingPanel";
-import { useBackendUpdate, useExportCsv, useSyncBackend } from "./hooks/useBackend";
+import {
+	useBackendUpdate,
+	useExportCsv,
+	useSyncBackend,
+} from "./hooks/useBackend";
 import { postExrCsv } from "./logics/api";
 import { getAllOptions } from "./logics/api.store";
 import {

--- a/src/components/parts/ImportButton.tsx
+++ b/src/components/parts/ImportButton.tsx
@@ -30,6 +30,9 @@ export function ImportButton({ onImport, disabled }: ImportButtonProps) {
 				onImport(content);
 			}
 		};
+		reader.onerror = (e) => {
+			console.error("FileReader error:", e);
+		};
 		reader.readAsText(file, "UTF-8");
 
 		// 入力をクリアして、同じファイルを再度選択できるようにする

--- a/src/components/parts/ImportButton.tsx
+++ b/src/components/parts/ImportButton.tsx
@@ -46,7 +46,6 @@ export function ImportButton({ onImport, disabled }: ImportButtonProps) {
 				ref={fileInputRef}
 				onChange={handleFileChange}
 				className="hidden"
-				aria-hidden="true"
 			/>
 			<button
 				type="button"

--- a/src/components/parts/ImportButton.tsx
+++ b/src/components/parts/ImportButton.tsx
@@ -1,0 +1,82 @@
+import { useRef } from "react";
+import { IMPORT_BUTTON_ARIA, IMPORT_BUTTON_TITLE } from "../../noTrans";
+
+interface ImportButtonProps {
+	onImport: (csvContent: string) => void;
+	disabled?: boolean;
+}
+
+/**
+ * インポートボタンコンポーネント
+ * アイコンとテキストを表示します。クリックするとファイル選択ダイアログを開きます。
+ */
+export function ImportButton({ onImport, disabled }: ImportButtonProps) {
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const handleClick = () => {
+		fileInputRef.current?.click();
+	};
+
+	const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const file = event.target.files?.[0];
+		if (!file) {
+			return;
+		}
+
+		const reader = new FileReader();
+		reader.onload = (e) => {
+			const content = e.target?.result;
+			if (typeof content === "string") {
+				onImport(content);
+			}
+		};
+		reader.readAsText(file, "UTF-8");
+
+		// 入力をクリアして、同じファイルを再度選択できるようにする
+		if (fileInputRef.current) {
+			fileInputRef.current.value = "";
+		}
+	};
+
+	return (
+		<>
+			<input
+				type="file"
+				accept=".csv"
+				ref={fileInputRef}
+				onChange={handleFileChange}
+				className="hidden"
+				aria-hidden="true"
+			/>
+			<button
+				type="button"
+				onClick={handleClick}
+				disabled={disabled}
+				className={`
+          flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-200 font-medium
+          ${disabled ? "text-gray-400 cursor-not-allowed bg-gray-50 border-gray-200" : "text-blue-600 hover:bg-blue-50 active:bg-blue-100 shadow-sm border border-gray-200 bg-white"}
+        `}
+				title={IMPORT_BUTTON_TITLE}
+				aria-label={IMPORT_BUTTON_ARIA}
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="18"
+					height="18"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					aria-hidden="true"
+				>
+					<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+					<polyline points="17 8 12 3 7 8" />
+					<line x1="12" x2="12" y1="3" y2="15" />
+				</svg>
+				<span>{IMPORT_BUTTON_TITLE}</span>
+			</button>
+		</>
+	);
+}

--- a/src/feature/rightsidepanel/ExROptionRowView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowView.tsx
@@ -1,4 +1,3 @@
-import { ColoredText } from "../../components/parts/ColoredText";
 import type { UniqueOptionId } from "../../type";
 import { ExROptionRowViewContent } from "./ExROptionRowViewContent";
 
@@ -10,7 +9,6 @@ interface ExROptionRowViewProps {
 
 export function ExROptionRowView({
 	uniqueOptionId,
-	depth = 0,
 	isLeaf = false,
 }: ExROptionRowViewProps) {
 	return isLeaf ? (

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -30,6 +30,7 @@ import { getAuOptionId, getUniqueOptionId } from "./optionUtils";
  * API エンドポイントの定数定義
  */
 const EXR_OPTION_URL = "/exr/option/";
+const EXR_CSV_URL = "/exr/option/csv/";
 const AU_OPTION_URL = "/au/option/";
 const EXR_ROLE_FILTER_URL = "/exr/role/filter/";
 const TRANSLATION_BATCH_URL = "/au/translation/batch/optionunit/";
@@ -359,6 +360,20 @@ export async function updateExrOption(
 
 	const jsonData = await res.json();
 	return await UpdatedOptionsSchema.parseAsync(jsonData);
+}
+
+export async function postExrCsv(csvBody: string): Promise<void> {
+	const res = await fetch(EXR_CSV_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ CsvBody: csvBody }),
+	});
+
+	if (!res.ok) {
+		throw new Error(`Failed to post ExR CSV: ${res.statusText}`);
+	}
 }
 
 export async function fetchRoleFilterData(): Promise<

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -7,7 +7,8 @@ export const SYNC_BUTTON_ARIA = "データを同期";
 export const IMPORT_BUTTON_TITLE = "CSVインポート";
 export const IMPORT_BUTTON_ARIA = "CSVファイルをインポート";
 export const IMPORT_CONFIRM_TITLE = "インポートの確認";
-export const IMPORT_CONFIRM_MESSAGE = "CSVファイルをインポートして設定を上書きしますか？";
+export const IMPORT_CONFIRM_MESSAGE =
+	"CSVファイルをインポートして設定を上書きしますか？";
 export const CANCEL = "キャンセル";
 export const SIDEBAR_CLOSE_ARIA = "サイドバーを閉じる";
 export const SIDEBAR_OPEN_ARIA = "サイドバーを開く";

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -4,6 +4,10 @@
 
 export const SYNC_BUTTON_TITLE = "同期";
 export const SYNC_BUTTON_ARIA = "データを同期";
+export const IMPORT_BUTTON_TITLE = "CSVインポート";
+export const IMPORT_BUTTON_ARIA = "CSVファイルをインポート";
+export const IMPORT_CONFIRM_TITLE = "インポートの確認";
+export const IMPORT_CONFIRM_MESSAGE = "CSVファイルをインポートして設定を上書きしますか？";
 export const CANCEL = "キャンセル";
 export const SIDEBAR_CLOSE_ARIA = "サイドバーを閉じる";
 export const SIDEBAR_OPEN_ARIA = "サイドバーを開く";

--- a/tests/ImportButton.test.tsx
+++ b/tests/ImportButton.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ImportButton } from "../src/components/parts/ImportButton";
+import { IMPORT_BUTTON_ARIA, IMPORT_BUTTON_TITLE } from "../src/noTrans";
+
+describe("ImportButton", () => {
+	it("renders correctly with title and icon", () => {
+		render(<ImportButton onImport={vi.fn()} />);
+
+		const button = screen.getByRole("button", { name: IMPORT_BUTTON_ARIA });
+		expect(button).toBeInTheDocument();
+		expect(button).toContainElement(screen.getByText(IMPORT_BUTTON_TITLE));
+		expect(button.querySelector("svg")).toBeInTheDocument();
+	});
+
+	it("is disabled when disabled prop is true", () => {
+		render(<ImportButton onImport={vi.fn()} disabled={true} />);
+
+		const button = screen.getByRole("button", { name: IMPORT_BUTTON_ARIA });
+		expect(button).toBeDisabled();
+		expect(button).toHaveClass("cursor-not-allowed");
+	});
+
+	it("triggers file input click when button is clicked", () => {
+		render(<ImportButton onImport={vi.fn()} />);
+
+		screen.getByRole("button", { name: IMPORT_BUTTON_ARIA });
+		// In JSDOM, input[type='file'].hidden is still findable by CSS selector but maybe not by role if not labeled.
+		const input = document.querySelector("input[type='file']");
+		expect(input).toBeInTheDocument();
+		expect(input).toHaveAttribute("accept", ".csv");
+	});
+
+	it("calls onImport when a file is selected", async () => {
+		const onImport = vi.fn();
+		render(<ImportButton onImport={onImport} />);
+
+		const input = document.querySelector(
+			"input[type='file']",
+		) as HTMLInputElement;
+		const file = new File(["test,csv,content"], "test.csv", {
+			type: "text/csv",
+		});
+
+		fireEvent.change(input, { target: { files: [file] } });
+
+		await waitFor(() => {
+			expect(onImport).toHaveBeenCalledWith("test,csv,content");
+		});
+	});
+});

--- a/tests/RightPanelFloatingPanelResizeHandle.test.tsx
+++ b/tests/RightPanelFloatingPanelResizeHandle.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RightPanelFloatingPanelResizeHandle } from "../src/feature/rightsidepanel/RightPanelFloatingPanelResizeHandle";
 import { useStore } from "../src/useStore";
@@ -33,7 +33,10 @@ describe("RightPanelFloatingPanelResizeHandle Component", () => {
 		const { container } = render(<RightPanelFloatingPanelResizeHandle />);
 		const handle = container.querySelector(".cursor-ew-resize");
 
-		fireEvent.mouseDown(handle!);
+		if (!handle) {
+			throw new Error("Handle not found");
+		}
+		fireEvent.mouseDown(handle);
 
 		expect(useStore.getState().isResizing).toBe(true);
 	});


### PR DESCRIPTION
This PR adds a new "CSV Import" button to the header, positioned to the left of the Sync button. 

Key changes:
- Created a new `ImportButton` component that allows users to select a CSV file, which is then read as a UTF-8 string.
- Added a `postExrCsv` function to `src/logics/api.ts` to send the CSV content to the backend.
- Updated `App.tsx` to include the `ImportButton`. When clicked and a file is selected, it prompts the user for confirmation before uploading and triggering a backend sync using `useBackendUpdate`.
- Added required UI strings to `src/noTrans.ts`.

Verification:
- Manually verified the UI changes and confirmation dialog using Playwright.
- Existing unit tests pass successfully.

---
*PR created automatically by Jules for task [1884211530425433252](https://jules.google.com/task/1884211530425433252) started by @yukieiji*