### PR TITLE
RoleFilterダイアログの複数選択対応

### DIFF
--- a/e2e/role_filter.spec.ts
+++ b/e2e/role_filter.spec.ts
@@ -32,7 +32,9 @@ test.describe("Role Filter Tab", () => {
 		).toBeVisible();
 
 		// フィルターカードが表示されていることを確認
-		const cardElement = page.getByRole("listitem");
+		const cardElement = page
+			.getByRole("list", { name: "Filter List" })
+			.getByRole("listitem");
 		await expect(cardElement.first()).toBeVisible();
 
 		// AssignNumが表示されていることを確認

--- a/e2e/role_filter.spec.ts
+++ b/e2e/role_filter.spec.ts
@@ -32,14 +32,14 @@ test.describe("Role Filter Tab", () => {
 		).toBeVisible();
 
 		// フィルターカードが表示されていることを確認
-		const cardElement = page.locator("[data-guid]");
+		const cardElement = page.getByRole("listitem");
 		await expect(cardElement.first()).toBeVisible();
 
 		// AssignNumが表示されていることを確認
 		await expect(page.getByText("AssignNum:").first()).toBeVisible();
 
 		// 役職ピンが表示されていることを確認
-		const pinElement = page.locator("[data-role-id]");
-		await expect(pinElement.first()).toBeVisible();
+		// RolePinはテキストを表示するdivとして実装されている
+		await expect(page.getByText("Bakary").first()).toBeVisible();
 	});
 });

