### PR TITLE
useExportCsv で showSaveFilePicker を使用するように変更

### DIFF
--- a/.gemini/knowledge/showSaveFilePicker/README.md
+++ b/.gemini/knowledge/showSaveFilePicker/README.md
@@ -1,0 +1,30 @@
+# showSaveFilePicker の使用とテスト
+
+## 概要
+`showSaveFilePicker` API を使用することで、ブラウザから直接ローカルファイルシステムにファイルを保存するダイアログを表示できます。従来の `<a>` タグによる自動ダウンロードと異なり、ユーザーが保存先とファイル名を選択できます。
+
+## 実装のポイント
+- `window.showSaveFilePicker` が存在するか確認し、未サポートのブラウザ（Firefoxなど）では従来の `<a>` タグによるダウンロードにフォールバックします。
+- ユーザーがキャンセルした場合、`AbortError` がスローされるため、これをキャッチして静かに処理を終了します。
+- TypeScript では `window` オブジェクトに型定義が不足している場合があるため、`(window as any)` 等でキャストするか、型定義を拡張する必要があります。
+
+## テスト方法
+### ユニットテスト (Vitest + JSDOM)
+`vi.stubGlobal` を使用して `showSaveFilePicker` をモック化します。
+```ts
+const showSaveFilePicker = vi.fn().mockResolvedValue({
+    createWritable: () => ({
+        write: vi.fn(),
+        close: vi.fn(),
+    })
+});
+vi.stubGlobal("showSaveFilePicker", showSaveFilePicker);
+```
+
+### E2Eテスト (Playwright)
+Playwright の `download` イベントは `showSaveFilePicker` では発生しません。そのため、E2Eテストでダウンロードを検証する場合は、一時的に `showSaveFilePicker` を削除してフォールバック動作を検証するか、API自体をモック化する必要があります。
+```ts
+await page.addInitScript(() => {
+    delete (window as any).showSaveFilePicker;
+});
+```

