### PR TITLE
エクスポートボタンの追加

### DIFF
--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	await page.goto("/");
+	await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible({
+		timeout: 15000,
+	});
+});
+
+test("export button triggers download", async ({ page }) => {
+	// エクスポートボタンが表示されていることを確認
+	const exportButton = page.getByLabel("CSVとしてエクスポート");
+	await expect(exportButton).toBeVisible();
+
+	// ボタンをクリックしてダウンロードを待機
+	const downloadPromise = page.waitForEvent("download");
+	await exportButton.click();
+	const download = await downloadPromise;
+
+	// ファイル名を確認 (export_... .csv)
+	expect(download.suggestedFilename()).toMatch(/^export_.*\.csv$/);
+});

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -197,6 +197,17 @@ export const handlers = [
   }),
 
   /**
+   * GET /exr/option/csv/ のハンドラー
+   */
+  http.get('/exr/option/csv/', () => {
+    return HttpResponse.json({
+      ExportAt: new Date().toISOString(),
+      Version: '1.0.0',
+      CsvBody: 'Header1,Header2\nValue1,Value2',
+    });
+  }),
+
+  /**
    * モックデータをリセットするハンドラー
    */
   http.post('/mock/reset', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Suspense, use } from "react";
 import { LoadingView } from "./components/blocks/LoadingView";
+import { ExportButton } from "./components/parts/ExportButton";
 import { SyncButton } from "./components/parts/SyncButton";
 import { AuOptionEditor } from "./feature/amongus/AuOptionEditor";
 import { BlockableDialog } from "./feature/BlockableDialog";
@@ -9,7 +10,7 @@ import { PresetSelector } from "./feature/exr/PresetSelector";
 import { RoleFilterViewer } from "./feature/exr/RoleFilterViewer";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
 import { RightFloatingPanel } from "./feature/rightsidepanel/RightFloatingPanel";
-import { useSyncBackend } from "./hooks/useBackend";
+import { useExportCsv, useSyncBackend } from "./hooks/useBackend";
 import { getAllOptions } from "./logics/api.store";
 import {
 	AU_OPTIONS_TITLE,
@@ -57,6 +58,7 @@ function MainContent() {
 	});
 
 	const syncer = useSyncBackend();
+	const exporter = useExportCsv();
 
 	const titleMap = {
 		Au: AU_OPTIONS_TITLE,
@@ -87,6 +89,7 @@ function MainContent() {
 						<div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
 					)}
 				</div>
+				<ExportButton onClick={exporter} />
 				<SyncButton onClick={syncer} />
 			</div>
 			<Suspense

--- a/src/components/parts/ExportButton.tsx
+++ b/src/components/parts/ExportButton.tsx
@@ -1,0 +1,44 @@
+import { EXPORT_CSV_LABEL, EXPORT_CSV_TITLE } from "../../noTrans";
+
+interface ExportButtonProps {
+	onClick: () => void;
+	disabled?: boolean;
+}
+
+/**
+ * エクスポートボタンコンポーネント
+ * アイコンとテキストを表示します
+ */
+export function ExportButton({ onClick, disabled }: ExportButtonProps) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			disabled={disabled}
+			className={`
+        flex items-center gap-2 px-3 py-2 rounded-full transition-all duration-200
+        ${disabled ? "text-gray-400 cursor-not-allowed bg-gray-50 border-gray-100" : "text-green-600 hover:bg-green-50 active:bg-green-100 shadow-sm border border-gray-200 bg-white"}
+      `}
+			title={EXPORT_CSV_TITLE}
+			aria-label={EXPORT_CSV_TITLE}
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="18"
+				height="18"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				aria-hidden="true"
+			>
+				<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+				<polyline points="7 10 12 15 17 10" />
+				<line x1="12" x2="12" y1="15" y2="3" />
+			</svg>
+			<span className="text-sm font-medium">{EXPORT_CSV_LABEL}</span>
+		</button>
+	);
+}

--- a/src/hooks/useBackend.ts
+++ b/src/hooks/useBackend.ts
@@ -1,4 +1,5 @@
 import { useEffect, useTransition } from "react";
+import { fetchCsvData } from "../logics/api";
 import { refechAll, resetApiCache } from "../logics/api.store";
 import { useStore } from "../useStore";
 import { useBlock, useBlockAsync } from "./useManualBlock";
@@ -22,6 +23,33 @@ export function useSyncBackend(): () => void {
 				await refechAll();
 				validate();
 			});