--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -25,7 +25,7 @@ test.describe("Role Filter Management", () => {
 
 	test("should add and delete a role filter", async ({ page }) => {
 		// Initial count of filters
-		const initialFilters = await page.locator("[data-guid]").count();
+		const initialFilters = await page.getByRole("listitem").count();
 
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
@@ -34,13 +34,13 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// Verify new filter is added
-		await expect(page.locator("[data-guid]")).toHaveCount(initialFilters + 1, {
+		await expect(page.getByRole("listitem")).toHaveCount(initialFilters + 1, {
 			timeout: 15000,
 		});
 		await expect(page.getByText("AssignNum: 1").last()).toBeVisible();
 
 		// Delete the filter
-		const lastFilter = page.locator("[data-guid]").last();
+		const lastFilter = page.getByRole("listitem").last();
 		await lastFilter.getByLabel("Delete filter").click();
 
 		// Confirmation dialog
@@ -48,13 +48,13 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: "OK" }).click();
 
 		// Verify filter is removed
-		await expect(page.locator("[data-guid]")).toHaveCount(initialFilters, {
+		await expect(page.getByRole("listitem")).toHaveCount(initialFilters, {
 			timeout: 15000,
 		});
 	});
 
 	test("should add a role to filter using search", async ({ page }) => {
-		const initialFilters = await page.locator("[data-guid]").count();
+		const initialFilters = await page.getByRole("listitem").count();
 
 		// Add a new filter first (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
@@ -67,11 +67,11 @@ test.describe("Role Filter Management", () => {
 		});
 
 		// Verify new filter is added
-		await expect(page.locator("[data-guid]")).toHaveCount(initialFilters + 1, {
+		await expect(page.getByRole("listitem")).toHaveCount(initialFilters + 1, {
 			timeout: 15000,
 		});
 
-		const lastFilter = page.locator("[data-guid]").last();
+		const lastFilter = page.getByRole("listitem").last();
 
 		// Open role select dialog to add another role
 		await lastFilter.getByRole("button", { name: "役職を追加" }).click();
@@ -99,7 +99,7 @@ test.describe("Role Filter Management", () => {
 
 		// Verify role is added to the filter
 		// 要素の出現を待つ
-		await expect(lastFilter.locator('[data-role-name="Opener"]')).toBeVisible({
+		await expect(lastFilter.getByText("Opener", { exact: true })).toBeVisible({
 			timeout: 20000,
 		});
 	});
@@ -110,14 +110,16 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: "Bakary" }).first().click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
-		const lastFilter = page.locator("[data-guid]").last();
+		const lastFilter = page.getByRole("listitem").last();
 
-		await expect(lastFilter.locator('[data-role-name="Bakary"]')).toBeVisible({
+		await expect(lastFilter.getByText("Bakary", { exact: true })).toBeVisible({
 			timeout: 15000,
 		});
 
 		// Remove the role
-		const rolePin = lastFilter.locator('[data-role-name="Bakary"]');
+		const rolePin = lastFilter
+			.getByText("Bakary", { exact: true })
+			.locator("xpath=..");
 		await rolePin.getByLabel("Remove Bakary").click();
 
 		// Confirmation dialog

--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -31,6 +31,7 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
 		await expect(page.getByText("役職の選択")).toBeVisible();
 		await page.getByRole("button", { name: "Bakary" }).first().click();
+		await page.getByRole("button", { name: /確定/ }).click();
 
 		// Verify new filter is added
 		await expect(page.locator("[data-guid]")).toHaveCount(initialFilters + 1, {
@@ -58,6 +59,7 @@ test.describe("Role Filter Management", () => {
 		// Add a new filter first (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
 		await page.getByRole("button", { name: "Bakary" }).first().click();
+		await page.getByRole("button", { name: /確定/ }).click();
 
 		// ダイアログが閉じるのを待つ
 		await expect(page.getByText("役職の選択")).not.toBeVisible({
@@ -88,6 +90,7 @@ test.describe("Role Filter Management", () => {
 		});
 		await expect(roleButton).toBeVisible({ timeout: 10000 });
 		await roleButton.click();
+		await page.getByRole("button", { name: /確定/ }).click();
 
 		// ダイアログが閉じるのを待つ
 		await expect(page.getByText("役職の選択")).not.toBeVisible({
@@ -105,6 +108,7 @@ test.describe("Role Filter Management", () => {
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
 		await page.getByRole("button", { name: "Bakary" }).first().click();
+		await page.getByRole("button", { name: /確定/ }).click();
 
 		const lastFilter = page.locator("[data-guid]").last();
 

--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -24,8 +24,9 @@ test.describe("Role Filter Management", () => {
 	});
 
 	test("should add and delete a role filter", async ({ page }) => {
+		const filterList = page.getByRole("list", { name: "Filter List" });
 		// Initial count of filters
-		const initialFilters = await page.getByRole("listitem").count();
+		const initialFilters = await filterList.getByRole("listitem").count();
 
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
@@ -34,13 +35,16 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// Verify new filter is added
-		await expect(page.getByRole("listitem")).toHaveCount(initialFilters + 1, {
-			timeout: 15000,
-		});
+		await expect(filterList.getByRole("listitem")).toHaveCount(
+			initialFilters + 1,
+			{
+				timeout: 15000,
+			},
+		);
 		await expect(page.getByText("AssignNum: 1").last()).toBeVisible();
 
 		// Delete the filter
-		const lastFilter = page.getByRole("listitem").last();
+		const lastFilter = filterList.getByRole("listitem").last();
 		await lastFilter.getByLabel("Delete filter").click();
 
 		// Confirmation dialog
@@ -48,13 +52,14 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: "OK" }).click();
 
 		// Verify filter is removed
-		await expect(page.getByRole("listitem")).toHaveCount(initialFilters, {
+		await expect(filterList.getByRole("listitem")).toHaveCount(initialFilters, {
 			timeout: 15000,
 		});
 	});
 
 	test("should add a role to filter using search", async ({ page }) => {
-		const initialFilters = await page.getByRole("listitem").count();
+		const filterList = page.getByRole("list", { name: "Filter List" });
+		const initialFilters = await filterList.getByRole("listitem").count();
 
 		// Add a new filter first (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
@@ -67,11 +72,14 @@ test.describe("Role Filter Management", () => {
 		});
 
 		// Verify new filter is added
-		await expect(page.getByRole("listitem")).toHaveCount(initialFilters + 1, {
-			timeout: 15000,
-		});
+		await expect(filterList.getByRole("listitem")).toHaveCount(
+			initialFilters + 1,
+			{
+				timeout: 15000,
+			},
+		);
 
-		const lastFilter = page.getByRole("listitem").last();
+		const lastFilter = filterList.getByRole("listitem").last();
 
 		// Open role select dialog to add another role
 		await lastFilter.getByRole("button", { name: "役職を追加" }).click();
@@ -105,12 +113,13 @@ test.describe("Role Filter Management", () => {
 	});
 
 	test("should remove a role from filter", async ({ page }) => {
+		const filterList = page.getByRole("list", { name: "Filter List" });
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
 		await page.getByRole("button", { name: "Bakary" }).first().click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
-		const lastFilter = page.getByRole("listitem").last();
+		const lastFilter = filterList.getByRole("listitem").last();
 
 		await expect(lastFilter.getByText("Bakary", { exact: true })).toBeVisible({
 			timeout: 15000,

--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -126,10 +126,7 @@ test.describe("Role Filter Management", () => {
 		});
 
 		// Remove the role
-		const rolePin = lastFilter
-			.getByText("Bakary", { exact: true })
-			.locator("xpath=..");
-		await rolePin.getByLabel("Remove Bakary").click();
+		await lastFilter.getByLabel("Remove Bakary").click();
 
 		// Confirmation dialog
 		await expect(page.getByText("役職の削除")).toBeVisible();

--- a/src/components/blocks/RoleFilterCardLayout.tsx
+++ b/src/components/blocks/RoleFilterCardLayout.tsx
@@ -2,7 +2,6 @@ import { X } from "lucide-react";
 import type { ReactNode } from "react";
 
 interface RoleFilterCardLayoutProps {
-	guid: string;
 	onDelete: () => void;
 	header: ReactNode;
 	children: ReactNode;
@@ -12,16 +11,12 @@ interface RoleFilterCardLayoutProps {
  * Role Filter Card の基本レイアウトコンポーネント (Stateless)
  */
 export function RoleFilterCardLayout({
-	guid,
 	onDelete,
 	header,
 	children,
 }: RoleFilterCardLayoutProps) {
 	return (
-		<div
-			data-guid={guid}
-			className="bg-white shadow rounded-lg p-4 border border-gray-200 flex flex-col gap-3 relative"
-		>
+		<div className="bg-white shadow rounded-lg p-4 border border-gray-200 flex flex-col gap-3 relative">
 			<button
 				type="button"
 				onClick={onDelete}

--- a/src/components/blocks/RoleFilterCardLayout.tsx
+++ b/src/components/blocks/RoleFilterCardLayout.tsx
@@ -16,7 +16,7 @@ export function RoleFilterCardLayout({
 	children,
 }: RoleFilterCardLayoutProps) {
 	return (
-		<div className="bg-white shadow rounded-lg p-4 border border-gray-200 flex flex-col gap-3 relative">
+		<li className="bg-white shadow rounded-lg p-4 border border-gray-200 flex flex-col gap-3 relative list-none">
 			<button
 				type="button"
 				onClick={onDelete}
@@ -31,6 +31,6 @@ export function RoleFilterCardLayout({
 			</div>
 
 			<div className="flex flex-wrap gap-2">{children}</div>
-		</div>
+		</li>
 	);
 }

--- a/src/components/blocks/RoleGrid.tsx
+++ b/src/components/blocks/RoleGrid.tsx
@@ -64,6 +64,8 @@ export function RoleGrid({
 									fill="none"
 									viewBox="0 0 24 24"
 									stroke="currentColor"
+									role="img"
+									aria-label="Selected"
 								>
 									<path
 										strokeLinecap="round"

--- a/src/components/blocks/RoleGrid.tsx
+++ b/src/components/blocks/RoleGrid.tsx
@@ -1,3 +1,5 @@
+import { Check } from "lucide-react";
+
 interface RoleGridItem {
 	roleId: number;
 	roleName: string;
@@ -59,21 +61,11 @@ export function RoleGrid({
 							}`}
 						>
 							{isSelected && (
-								<svg
+								<Check
 									className="w-3 h-3 text-white"
-									fill="none"
-									viewBox="0 0 24 24"
-									stroke="currentColor"
-									role="img"
+									strokeWidth={4}
 									aria-label="Selected"
-								>
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										strokeWidth={3}
-										d="M5 13l4 4L19 7"
-									/>
-								</svg>
+								/>
 							)}
 						</div>
 						<div className="flex flex-col gap-0.5 overflow-hidden">

--- a/src/components/blocks/RoleGrid.tsx
+++ b/src/components/blocks/RoleGrid.tsx
@@ -5,7 +5,8 @@ interface RoleGridItem {
 
 interface RoleGridProps {
 	items: RoleGridItem[];
-	onSelect: (roleId: number) => void;
+	onSelect: (roleId: number, event: React.MouseEvent) => void;
+	selectedRoleIds?: number[];
 	excludeRoleIds?: number[];
 	emptyMessage?: string;
 }
@@ -16,6 +17,7 @@ interface RoleGridProps {
 export function RoleGrid({
 	items,
 	onSelect,
+	selectedRoleIds = [],
 	excludeRoleIds = [],
 	emptyMessage = "見つかりませんでした",
 }: RoleGridProps) {
@@ -31,20 +33,48 @@ export function RoleGrid({
 		<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
 			{items.map(({ roleId, roleName }) => {
 				const isExcluded = excludeRoleIds.includes(roleId);
+				const isSelected = selectedRoleIds.includes(roleId);
 
 				return (
 					<button
 						key={roleId}
 						type="button"
 						disabled={isExcluded}
-						onClick={() => onSelect(roleId)}
-						className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition-all ${
+						onClick={(e) => onSelect(roleId, e)}
+						className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition-all border flex items-center gap-3 ${
 							isExcluded
-								? "bg-gray-100 text-gray-400 cursor-not-allowed"
-								: "bg-gray-50 hover:bg-indigo-50 text-gray-700 border border-gray-200 hover:border-indigo-200 shadow-sm"
+								? "bg-gray-100 text-gray-400 cursor-not-allowed border-gray-200"
+								: isSelected
+									? "bg-indigo-100 text-indigo-700 border-indigo-300 shadow-sm ring-1 ring-indigo-300"
+									: "bg-gray-50 hover:bg-indigo-50 text-gray-700 border-gray-200 hover:border-indigo-200 shadow-sm"
 						}`}
 					>
-						<div className="flex flex-col gap-0.5">
+						<div
+							className={`flex-shrink-0 w-4 h-4 rounded border flex items-center justify-center transition-colors ${
+								isExcluded
+									? "bg-gray-200 border-gray-300"
+									: isSelected
+										? "bg-indigo-600 border-indigo-600"
+										: "bg-white border-gray-300"
+							}`}
+						>
+							{isSelected && (
+								<svg
+									className="w-3 h-3 text-white"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										strokeWidth={3}
+										d="M5 13l4 4L19 7"
+									/>
+								</svg>
+							)}
+						</div>
+						<div className="flex flex-col gap-0.5 overflow-hidden">
 							<span className="truncate">{roleName}</span>
 							{isExcluded && (
 								<span className="text-[9px] text-gray-400 font-normal uppercase tracking-wider">

--- a/src/components/parts/RolePin.tsx
+++ b/src/components/parts/RolePin.tsx
@@ -10,10 +10,7 @@ interface RolePinProps {
  */
 export function RolePin({ name, onDelete }: RolePinProps) {
 	return (
-		<div
-			data-role-name={name}
-			className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200"
-		>
+		<div className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
 			<span>{name}</span>
 			{onDelete && (
 				<button

--- a/src/components/parts/RolePin.tsx
+++ b/src/components/parts/RolePin.tsx
@@ -1,7 +1,6 @@
 import { X } from "lucide-react";
 
 interface RolePinProps {
-	id: number;
 	name: string;
 	onDelete?: () => void;
 }
@@ -9,10 +8,9 @@ interface RolePinProps {
 /**
  * 個別の役職をピン形式で表示する最小単位のコンポーネント
  */
-export function RolePin({ id, name, onDelete }: RolePinProps) {
+export function RolePin({ name, onDelete }: RolePinProps) {
 	return (
 		<div
-			data-role-id={id}
 			data-role-name={name}
 			className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200"
 		>

--- a/src/feature/BlockableDialog.tsx
+++ b/src/feature/BlockableDialog.tsx
@@ -26,8 +26,8 @@ export function BlockableDialog() {
 			{blockDialog.type === "roleSelect" && (
 				<RoleSelectDialog
 					excludeRoleIds={blockDialog.excludeRoleIds}
-					onSelect={async (roleId) => {
-						await blockDialog.onSelect(roleId);
+					onSelect={async (roleIds) => {
+						await blockDialog.onSelect(roleIds);
 						closeDialog();
 					}}
 					onCancel={closeDialog}

--- a/src/feature/rolefilter/RoleFilterAddButton.tsx
+++ b/src/feature/rolefilter/RoleFilterAddButton.tsx
@@ -17,6 +17,8 @@ export function RoleFilterAddButton() {
 			title: "フィルター追加: 役職の選択",
 			searchQuery: "",
 			excludeRoleIds: [],
+			selectedRoleIds: [],
+			lastClickedId: null,
 			onSelect: async (roleIds: number[]) => {
 				const guid = crypto.randomUUID();
 				try {

--- a/src/feature/rolefilter/RoleFilterAddButton.tsx
+++ b/src/feature/rolefilter/RoleFilterAddButton.tsx
@@ -17,7 +17,7 @@ export function RoleFilterAddButton() {
 			title: "フィルター追加: 役職の選択",
 			searchQuery: "",
 			excludeRoleIds: [],
-			onSelect: async (roleId: number) => {
+			onSelect: async (roleIds: number[]) => {
 				const guid = crypto.randomUUID();
 				try {
 					// 1. フィルターの新規作成
@@ -29,19 +29,21 @@ export function RoleFilterAddButton() {
 					addRoleFilter(guid);
 
 					// 2. 選択された役職をフィルターに追加
-					await postRoleFilterUpdate({
-						Op: PostExRAssignOps.FilterRoleAdd,
-						FilterId: guid,
-						MapRoleId: roleId,
-					});
+					for (const roleId of roleIds) {
+						await postRoleFilterUpdate({
+							Op: PostExRAssignOps.FilterRoleAdd,
+							FilterId: guid,
+							MapRoleId: roleId,
+						});
 
-					const roleName =
-						(roleFilterMetaData.NormalRoleId[roleId] as string) ||
-						(roleFilterMetaData.CombinationId[roleId] as string) ||
-						(roleFilterMetaData.GhostRoleId[roleId] as string) ||
-						"Unknown Role";
+						const roleName =
+							(roleFilterMetaData.NormalRoleId[roleId] as string) ||
+							(roleFilterMetaData.CombinationId[roleId] as string) ||
+							(roleFilterMetaData.GhostRoleId[roleId] as string) ||
+							"Unknown Role";
 
-					addRoleToFilter(guid, roleId, roleName);
+						addRoleToFilter(guid, roleId, roleName);
+					}
 				} catch (error) {
 					console.error("Failed to add role filter with role:", error);
 				}

--- a/src/feature/rolefilter/RoleFilterCard.tsx
+++ b/src/feature/rolefilter/RoleFilterCard.tsx
@@ -1,10 +1,10 @@
-import { Plus } from "lucide-react";
 import { RoleFilterCardLayout } from "../../components/blocks/RoleFilterCardLayout";
 import { RolePin } from "../../components/parts/RolePin";
-import { postRoleFilterUpdate, roleFilterMetaData } from "../../logics/api";
+import { postRoleFilterUpdate } from "../../logics/api";
 import type { RoleAssignFilterSetUI } from "../../type";
 import { PostExRAssignOps } from "../../type";
 import { useStore } from "../../useStore";
+import { RoleFilterCardHeader } from "./RoleFilterCardHeader";
 
 interface RoleFilterCardProps {
 	guid: string;
@@ -18,7 +18,6 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 	const openBlockDialog = useStore((state) => state.openBlockDialog);
 	const deleteRoleFilter = useStore((state) => state.deleteRoleFilter);
 	const removeRoleFromFilter = useStore((state) => state.removeRoleFromFilter);
-	const addRoleToFilter = useStore((state) => state.addRoleToFilter);
 
 	const onDeleteFilter = () => {
 		openBlockDialog({
@@ -59,57 +58,17 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 			},
 		});
 	};
-
-	const onOpenRoleSelect = () => {
-		openBlockDialog({
-			type: "roleSelect",
-			title: "役職の追加",
-			searchQuery: "",
-			excludeRoleIds: filterSet.Roles.map((r) => r.id),
-			selectedRoleIds: [],
-			lastClickedId: null,
-			onSelect: async (roleIds: number[]) => {
-				try {
-					for (const roleId of roleIds) {
-						await postRoleFilterUpdate({
-							Op: PostExRAssignOps.FilterRoleAdd,
-							FilterId: guid,
-							MapRoleId: roleId,
-						});
-
-						const roleName =
-							(roleFilterMetaData.NormalRoleId[roleId] as string) ||
-							(roleFilterMetaData.CombinationId[roleId] as string) ||
-							(roleFilterMetaData.GhostRoleId[roleId] as string) ||
-							"Unknown Role";
-
-						addRoleToFilter(guid, roleId, roleName);
-					}
-				} catch (error) {
-					console.error("Failed to add role to filter:", error);
-				}
-			},
-		});
-	};
-
-	const header = (
-		<>
-			<span className="text-sm font-semibold text-gray-700">
-				AssignNum: {filterSet.AssignNum}
-			</span>
-			<button
-				type="button"
-				onClick={onOpenRoleSelect}
-				className="mt-1 self-start inline-flex items-center px-2 py-1 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none"
-			>
-				<Plus size={12} className="mr-1" aria-hidden="true" />
-				役職を追加
-			</button>
-		</>
-	);
-
 	return (
-		<RoleFilterCardLayout guid={guid} onDelete={onDeleteFilter} header={header}>
+		<RoleFilterCardLayout
+			onDelete={onDeleteFilter}
+			header={
+				<RoleFilterCardHeader
+					guid={guid}
+					assignNum={filterSet.AssignNum}
+					excludeRoleIds={filterSet.Roles.map((r) => r.id)}
+				/>
+			}
+		>
 			{filterSet.Roles.map((role) => {
 				return (
 					<RolePin

--- a/src/feature/rolefilter/RoleFilterCard.tsx
+++ b/src/feature/rolefilter/RoleFilterCard.tsx
@@ -66,6 +66,8 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 			title: "役職の追加",
 			searchQuery: "",
 			excludeRoleIds: filterSet.Roles.map((r) => r.id),
+			selectedRoleIds: [],
+			lastClickedId: null,
 			onSelect: async (roleIds: number[]) => {
 				try {
 					for (const roleId of roleIds) {

--- a/src/feature/rolefilter/RoleFilterCard.tsx
+++ b/src/feature/rolefilter/RoleFilterCard.tsx
@@ -66,21 +66,23 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 			title: "役職の追加",
 			searchQuery: "",
 			excludeRoleIds: filterSet.Roles.map((r) => r.id),
-			onSelect: async (roleId: number) => {
+			onSelect: async (roleIds: number[]) => {
 				try {
-					await postRoleFilterUpdate({
-						Op: PostExRAssignOps.FilterRoleAdd,
-						FilterId: guid,
-						MapRoleId: roleId,
-					});
+					for (const roleId of roleIds) {
+						await postRoleFilterUpdate({
+							Op: PostExRAssignOps.FilterRoleAdd,
+							FilterId: guid,
+							MapRoleId: roleId,
+						});
 
-					const roleName =
-						(roleFilterMetaData.NormalRoleId[roleId] as string) ||
-						(roleFilterMetaData.CombinationId[roleId] as string) ||
-						(roleFilterMetaData.GhostRoleId[roleId] as string) ||
-						"Unknown Role";
+						const roleName =
+							(roleFilterMetaData.NormalRoleId[roleId] as string) ||
+							(roleFilterMetaData.CombinationId[roleId] as string) ||
+							(roleFilterMetaData.GhostRoleId[roleId] as string) ||
+							"Unknown Role";
 
-					addRoleToFilter(guid, roleId, roleName);
+						addRoleToFilter(guid, roleId, roleName);
+					}
 				} catch (error) {
 					console.error("Failed to add role to filter:", error);
 				}

--- a/src/feature/rolefilter/RoleFilterCard.tsx
+++ b/src/feature/rolefilter/RoleFilterCard.tsx
@@ -73,7 +73,6 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 				return (
 					<RolePin
 						key={role.id}
-						id={role.id}
 						name={role.name}
 						onDelete={() => onDeleteRole(role.id, role.name)}
 					/>

--- a/src/feature/rolefilter/RoleFilterCardHeader.tsx
+++ b/src/feature/rolefilter/RoleFilterCardHeader.tsx
@@ -1,0 +1,67 @@
+import { Plus } from "lucide-react";
+import { postRoleFilterUpdate, roleFilterMetaData } from "../../logics/api";
+import { PostExRAssignOps } from "../../type";
+import { useStore } from "../../useStore";
+
+interface RoleFilterCardHeaderProp {
+	guid: string;
+	assignNum: number;
+	excludeRoleIds: number[];
+}
+
+export function RoleFilterCardHeader({
+	guid,
+	assignNum,
+	excludeRoleIds,
+}: RoleFilterCardHeaderProp) {
+	const openBlockDialog = useStore((state) => state.openBlockDialog);
+	const addRoleToFilter = useStore((state) => state.addRoleToFilter);
+
+	const onOpenRoleSelect = () => {
+		openBlockDialog({
+			type: "roleSelect",
+			title: "役職の追加",
+			searchQuery: "",
+			excludeRoleIds: excludeRoleIds,
+			selectedRoleIds: [],
+			lastClickedId: null,
+			onSelect: async (roleIds: number[]) => {
+				try {
+					for (const roleId of roleIds) {
+						await postRoleFilterUpdate({
+							Op: PostExRAssignOps.FilterRoleAdd,
+							FilterId: guid,
+							MapRoleId: roleId,
+						});
+
+						const roleName =
+							(roleFilterMetaData.NormalRoleId[roleId] as string) ||
+							(roleFilterMetaData.CombinationId[roleId] as string) ||
+							(roleFilterMetaData.GhostRoleId[roleId] as string) ||
+							"Unknown Role";
+
+						addRoleToFilter(guid, roleId, roleName);
+					}
+				} catch (error) {
+					console.error("Failed to add role to filter:", error);
+				}
+			},
+		});
+	};
+
+	return (
+		<>
+			<span className="text-sm font-semibold text-gray-700">
+				AssignNum: {assignNum}
+			</span>
+			<button
+				type="button"
+				onClick={onOpenRoleSelect}
+				className="mt-1 self-start inline-flex items-center px-2 py-1 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none"
+			>
+				<Plus size={12} className="mr-1" aria-hidden="true" />
+				役職を追加
+			</button>
+		</>
+	);
+}

--- a/src/feature/rolefilter/RoleFilterViewer.tsx
+++ b/src/feature/rolefilter/RoleFilterViewer.tsx
@@ -27,7 +27,10 @@ export function RoleFilterViewer() {
 					</p>
 				</div>
 			) : (
-				<ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				<ul
+					aria-label="Filter List"
+					className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+				>
 					{filterEntries.map(([guid, filterSet]) => {
 						return (
 							<RoleFilterCard key={guid} guid={guid} filterSet={filterSet} />

--- a/src/feature/rolefilter/RoleFilterViewer.tsx
+++ b/src/feature/rolefilter/RoleFilterViewer.tsx
@@ -27,13 +27,13 @@ export function RoleFilterViewer() {
 					</p>
 				</div>
 			) : (
-				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				<ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 					{filterEntries.map(([guid, filterSet]) => {
 						return (
 							<RoleFilterCard key={guid} guid={guid} filterSet={filterSet} />
 						);
 					})}
-				</div>
+				</ul>
 			)}
 		</div>
 	);

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -1,5 +1,4 @@
 import { X } from "lucide-react";
-import { useState } from "react";
 import { RoleGrid } from "../../components/blocks/RoleGrid";
 import { RoleSearchInput } from "../../components/parts/RoleSearchInput";
 import { roleFilterMetaData } from "../../logics/api";
@@ -20,8 +19,21 @@ export function RoleSelectDialog({
 	onCancel,
 	excludeRoleIds = [],
 }: RoleSelectDialogProps) {
-	const [selectedRoleIds, setSelectedRoleIds] = useState<number[]>([]);
-	const [lastClickedId, setLastClickedId] = useState<number | null>(null);
+	const selectedRoleIds = useStore((state) => {
+		if (state.blockDialog?.type === "roleSelect") {
+			return state.blockDialog.selectedRoleIds;
+		}
+		return [];
+	});
+	const setSelectedRoleIds = useStore((state) => state.setSelectedRoleIds);
+
+	const lastClickedId = useStore((state) => {
+		if (state.blockDialog?.type === "roleSelect") {
+			return state.blockDialog.lastClickedId;
+		}
+		return null;
+	});
+	const setLastClickedId = useStore((state) => state.setLastClickedId);
 
 	const searchQuery = useStore((state) => {
 		if (state.blockDialog?.type === "roleSelect") {
@@ -60,29 +72,27 @@ export function RoleSelectDialog({
 					.filter((r) => !excludeRoleIds.includes(r.roleId))
 					.map((r) => r.roleId);
 
-				setSelectedRoleIds((prev) => {
-					const next = [...prev];
-					for (const id of rangeIds) {
-						if (!next.includes(id)) {
-							next.push(id);
-						}
+				const next = [...selectedRoleIds];
+				for (const id of rangeIds) {
+					if (!next.includes(id)) {
+						next.push(id);
 					}
-					return next;
-				});
+				}
+				setSelectedRoleIds(next);
 			}
 		} else if (event.ctrlKey || event.metaKey) {
 			// Toggle single selection
-			setSelectedRoleIds((prev) =>
-				prev.includes(roleId)
-					? prev.filter((id) => id !== roleId)
-					: [...prev, roleId],
+			setSelectedRoleIds(
+				selectedRoleIds.includes(roleId)
+					? selectedRoleIds.filter((id) => id !== roleId)
+					: [...selectedRoleIds, roleId],
 			);
 		} else {
 			// Single selection (toggle for consistency with checkbox UI)
-			setSelectedRoleIds((prev) =>
-				prev.includes(roleId)
-					? prev.filter((id) => id !== roleId)
-					: [...prev, roleId],
+			setSelectedRoleIds(
+				selectedRoleIds.includes(roleId)
+					? selectedRoleIds.filter((id) => id !== roleId)
+					: [...selectedRoleIds, roleId],
 			);
 		}
 		setLastClickedId(roleId);

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -72,13 +72,8 @@ export function RoleSelectDialog({
 					.filter((r) => !excludeRoleIds.includes(r.roleId))
 					.map((r) => r.roleId);
 
-				const next = [...selectedRoleIds];
-				for (const id of rangeIds) {
-					if (!next.includes(id)) {
-						next.push(id);
-					}
-				}
-				setSelectedRoleIds(next);
+				const nextSet = new Set([...selectedRoleIds, ...rangeIds]);
+				setSelectedRoleIds(Array.from(nextSet));
 			}
 		} else if (event.ctrlKey || event.metaKey) {
 			// Toggle single selection

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -1,12 +1,13 @@
 import { X } from "lucide-react";
+import { useState } from "react";
 import { RoleGrid } from "../../components/blocks/RoleGrid";
 import { RoleSearchInput } from "../../components/parts/RoleSearchInput";
 import { roleFilterMetaData } from "../../logics/api";
-import { CLOSE } from "../../noTrans";
+import { CLOSE, CONFIRM } from "../../noTrans";
 import { useStore } from "../../useStore";
 
 interface RoleSelectDialogProps {
-	onSelect: (roleId: number) => void;
+	onSelect: (roleIds: number[]) => void;
 	onCancel: () => void;
 	excludeRoleIds?: number[];
 }
@@ -19,6 +20,9 @@ export function RoleSelectDialog({
 	onCancel,
 	excludeRoleIds = [],
 }: RoleSelectDialogProps) {
+	const [selectedRoleIds, setSelectedRoleIds] = useState<number[]>([]);
+	const [lastClickedId, setLastClickedId] = useState<number | null>(null);
+
 	const searchQuery = useStore((state) => {
 		if (state.blockDialog?.type === "roleSelect") {
 			return state.blockDialog.searchQuery;
@@ -27,16 +31,62 @@ export function RoleSelectDialog({
 	});
 	const setSearchQuery = useStore((state) => state.setRoleSearchQuery);
 
-	const filteredRoles = roleFilterMetaData.FilterRoleId.map((roleId) => {
+	const allRoles = roleFilterMetaData.FilterRoleId.map((roleId) => {
 		const roleName =
 			(roleFilterMetaData.NormalRoleId[roleId] as string) ||
 			(roleFilterMetaData.CombinationId[roleId] as string) ||
 			(roleFilterMetaData.GhostRoleId[roleId] as string) ||
 			`Role ${roleId}`;
 		return { roleId, roleName };
-	}).filter(({ roleName }) =>
+	});
+
+	const filteredRoles = allRoles.filter(({ roleName }) =>
 		roleName.toLowerCase().includes(searchQuery.toLowerCase()),
 	);
+
+	const handleSelect = (roleId: number, event: React.MouseEvent) => {
+		if (event.shiftKey && lastClickedId !== null) {
+			// Range selection
+			const lastIndex = filteredRoles.findIndex(
+				(r) => r.roleId === lastClickedId,
+			);
+			const currentIndex = filteredRoles.findIndex((r) => r.roleId === roleId);
+
+			if (lastIndex !== -1 && currentIndex !== -1) {
+				const start = Math.min(lastIndex, currentIndex);
+				const end = Math.max(lastIndex, currentIndex);
+				const rangeIds = filteredRoles
+					.slice(start, end + 1)
+					.filter((r) => !excludeRoleIds.includes(r.roleId))
+					.map((r) => r.roleId);
+
+				setSelectedRoleIds((prev) => {
+					const next = [...prev];
+					for (const id of rangeIds) {
+						if (!next.includes(id)) {
+							next.push(id);
+						}
+					}
+					return next;
+				});
+			}
+		} else if (event.ctrlKey || event.metaKey) {
+			// Toggle single selection
+			setSelectedRoleIds((prev) =>
+				prev.includes(roleId)
+					? prev.filter((id) => id !== roleId)
+					: [...prev, roleId],
+			);
+		} else {
+			// Single selection (toggle for consistency with checkbox UI)
+			setSelectedRoleIds((prev) =>
+				prev.includes(roleId)
+					? prev.filter((id) => id !== roleId)
+					: [...prev, roleId],
+			);
+		}
+		setLastClickedId(roleId);
+	};
 
 	return (
 		<div className="bg-white rounded-lg shadow-2xl w-full max-w-2xl overflow-hidden animate-in fade-in zoom-in duration-200 flex flex-col max-h-[80vh]">
@@ -60,17 +110,26 @@ export function RoleSelectDialog({
 			<div className="px-6 py-4 overflow-y-auto">
 				<RoleGrid
 					items={filteredRoles}
-					onSelect={onSelect}
+					onSelect={handleSelect}
+					selectedRoleIds={selectedRoleIds}
 					excludeRoleIds={excludeRoleIds}
 				/>
 			</div>
-			<div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end">
+			<div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end gap-3">
 				<button
 					type="button"
 					onClick={onCancel}
 					className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
 				>
 					{CLOSE}
+				</button>
+				<button
+					type="button"
+					disabled={selectedRoleIds.length === 0}
+					onClick={() => onSelect(selectedRoleIds)}
+					className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+				>
+					{CONFIRM} ({selectedRoleIds.length})
 				</button>
 			</div>
 		</div>

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -19,6 +19,7 @@ export const ROLE_SPAWN_RATE = "レート";
 export const ROLE_SPAWN_COUNT = "数";
 export const CLOSE = "閉じる";
 export const OPEN = "開く";
+export const CONFIRM = "確定";
 export const PRESET_SWITCH_TITLE = "プリセットの切り替え";
 export const PRESET_SWITCH_MESSAGE =
 	"プリセットを「{0}」から「{1}」に切り替えます";

--- a/src/slices/globalUiSlice.ts
+++ b/src/slices/globalUiSlice.ts
@@ -16,6 +16,8 @@ export interface GlobalUiSlice {
 	openBlockDialog: (dialog: BlockDialog) => void;
 	closeBlockDialog: () => void;
 	setRoleSearchQuery: (query: string) => void;
+	setSelectedRoleIds: (roleIds: number[]) => void;
+	setLastClickedId: (roleId: number | null) => void;
 }
 
 export const createGlobalUiSlice: StateCreator<GlobalUiSlice> = (set, get) => {
@@ -53,6 +55,34 @@ export const createGlobalUiSlice: StateCreator<GlobalUiSlice> = (set, get) => {
 						blockDialog: {
 							...blockDialog,
 							searchQuery: query,
+						},
+					};
+				}
+				return state;
+			});
+		},
+		setSelectedRoleIds: (roleIds: number[]) => {
+			set((state) => {
+				const blockDialog = state.blockDialog;
+				if (blockDialog?.type === "roleSelect") {
+					return {
+						blockDialog: {
+							...blockDialog,
+							selectedRoleIds: roleIds,
+						},
+					};
+				}
+				return state;
+			});
+		},
+		setLastClickedId: (roleId: number | null) => {
+			set((state) => {
+				const blockDialog = state.blockDialog;
+				if (blockDialog?.type === "roleSelect") {
+					return {
+						blockDialog: {
+							...blockDialog,
+							lastClickedId: roleId,
 						},
 					};
 				}

--- a/src/type.ts
+++ b/src/type.ts
@@ -362,6 +362,8 @@ export interface RoleSelectDialogData {
 	excludeRoleIds: number[];
 	onSelect: (roleIds: number[]) => void;
 	searchQuery: string;
+	selectedRoleIds: number[];
+	lastClickedId: number | null;
 }
 
 export type BlockDialog = ConfirmDialogData | RoleSelectDialogData;

--- a/src/type.ts
+++ b/src/type.ts
@@ -360,7 +360,7 @@ export interface RoleSelectDialogData {
 	type: "roleSelect";
 	title: string;
 	excludeRoleIds: number[];
-	onSelect: (roleId: number) => void;
+	onSelect: (roleIds: number[]) => void;
 	searchQuery: string;
 }
 

--- a/tests/RoleFilter.test.tsx
+++ b/tests/RoleFilter.test.tsx
@@ -51,7 +51,7 @@ describe("RoleFilterViewer and RoleFilterCard", () => {
 		// Simulate role selection
 		if (state.blockDialog?.type === "roleSelect") {
 			await act(async () => {
-				await state.blockDialog?.onSelect(1);
+				await state.blockDialog?.onSelect([1]);
 			});
 		}
 
@@ -122,7 +122,7 @@ describe("RoleFilterViewer and RoleFilterCard", () => {
 		// Simulate role selection
 		if (state.blockDialog?.type === "roleSelect") {
 			await act(async () => {
-				await state.blockDialog?.onSelect(1);
+				await state.blockDialog?.onSelect([1]);
 			});
 		}
 


### PR DESCRIPTION
RoleFilterのダイアログで複数の役職を一度に選択できるようにしました。
チェックボックスによる選択状態の可視化に加え、Ctrlキーによる個別選択の切り替え、Shiftキーによる範囲選択に対応しています。
一括追加用のAPIがないため、選択された役職は順次APIを呼び出すことで追加されます。

---
*PR created automatically by Jules for task [6080244226292695957](https://jules.google.com/task/6080244226292695957) started by @yukieiji*