### PR TITLE
RoleSelectDialogの検索時のがたつきを修正

### DIFF
--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -39,7 +39,7 @@ export function RoleSelectDialog({
 	);
 
 	return (
-		<div className="bg-white rounded-lg shadow-2xl w-full max-w-2xl overflow-hidden animate-in fade-in zoom-in duration-200 flex flex-col max-h-[80vh]">
+		<div className="bg-white rounded-lg shadow-2xl w-full max-w-2xl overflow-hidden animate-in fade-in zoom-in duration-200 flex flex-col h-[80vh]">
 			<div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center">
 				<h3 className="text-xl font-bold text-gray-900">役職の選択</h3>
 				<button
@@ -57,7 +57,7 @@ export function RoleSelectDialog({
 					placeholder="役職を検索..."
 				/>
 			</div>
-			<div className="px-6 py-4 overflow-y-auto">
+			<div className="px-6 py-4 overflow-y-auto flex-1">
 				<RoleGrid
 					items={filteredRoles}
 					onSelect={onSelect}


### PR DESCRIPTION
RoleSelectDialogの検索時のがたつきを修正しました。
ダイアログの高さを80vhに固定し、中身のRoleGrid部分をflex-1で広げるように変更しています。
これにより、検索結果が少なくなってもダイアログの高さが維持され、検索バーの位置が固定されます。

---
*PR created automatically by Jules for task [1081848220897507469](https://jules.google.com/task/1081848220897507469) started by @yukieiji*