+		});
+	};
+}
+
+export function useExportCsv(): () => Promise<void> {
+	const blocker = useBlockAsync();
+
+	return async () => {
+		await blocker(async () => {
+			try {
+				const result = await fetchCsvData();
+				const blob = new Blob([result.CsvBody], { type: "text/csv" });
+				const url = URL.createObjectURL(blob);
+				const a = document.createElement("a");
+
+				// ファイル名の生成: export_YYYYMMDD_HHMMSS.csv
+				const dateStr = result.ExportAt.replace(/[:.-]/g, "").replace("T", "_");
+				a.href = url;
+				a.download = `export_${dateStr}.csv`;
+				document.body.appendChild(a);
+				a.click();
+				document.body.removeChild(a);
+				URL.revokeObjectURL(url);
+			} catch (error) {
+				console.error("Failed to export CSV:", error);
+				// エラーハンドリングが必要な場合はここに追加
+			}
 		});
 	};
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -6,6 +6,7 @@ import type {
 	ExROptionMetaDataRecords,
 	ExROptionValueData,
 	ExRTabMetaData,
+	GetCsvResult,
 	RoleAssignFilterSetUI,
 	RoleFilterMetaData,
 	TranslationMetaDataRecords,
@@ -18,6 +19,7 @@ import {
 	AuOptionCategoryDtoArraySchema,
 	ExRTabDtoArraySchema,
 	ExRTabId,
+	GetCsvResultSchema,
 	GetTranslationResponseArraySchema,
 	OptionValueType,
 	RoleAssignFilterDtoSchema,
@@ -30,6 +32,7 @@ import { getAuOptionId, getUniqueOptionId } from "./optionUtils";
  * API エンドポイントの定数定義
  */
 const EXR_OPTION_URL = "/exr/option/";
+const EXR_CSV_URL = "/exr/option/csv/";
 const AU_OPTION_URL = "/au/option/";
 const EXR_ROLE_FILTER_URL = "/exr/role/filter/";
 const TRANSLATION_BATCH_URL = "/au/translation/batch/optionunit/";
@@ -359,6 +362,16 @@ export async function updateExrOption(
 
 	const jsonData = await res.json();
 	return await UpdatedOptionsSchema.parseAsync(jsonData);
+}
+
+export async function fetchCsvData(): Promise<GetCsvResult> {
+	const res = await fetch(EXR_CSV_URL);
+	if (!res.ok) {
+		throw new Error(`Failed to fetch CSV data: ${res.statusText}`);
+	}
+
+	const jsonData = await res.json();
+	return await GetCsvResultSchema.parseAsync(jsonData);
 }
 
 export async function fetchRoleFilterData(): Promise<

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -4,6 +4,8 @@
 
 export const SYNC_BUTTON_TITLE = "同期";
 export const SYNC_BUTTON_ARIA = "データを同期";
+export const EXPORT_CSV_LABEL = "エクスポート";
+export const EXPORT_CSV_TITLE = "CSVとしてエクスポート";
 export const CANCEL = "キャンセル";
 export const SIDEBAR_CLOSE_ARIA = "サイドバーを閉じる";
 export const SIDEBAR_OPEN_ARIA = "サイドバーを開く";

--- a/src/type.ts
+++ b/src/type.ts
@@ -431,3 +431,15 @@ export interface RoleFilterMetaData {
 	CombinationId: Record<string, number | string>;
 	GhostRoleId: Record<string, number | string>;
 }
+
+export interface GetCsvResult {
+	ExportAt: string;
+	Version: string;
+	CsvBody: string;
+}
+
+export const GetCsvResultSchema = z.object({
+	ExportAt: z.string(),
+	Version: z.string(),
+	CsvBody: z.string(),
+});

--- a/tests/csv-validation.test.ts
+++ b/tests/csv-validation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { GetCsvResultSchema } from "../src/type";
+
+describe("GetCsvResult Validation", () => {
+	it("should validate a correct GetCsvResult", () => {
+		const data = {
+			ExportAt: "2023-10-27T10:00:00Z",
+			Version: "1.0.0",
+			CsvBody: "Header1,Header2\nValue1,Value2",
+		};
+
+		const result = GetCsvResultSchema.safeParse(data);
+		expect(result.success).toBe(true);
+	});
+
+	it("should fail validation if GetCsvResult has missing fields", () => {
+		const data = {
+			ExportAt: "2023-10-27T10:00:00Z",
+			// Version missing
+			CsvBody: "Header1,Header2\nValue1,Value2",
+		};
+
+		const result = GetCsvResultSchema.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+});


### PR DESCRIPTION
SyncButtonの横にエクポートボタンを追加しました。
/exr/option/csv/のGETを呼び出し、ダイアログを表示してCsvBodyをcsv化したデータをダウンロードする機能を実装しました。
実装にあたり、GetCsvResult型の定義、API関数の追加、カスタムフックの作成、UIコンポーネントの作成、およびユニットテストとE2Eテストの追加を行いました。

---
*PR created automatically by Jules for task [5263058625576138361](https://jules.google.com/task/5263058625576138361) started by @yukieiji*