### PR TITLE
Replace SVG icons and symbols with lucide-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.4",
+    "lucide-react": "^1.14.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tailwindcss": "^4.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -214,24 +217,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.13':
     resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.13':
     resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.13':
     resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.13':
     resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
@@ -425,36 +432,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -543,24 +556,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -1167,24 +1184,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1208,6 +1229,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -2725,6 +2751,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.14.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   lz-string@1.5.0: {}
 

--- a/src/components/blocks/RoleCategoryAccordion.tsx
+++ b/src/components/blocks/RoleCategoryAccordion.tsx
@@ -42,7 +42,7 @@ export function RoleCategoryAccordion({
 				>
 					{disable ? (
 						<div className="w-5 h-5 flex items-center justify-center text-gray-500 font-bold">
-							<Dot size={20} aria-hidden="true" />
+							<Dot size={18} aria-hidden="true" />
 						</div>
 					) : (
 						<AccordionSvg isOpen={isOpen} className="w-5 h-5 text-gray-400" />

--- a/src/components/blocks/RoleCategoryAccordion.tsx
+++ b/src/components/blocks/RoleCategoryAccordion.tsx
@@ -42,7 +42,7 @@ export function RoleCategoryAccordion({
 				>
 					{disable ? (
 						<div className="w-5 h-5 flex items-center justify-center text-gray-500 font-bold">
-							<Dot size={20} />
+<Dot size={20} aria-hidden="true" />
 						</div>
 					) : (
 						<AccordionSvg isOpen={isOpen} className="w-5 h-5 text-gray-400" />

--- a/src/components/blocks/RoleCategoryAccordion.tsx
+++ b/src/components/blocks/RoleCategoryAccordion.tsx
@@ -42,7 +42,7 @@ export function RoleCategoryAccordion({
 				>
 					{disable ? (
 						<div className="w-5 h-5 flex items-center justify-center text-gray-500 font-bold">
-<Dot size={20} aria-hidden="true" />
+							<Dot size={20} aria-hidden="true" />
 						</div>
 					) : (
 						<AccordionSvg isOpen={isOpen} className="w-5 h-5 text-gray-400" />

--- a/src/components/blocks/RoleCategoryAccordion.tsx
+++ b/src/components/blocks/RoleCategoryAccordion.tsx
@@ -1,3 +1,4 @@
+import { Dot } from "lucide-react";
 import type { ReactNode } from "react";
 import { AccordionContentContainer } from "../parts/AccordionContentContainer";
 import { AccordionSvg } from "../parts/AccordionSvg";
@@ -41,7 +42,7 @@ export function RoleCategoryAccordion({
 				>
 					{disable ? (
 						<div className="w-5 h-5 flex items-center justify-center text-gray-500 font-bold">
-							・
+							<Dot size={20} />
 						</div>
 					) : (
 						<AccordionSvg isOpen={isOpen} className="w-5 h-5 text-gray-400" />

--- a/src/components/blocks/RoleFilterCardLayout.tsx
+++ b/src/components/blocks/RoleFilterCardLayout.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-react";
 import type { ReactNode } from "react";
 
 interface RoleFilterCardLayoutProps {
@@ -27,22 +28,7 @@ export function RoleFilterCardLayout({
 				className="absolute top-2 right-2 text-gray-400 hover:text-red-500 transition-colors"
 				aria-label="Delete filter"
 			>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					className="h-5 w-5"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke="currentColor"
-					role="img"
-					aria-label="Delete icon"
-				>
-					<path
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						strokeWidth={2}
-						d="M6 18L18 6M6 6l12 12"
-					/>
-				</svg>
+				<X size={20} aria-label="Delete icon" />
 			</button>
 
 			<div className="flex flex-col border-b border-gray-100 pb-2">

--- a/src/components/blocks/RoleFilterCardLayout.tsx
+++ b/src/components/blocks/RoleFilterCardLayout.tsx
@@ -28,7 +28,7 @@ export function RoleFilterCardLayout({
 				className="absolute top-2 right-2 text-gray-400 hover:text-red-500 transition-colors"
 				aria-label="Delete filter"
 			>
-<X size={20} aria-hidden="true" />
+				<X size={20} aria-hidden="true" />
 			</button>
 
 			<div className="flex flex-col border-b border-gray-100 pb-2">

--- a/src/components/blocks/RoleFilterCardLayout.tsx
+++ b/src/components/blocks/RoleFilterCardLayout.tsx
@@ -28,7 +28,7 @@ export function RoleFilterCardLayout({
 				className="absolute top-2 right-2 text-gray-400 hover:text-red-500 transition-colors"
 				aria-label="Delete filter"
 			>
-				<X size={20} aria-label="Delete icon" />
+<X size={20} aria-hidden="true" />
 			</button>
 
 			<div className="flex flex-col border-b border-gray-100 pb-2">

--- a/src/components/parts/AccordionSvg.tsx
+++ b/src/components/parts/AccordionSvg.tsx
@@ -10,7 +10,7 @@ export function AccordionSvg({ className, isOpen }: AccordionSvgProp) {
 	return (
 		<ChevronDown
 			className={`transition-transform duration-200 ${className} ${isOpen ? "rotate-180" : ""}`}
-aria-hidden="true"
+			aria-hidden="true"
 		/>
 	);
 }

--- a/src/components/parts/AccordionSvg.tsx
+++ b/src/components/parts/AccordionSvg.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from "lucide-react";
 import { CLOSE, OPEN } from "../../noTrans";
 
 interface AccordionSvgProp {
@@ -7,19 +8,9 @@ interface AccordionSvgProp {
 
 export function AccordionSvg({ className, isOpen }: AccordionSvgProp) {
 	return (
-		<svg
+		<ChevronDown
 			className={`transition-transform duration-200 ${className} ${isOpen ? "rotate-180" : ""}`}
-			fill="none"
-			viewBox="0 0 24 24"
-			stroke="currentColor"
-		>
-			<title>{isOpen ? CLOSE : OPEN}</title>
-			<path
-				strokeLinecap="round"
-				strokeLinejoin="round"
-				strokeWidth={2}
-				d="M19 9l-7 7-7-7"
-			/>
-		</svg>
+			aria-label={isOpen ? CLOSE : OPEN}
+		/>
 	);
 }

--- a/src/components/parts/AccordionSvg.tsx
+++ b/src/components/parts/AccordionSvg.tsx
@@ -1,5 +1,4 @@
 import { ChevronDown } from "lucide-react";
-import { CLOSE, OPEN } from "../../noTrans";
 
 interface AccordionSvgProp {
 	className: string;

--- a/src/components/parts/AccordionSvg.tsx
+++ b/src/components/parts/AccordionSvg.tsx
@@ -10,7 +10,7 @@ export function AccordionSvg({ className, isOpen }: AccordionSvgProp) {
 	return (
 		<ChevronDown
 			className={`transition-transform duration-200 ${className} ${isOpen ? "rotate-180" : ""}`}
-			aria-label={isOpen ? CLOSE : OPEN}
+aria-hidden="true"
 		/>
 	);
 }

--- a/src/components/parts/ExportButton.tsx
+++ b/src/components/parts/ExportButton.tsx
@@ -1,3 +1,4 @@
+import { Download } from "lucide-react";
 import { EXPORT_CSV_LABEL, EXPORT_CSV_TITLE } from "../../noTrans";
 
 interface ExportButtonProps {
@@ -22,22 +23,7 @@ export function ExportButton({ onClick, disabled }: ExportButtonProps) {
 			title={EXPORT_CSV_TITLE}
 			aria-label={EXPORT_CSV_TITLE}
 		>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="18"
-				height="18"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				strokeWidth="2"
-				strokeLinecap="round"
-				strokeLinejoin="round"
-				aria-hidden="true"
-			>
-				<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-				<polyline points="7 10 12 15 17 10" />
-				<line x1="12" x2="12" y1="15" y2="3" />
-			</svg>
+			<Download size={18} aria-hidden="true" />
 			<span className="text-sm font-medium">{EXPORT_CSV_LABEL}</span>
 		</button>
 	);

--- a/src/components/parts/ImportButton.tsx
+++ b/src/components/parts/ImportButton.tsx
@@ -1,3 +1,4 @@
+import { Upload } from "lucide-react";
 import { useRef } from "react";
 import { IMPORT_BUTTON_ARIA, IMPORT_BUTTON_TITLE } from "../../noTrans";
 
@@ -61,22 +62,7 @@ export function ImportButton({ onImport, disabled }: ImportButtonProps) {
 				title={IMPORT_BUTTON_TITLE}
 				aria-label={IMPORT_BUTTON_ARIA}
 			>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="18"
-					height="18"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					strokeWidth="2"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					aria-hidden="true"
-				>
-					<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-					<polyline points="17 8 12 3 7 8" />
-					<line x1="12" x2="12" y1="3" y2="15" />
-				</svg>
+				<Upload size={18} aria-hidden="true" />
 				<span>{IMPORT_BUTTON_TITLE}</span>
 			</button>
 		</>

--- a/src/components/parts/LargePoint.tsx
+++ b/src/components/parts/LargePoint.tsx
@@ -3,7 +3,7 @@ import { Dot } from "lucide-react";
 export function LargePoint() {
 	return (
 		<span className="text-gray-500 select-none text-xs inline-flex items-center">
-			<Dot size={12} />
+<Dot size={12} aria-hidden="true" />
 		</span>
 	);
 }

--- a/src/components/parts/LargePoint.tsx
+++ b/src/components/parts/LargePoint.tsx
@@ -3,7 +3,7 @@ import { Dot } from "lucide-react";
 export function LargePoint() {
 	return (
 		<span className="text-gray-500 select-none text-xs inline-flex items-center">
-			<Dot size={12} aria-hidden="true" />
+			<Dot size={18} aria-hidden="true" />
 		</span>
 	);
 }

--- a/src/components/parts/LargePoint.tsx
+++ b/src/components/parts/LargePoint.tsx
@@ -1,3 +1,9 @@
+import { Dot } from "lucide-react";
+
 export function LargePoint() {
-	return <span className="text-gray-500 select-none text-xs">・</span>;
+	return (
+		<span className="text-gray-500 select-none text-xs inline-flex items-center">
+			<Dot size={12} />
+		</span>
+	);
 }

--- a/src/components/parts/LargePoint.tsx
+++ b/src/components/parts/LargePoint.tsx
@@ -3,7 +3,7 @@ import { Dot } from "lucide-react";
 export function LargePoint() {
 	return (
 		<span className="text-gray-500 select-none text-xs inline-flex items-center">
-<Dot size={12} aria-hidden="true" />
+			<Dot size={12} aria-hidden="true" />
 		</span>
 	);
 }

--- a/src/components/parts/RolePin.tsx
+++ b/src/components/parts/RolePin.tsx
@@ -1,3 +1,5 @@
+import { X } from "lucide-react";
+
 interface RolePinProps {
 	id: number;
 	name: string;
@@ -25,22 +27,7 @@ export function RolePin({ id, name, onDelete }: RolePinProps) {
 					className="hover:text-blue-600 focus:outline-none"
 					aria-label={`Remove ${name}`}
 				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						className="h-3 w-3"
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
-						role="img"
-						aria-label="Remove icon"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							strokeWidth={2}
-							d="M6 18L18 6M6 6l12 12"
-						/>
-					</svg>
+					<X size={12} aria-label="Remove icon" />
 				</button>
 			)}
 		</div>

--- a/src/components/parts/RolePin.tsx
+++ b/src/components/parts/RolePin.tsx
@@ -27,7 +27,7 @@ export function RolePin({ id, name, onDelete }: RolePinProps) {
 					className="hover:text-blue-600 focus:outline-none"
 					aria-label={`Remove ${name}`}
 				>
-					<X size={12} aria-label="Remove icon" />
+<X size={12} aria-hidden="true" />
 				</button>
 			)}
 		</div>

--- a/src/components/parts/RolePin.tsx
+++ b/src/components/parts/RolePin.tsx
@@ -27,7 +27,7 @@ export function RolePin({ id, name, onDelete }: RolePinProps) {
 					className="hover:text-blue-600 focus:outline-none"
 					aria-label={`Remove ${name}`}
 				>
-<X size={12} aria-hidden="true" />
+					<X size={12} aria-hidden="true" />
 				</button>
 			)}
 		</div>

--- a/src/components/parts/RoleSearchInput.tsx
+++ b/src/components/parts/RoleSearchInput.tsx
@@ -17,7 +17,7 @@ export function RoleSearchInput({
 	return (
 		<div className="relative">
 			<span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
-<Search size={20} aria-hidden="true" />
+				<Search size={20} aria-hidden="true" />
 			</span>
 			<input
 				type="text"

--- a/src/components/parts/RoleSearchInput.tsx
+++ b/src/components/parts/RoleSearchInput.tsx
@@ -17,7 +17,7 @@ export function RoleSearchInput({
 	return (
 		<div className="relative">
 			<span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
-				<Search size={20} aria-label="Search icon" />
+<Search size={20} aria-hidden="true" />
 			</span>
 			<input
 				type="text"

--- a/src/components/parts/RoleSearchInput.tsx
+++ b/src/components/parts/RoleSearchInput.tsx
@@ -1,3 +1,5 @@
+import { Search } from "lucide-react";
+
 interface RoleSearchInputProps {
 	value: string;
 	onChange: (value: string) => void;
@@ -15,22 +17,7 @@ export function RoleSearchInput({
 	return (
 		<div className="relative">
 			<span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-400">
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					className="h-5 w-5"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke="currentColor"
-					role="img"
-					aria-label="Search icon"
-				>
-					<path
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						strokeWidth={2}
-						d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-					/>
-				</svg>
+				<Search size={20} aria-label="Search icon" />
 			</span>
 			<input
 				type="text"

--- a/src/components/parts/SyncButton.tsx
+++ b/src/components/parts/SyncButton.tsx
@@ -1,3 +1,4 @@
+import { RefreshCw } from "lucide-react";
 import { SYNC_BUTTON_ARIA, SYNC_BUTTON_TITLE } from "../../noTrans";
 
 interface SyncButtonProps {
@@ -22,23 +23,7 @@ export function SyncButton({ onClick, disabled }: SyncButtonProps) {
 			title={SYNC_BUTTON_TITLE}
 			aria-label={SYNC_BUTTON_ARIA}
 		>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="20"
-				height="20"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				strokeWidth="2"
-				strokeLinecap="round"
-				strokeLinejoin="round"
-				aria-hidden="true"
-			>
-				<path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-				<path d="M3 3v5h5" />
-				<path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
-				<path d="M16 16h5v5" />
-			</svg>
+			<RefreshCw size={20} aria-hidden="true" />
 		</button>
 	);
 }

--- a/src/feature/exr/PresetDropdown.tsx
+++ b/src/feature/exr/PresetDropdown.tsx
@@ -37,6 +37,7 @@ export function PresetDropdown({
 		setPresetDropdownOpen(false);
 
 		setBlockDialog({
+			type: "confirm",
 			title: PRESET_SWITCH_TITLE,
 			message: format(PRESET_SWITCH_MESSAGE, currentPresetName, newPreset),
 			onConfirm: () =>

--- a/src/feature/exr/PresetInput.tsx
+++ b/src/feature/exr/PresetInput.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from "lucide-react";
 import { useRef } from "react";
 import { PRESET_INPUT_PLACEHOLDER, PRESET_SELECT_ARIA } from "../../noTrans";
 import { useStore } from "../../useStore";
@@ -79,20 +80,11 @@ export function PresetInput({
 				className="px-2 py-1.5 bg-gray-700 hover:bg-gray-600 border-l border-gray-600 transition-colors"
 				aria-label={PRESET_SELECT_ARIA}
 			>
-				<svg
-					className={`w-4 h-4 text-gray-400 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
-					fill="none"
-					stroke="currentColor"
-					viewBox="0 0 24 24"
+				<ChevronDown
+					size={16}
+					className={`text-gray-400 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
 					aria-hidden="true"
-				>
-					<path
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						strokeWidth={2}
-						d="M19 9l-7 7-7-7"
-					/>
-				</svg>
+				/>
 			</button>
 		</div>
 	);

--- a/src/feature/rolefilter/RoleFilterAddButton.tsx
+++ b/src/feature/rolefilter/RoleFilterAddButton.tsx
@@ -1,3 +1,4 @@
+import { Plus } from "lucide-react";
 import { postRoleFilterUpdate } from "../../logics/api";
 import { PostExRAssignOps } from "../../type";
 import { useStore } from "../../useStore";
@@ -28,22 +29,7 @@ export function RoleFilterAddButton() {
 			onClick={onAddFilter}
 			className="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none"
 		>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				className="h-5 w-5 mr-1"
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke="currentColor"
-				role="img"
-				aria-label="Add filter icon"
-			>
-				<path
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					strokeWidth={2}
-					d="M12 4v16m8-8H4"
-				/>
-			</svg>
+			<Plus size={20} className="mr-1" aria-label="Add filter icon" />
 			フィルターを追加
 		</button>
 	);

--- a/src/feature/rolefilter/RoleFilterAddButton.tsx
+++ b/src/feature/rolefilter/RoleFilterAddButton.tsx
@@ -29,7 +29,7 @@ export function RoleFilterAddButton() {
 			onClick={onAddFilter}
 			className="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none"
 		>
-<Plus size={20} className="mr-1" aria-hidden="true" />
+			<Plus size={20} className="mr-1" aria-hidden="true" />
 			フィルターを追加
 		</button>
 	);

--- a/src/feature/rolefilter/RoleFilterAddButton.tsx
+++ b/src/feature/rolefilter/RoleFilterAddButton.tsx
@@ -29,7 +29,7 @@ export function RoleFilterAddButton() {
 			onClick={onAddFilter}
 			className="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none"
 		>
-			<Plus size={20} className="mr-1" aria-label="Add filter icon" />
+<Plus size={20} className="mr-1" aria-hidden="true" />
 			フィルターを追加
 		</button>
 	);

--- a/src/feature/rolefilter/RoleFilterCard.tsx
+++ b/src/feature/rolefilter/RoleFilterCard.tsx
@@ -98,7 +98,7 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 				onClick={onOpenRoleSelect}
 				className="mt-1 self-start inline-flex items-center px-2 py-1 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none"
 			>
-				<Plus size={12} className="mr-1" aria-label="Add icon" />
+<Plus size={12} className="mr-1" aria-hidden="true" />
 				役職を追加
 			</button>
 		</>

--- a/src/feature/rolefilter/RoleFilterCard.tsx
+++ b/src/feature/rolefilter/RoleFilterCard.tsx
@@ -98,7 +98,7 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 				onClick={onOpenRoleSelect}
 				className="mt-1 self-start inline-flex items-center px-2 py-1 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none"
 			>
-<Plus size={12} className="mr-1" aria-hidden="true" />
+				<Plus size={12} className="mr-1" aria-hidden="true" />
 				役職を追加
 			</button>
 		</>

--- a/src/feature/rolefilter/RoleFilterCard.tsx
+++ b/src/feature/rolefilter/RoleFilterCard.tsx
@@ -1,3 +1,4 @@
+import { Plus } from "lucide-react";
 import { RoleFilterCardLayout } from "../../components/blocks/RoleFilterCardLayout";
 import { RolePin } from "../../components/parts/RolePin";
 import { postRoleFilterUpdate, roleFilterMetaData } from "../../logics/api";
@@ -97,22 +98,7 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 				onClick={onOpenRoleSelect}
 				className="mt-1 self-start inline-flex items-center px-2 py-1 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none"
 			>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					className="h-3 w-3 mr-1"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke="currentColor"
-					role="img"
-					aria-label="Add icon"
-				>
-					<path
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						strokeWidth={2}
-						d="M12 4v16m8-8H4"
-					/>
-				</svg>
+				<Plus size={12} className="mr-1" aria-label="Add icon" />
 				役職を追加
 			</button>
 		</>

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-react";
 import { RoleGrid } from "../../components/blocks/RoleGrid";
 import { RoleSearchInput } from "../../components/parts/RoleSearchInput";
 import { roleFilterMetaData } from "../../logics/api";
@@ -46,22 +47,7 @@ export function RoleSelectDialog({
 					onClick={onCancel}
 					className="text-gray-400 hover:text-gray-600 transition-colors"
 				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						className="h-6 w-6"
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
-						role="img"
-						aria-label="Close icon"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							strokeWidth={2}
-							d="M6 18L18 6M6 6l12 12"
-						/>
-					</svg>
+					<X size={24} aria-label="Close icon" />
 				</button>
 			</div>
 			<div className="px-6 py-3 border-b border-gray-50">


### PR DESCRIPTION
This change refactors the icon system to use the `lucide-react` library instead of inline SVGs and text-based symbols. 

Key changes:
1.  **Icon Library Migration**: Integrated `lucide-react` and replaced inline `<svg>` elements in components like `ExportButton`, `SyncButton`, `RoleSearchInput`, etc.
2.  **Symbol Replacement**: Replaced the "・" character used in `LargePoint` and `RoleCategoryAccordion` with the `Dot` icon for a more consistent visual appearance.
3.  **UI Consistency**: Used appropriate icons like `ChevronDown`, `Plus`, `X`, `Upload`, and `Download` to maintain the existing user interface while improving maintainability.
4.  **Bug Fix**: Corrected a missing `type` property in a `setBlockDialog` call within `PresetDropdown.tsx` which was causing a TypeScript build error.
5.  **Clean Up**: Verified that no `<svg>` tags remain in the component source files (assets are excluded).

All existing tests pass, and the project builds successfully.

---
*PR created automatically by Jules for task [7629652595870077136](https://jules.google.com/task/7629652595870077136) started by @yukieiji*