--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ export default defineConfig([
   },
 ])
 ```
+
+## 追加知識
+- [showSaveFilePicker の使用とテスト](.gemini/knowledge/showSaveFilePicker/README.md)

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -1,7 +1,15 @@
 import { expect, test } from "@playwright/test";
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page, browserName }) => {
 	await page.request.post("/mock/reset", { maxRetries: 5 });
+	if (browserName === "chromium") {
+		// showSaveFilePicker を無効化してフォールバックをテストする
+		// (showSaveFilePicker は Playwright の download イベントを発生させないため)
+		await page.addInitScript(() => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			delete (window as any).showSaveFilePicker;
+		});
+	}
 	await page.goto("/");
 	await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible({
 		timeout: 15000,

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -206,7 +206,8 @@ export const handlers = [
     }
     return new HttpResponse(null, { status: 200 });
   }),
-  
+
+  /**
    * GET /exr/option/csv/ のハンドラー
    */
   http.get('/exr/option/csv/', () => {

--- a/src/hooks/useBackend.ts
+++ b/src/hooks/useBackend.ts
@@ -35,20 +35,47 @@ export function useExportCsv(): () => Promise<void> {
 			try {
 				const result = await fetchCsvData();
 				const blob = new Blob([result.CsvBody], { type: "text/csv" });
+				const dateStr = result.ExportAt.replace(/[:.-]/g, "").replace("T", "_");
+				const fileName = `export_${dateStr}.csv`;
+
+				// showSaveFilePickerが利用可能な場合
+				if ("showSaveFilePicker" in window) {
+					try {
+						// biome-ignore lint/suspicious/noExplicitAny: showSaveFilePicker is not in standard lib yet
+						const handle = await (window as any).showSaveFilePicker({
+							suggestedName: fileName,
+							types: [
+								{
+									description: "CSV File",
+									accept: { "text/csv": [".csv"] },
+								},
+							],
+						});
+						const writable = await handle.createWritable();
+						await writable.write(blob);
+						await writable.close();
+						return;
+					} catch (error: unknown) {
+						// ユーザーがキャンセルした場合は静かに終了
+						if (error instanceof Error && error.name === "AbortError") {
+							return;
+						}
+						// それ以外のエラーの場合はフォールバックへ進む
+						console.error("showSaveFilePicker failed:", error);
+					}
+				}
+
+				// フォールバック: 従来のaタグによるダウンロード
 				const url = URL.createObjectURL(blob);
 				const a = document.createElement("a");
-
-				// ファイル名の生成: export_YYYYMMDD_HHMMSS.csv
-				const dateStr = result.ExportAt.replace(/[:.-]/g, "").replace("T", "_");
 				a.href = url;
-				a.download = `export_${dateStr}.csv`;
+				a.download = fileName;
 				document.body.appendChild(a);
 				a.click();
 				document.body.removeChild(a);
 				URL.revokeObjectURL(url);
 			} catch (error) {
 				console.error("Failed to export CSV:", error);
-				// エラーハンドリングが必要な場合はここに追加
 			}
 		});
 	};

--- a/tests/useBackendHooks.test.tsx
+++ b/tests/useBackendHooks.test.tsx
@@ -1,6 +1,6 @@
-import { renderHook, act } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { useSyncBackend, useBackendUpdate } from "../src/hooks/useBackend";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useBackendUpdate, useSyncBackend } from "../src/hooks/useBackend";
 import * as apiStore from "../src/logics/api.store";
 import { useStore } from "../src/useStore";
 

--- a/tests/useBackendHooks.test.tsx
+++ b/tests/useBackendHooks.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useSyncBackend, useBackendUpdate } from "../src/hooks/useBackend";
+import * as apiStore from "../src/logics/api.store";
+import { useStore } from "../src/useStore";
+
+vi.mock("../src/logics/api.store", () => ({
+	resetApiCache: vi.fn(),
+	refechAll: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/hooks/useManualBlock", () => ({
+	useBlock: () => (fn: () => void) => fn(),
+	useBlockAsync: () => (fn: () => Promise<void>) => fn(),
+}));
+
+describe("useSyncBackend", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("sync 関数を呼び出したときに api 関連の処理が実行される", async () => {
+		const validateOpenedIds = vi.fn();
+		// useStore の状態を部分的にモック化
+		useStore.setState({ validateOpenedIds });
+
+		const { result } = renderHook(() => useSyncBackend());
+
+		await act(async () => {
+			result.current();
+		});
+
+		expect(apiStore.resetApiCache).toHaveBeenCalled();
+		expect(apiStore.refechAll).toHaveBeenCalled();
+		// startTransition 内で実行されるため、少し待つ必要があるかもしれないが、
+		// act でラップしているので同期的に扱えるはず
+		expect(validateOpenedIds).toHaveBeenCalled();
+	});
+});
+
+describe("useBackendUpdate", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("update 関数を呼び出した後に sync が実行される", async () => {
+		const { result } = renderHook(() => useBackendUpdate());
+		const mockUpdate = vi.fn().mockResolvedValue(undefined);
+
+		await act(async () => {
+			await result.current(mockUpdate);
+		});
+
+		expect(mockUpdate).toHaveBeenCalled();
+		expect(apiStore.refechAll).toHaveBeenCalled();
+	});
+});

--- a/tests/useExportCsv.test.tsx
+++ b/tests/useExportCsv.test.tsx
@@ -1,0 +1,134 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useExportCsv } from "../src/hooks/useBackend";
+import * as api from "../src/logics/api";
+
+vi.mock("../src/logics/api", () => ({
+	fetchCsvData: vi.fn(),
+}));
+
+vi.mock("../src/hooks/useManualBlock", () => ({
+	useBlockAsync: () => (fn: () => Promise<void>) => fn(),
+}));
+
+describe("useExportCsv", () => {
+	const mockCsvData = {
+		CsvBody: "test,csv,data",
+		ExportAt: "2023-10-01T12:34:56",
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(api.fetchCsvData as any).mockResolvedValue(mockCsvData);
+
+		// URL.createObjectURL のモック化
+		vi.stubGlobal("URL", {
+			createObjectURL: vi.fn(() => "blob:url"),
+			revokeObjectURL: vi.fn(),
+		});
+
+		// showSaveFilePicker をデフォルトで未定義にする
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		delete (window as any).showSaveFilePicker;
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("showSaveFilePicker が利用可能な場合、それを使用して保存する", async () => {
+		const mockWritable = {
+			write: vi.fn().mockResolvedValue(undefined),
+			close: vi.fn().mockResolvedValue(undefined),
+		};
+		const mockHandle = {
+			createWritable: vi.fn().mockResolvedValue(mockWritable),
+		};
+		const showSaveFilePicker = vi.fn().mockResolvedValue(mockHandle);
+		vi.stubGlobal("showSaveFilePicker", showSaveFilePicker);
+
+		const { result } = renderHook(() => useExportCsv());
+		await result.current();
+
+		expect(showSaveFilePicker).toHaveBeenCalledWith({
+			suggestedName: "export_20231001_123456.csv",
+			types: [
+				{
+					description: "CSV File",
+					accept: { "text/csv": [".csv"] },
+				},
+			],
+		});
+		expect(mockHandle.createWritable).toHaveBeenCalled();
+		expect(mockWritable.write).toHaveBeenCalledWith(expect.any(Blob));
+		expect(mockWritable.close).toHaveBeenCalled();
+	});
+
+	it("showSaveFilePicker で AbortError が発生した場合、静かに終了しフォールバックしない", async () => {
+		const abortError = new Error("The user aborted a request.");
+		abortError.name = "AbortError";
+		const showSaveFilePicker = vi.fn().mockRejectedValue(abortError);
+		vi.stubGlobal("showSaveFilePicker", showSaveFilePicker);
+
+		const createElementSpy = vi.spyOn(document, "createElement");
+
+		const { result } = renderHook(() => useExportCsv());
+		await result.current();
+
+		expect(showSaveFilePicker).toHaveBeenCalled();
+		// 'a' タグが作成されていないことを確認
+		const aCalls = createElementSpy.mock.calls.filter(
+			(call) => call[0] === "a",
+		);
+		expect(aCalls.length).toBe(0);
+	});
+
+	it("showSaveFilePicker が失敗（AbortError以外）した場合、aタグによるダウンロードにフォールバックする", async () => {
+		const otherError = new Error("Some other error");
+		const showSaveFilePicker = vi.fn().mockRejectedValue(otherError);
+		vi.stubGlobal("showSaveFilePicker", showSaveFilePicker);
+
+		const originalCreateElement = document.createElement.bind(document);
+		const mockA = originalCreateElement("a");
+		const clickSpy = vi.spyOn(mockA, "click").mockImplementation(() => {});
+		vi.spyOn(document, "createElement").mockImplementation((tagName) => {
+			if (tagName === "a") {
+				return mockA;
+			}
+			return originalCreateElement(tagName);
+		});
+
+		const { result } = renderHook(() => useExportCsv());
+		// console.error を一時的に抑制
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await result.current();
+
+		expect(showSaveFilePicker).toHaveBeenCalled();
+		expect(document.createElement).toHaveBeenCalledWith("a");
+		expect(mockA.download).toBe("export_20231001_123456.csv");
+		expect(clickSpy).toHaveBeenCalled();
+		errorSpy.mockRestore();
+	});
+
+	it("showSaveFilePicker が未定義の場合、aタグによるダウンロードを行う", async () => {
+		const originalCreateElement = document.createElement.bind(document);
+		const mockA = originalCreateElement("a");
+		const clickSpy = vi.spyOn(mockA, "click").mockImplementation(() => {});
+		vi.spyOn(document, "createElement").mockImplementation((tagName) => {
+			if (tagName === "a") {
+				return mockA;
+			}
+			return originalCreateElement(tagName);
+		});
+
+		const { result } = renderHook(() => useExportCsv());
+		await result.current();
+
+		expect(document.createElement).toHaveBeenCalledWith("a");
+		expect(mockA.download).toBe("export_20231001_123456.csv");
+		expect(clickSpy).toHaveBeenCalled();
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     unstubEnvs: true,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html', 'json-summary'],
+      reporter: ['text', 'html', 'json-summary', 'json'],
       thresholds: {
         lines: 85,
         functions: 80,


### PR DESCRIPTION
useExportCsv において、ブラウザが showSaveFilePicker をサポートしている場合にそれを利用して CSV を保存するように変更しました。サポートしていないブラウザや、何らかの理由で showSaveFilePicker が失敗した場合には、従来の a タグを用いたダウンロード処理にフォールバックします。ユーザーが保存ダイアログをキャンセルした場合は、エラーを表示せず静かに処理を終了します。これに伴い、ユニットテストの追加と E2E テストの調整を行いました。

---
*PR created automatically by Jules for task [10028204007754933303](https://jules.google.com/task/10028204007754933303) started by @yukieiji*