### PR TITLE
E2Eテストの修正とアクセシビリティの向上

### DIFF
--- a/e2e/role_filter.spec.ts
+++ b/e2e/role_filter.spec.ts
@@ -32,7 +32,9 @@ test.describe("Role Filter Tab", () => {
 		).toBeVisible();
 
 		// フィルターカードが表示されていることを確認
-		const cardElement = page.getByRole("listitem");
+		const cardElement = page
+			.getByRole("list", { name: "Filter List" })
+			.getByRole("listitem");
 		await expect(cardElement.first()).toBeVisible();
 
 		// AssignNumが表示されていることを確認

--- a/e2e/role_filter.spec.ts
+++ b/e2e/role_filter.spec.ts
@@ -32,14 +32,14 @@ test.describe("Role Filter Tab", () => {
 		).toBeVisible();
 
 		// フィルターカードが表示されていることを確認
-		const cardElement = page.locator("[data-guid]");
+		const cardElement = page.getByRole("listitem");
 		await expect(cardElement.first()).toBeVisible();
 
 		// AssignNumが表示されていることを確認
 		await expect(page.getByText("AssignNum:").first()).toBeVisible();
 
 		// 役職ピンが表示されていることを確認
-		const pinElement = page.locator("[data-role-id]");
-		await expect(pinElement.first()).toBeVisible();
+		// RolePinはテキストを表示するdivとして実装されている
+		await expect(page.getByText("Bakary").first()).toBeVisible();
 	});
 });

--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -25,7 +25,7 @@ test.describe("Role Filter Management", () => {
 
 	test("should add and delete a role filter", async ({ page }) => {
 		// Initial count of filters
-		const initialFilters = await page.locator("[data-guid]").count();
+		const initialFilters = await page.getByRole("listitem").count();
 
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
@@ -34,13 +34,13 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// Verify new filter is added
-		await expect(page.locator("[data-guid]")).toHaveCount(initialFilters + 1, {
+		await expect(page.getByRole("listitem")).toHaveCount(initialFilters + 1, {
 			timeout: 15000,
 		});
 		await expect(page.getByText("AssignNum: 1").last()).toBeVisible();
 
 		// Delete the filter
-		const lastFilter = page.locator("[data-guid]").last();
+		const lastFilter = page.getByRole("listitem").last();
 		await lastFilter.getByLabel("Delete filter").click();
 
 		// Confirmation dialog
@@ -48,13 +48,13 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: "OK" }).click();
 
 		// Verify filter is removed
-		await expect(page.locator("[data-guid]")).toHaveCount(initialFilters, {
+		await expect(page.getByRole("listitem")).toHaveCount(initialFilters, {
 			timeout: 15000,
 		});
 	});
 
 	test("should add a role to filter using search", async ({ page }) => {
-		const initialFilters = await page.locator("[data-guid]").count();
+		const initialFilters = await page.getByRole("listitem").count();
 
 		// Add a new filter first (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
@@ -67,11 +67,11 @@ test.describe("Role Filter Management", () => {
 		});
 
 		// Verify new filter is added
-		await expect(page.locator("[data-guid]")).toHaveCount(initialFilters + 1, {
+		await expect(page.getByRole("listitem")).toHaveCount(initialFilters + 1, {
 			timeout: 15000,
 		});
 
-		const lastFilter = page.locator("[data-guid]").last();
+		const lastFilter = page.getByRole("listitem").last();
 
 		// Open role select dialog to add another role
 		await lastFilter.getByRole("button", { name: "役職を追加" }).click();
@@ -99,7 +99,7 @@ test.describe("Role Filter Management", () => {
 
 		// Verify role is added to the filter
 		// 要素の出現を待つ
-		await expect(lastFilter.locator('[data-role-name="Opener"]')).toBeVisible({
+		await expect(lastFilter.getByText("Opener", { exact: true })).toBeVisible({
 			timeout: 20000,
 		});
 	});
@@ -110,14 +110,16 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: "Bakary" }).first().click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
-		const lastFilter = page.locator("[data-guid]").last();
+		const lastFilter = page.getByRole("listitem").last();
 
-		await expect(lastFilter.locator('[data-role-name="Bakary"]')).toBeVisible({
+		await expect(lastFilter.getByText("Bakary", { exact: true })).toBeVisible({
 			timeout: 15000,
 		});
 
 		// Remove the role
-		const rolePin = lastFilter.locator('[data-role-name="Bakary"]');
+		const rolePin = lastFilter
+			.getByText("Bakary", { exact: true })
+			.locator("xpath=..");
 		await rolePin.getByLabel("Remove Bakary").click();
 
 		// Confirmation dialog

--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -24,8 +24,9 @@ test.describe("Role Filter Management", () => {
 	});
 
 	test("should add and delete a role filter", async ({ page }) => {
+		const filterList = page.getByRole("list", { name: "Filter List" });
 		// Initial count of filters
-		const initialFilters = await page.getByRole("listitem").count();
+		const initialFilters = await filterList.getByRole("listitem").count();
 
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
@@ -34,13 +35,16 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// Verify new filter is added
-		await expect(page.getByRole("listitem")).toHaveCount(initialFilters + 1, {
-			timeout: 15000,
-		});
+		await expect(filterList.getByRole("listitem")).toHaveCount(
+			initialFilters + 1,
+			{
+				timeout: 15000,
+			},
+		);
 		await expect(page.getByText("AssignNum: 1").last()).toBeVisible();
 
 		// Delete the filter
-		const lastFilter = page.getByRole("listitem").last();
+		const lastFilter = filterList.getByRole("listitem").last();
 		await lastFilter.getByLabel("Delete filter").click();
 
 		// Confirmation dialog
@@ -48,13 +52,14 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: "OK" }).click();
 
 		// Verify filter is removed
-		await expect(page.getByRole("listitem")).toHaveCount(initialFilters, {
+		await expect(filterList.getByRole("listitem")).toHaveCount(initialFilters, {
 			timeout: 15000,
 		});
 	});
 
 	test("should add a role to filter using search", async ({ page }) => {
-		const initialFilters = await page.getByRole("listitem").count();
+		const filterList = page.getByRole("list", { name: "Filter List" });
+		const initialFilters = await filterList.getByRole("listitem").count();
 
 		// Add a new filter first (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
@@ -67,11 +72,14 @@ test.describe("Role Filter Management", () => {
 		});
 
 		// Verify new filter is added
-		await expect(page.getByRole("listitem")).toHaveCount(initialFilters + 1, {
-			timeout: 15000,
-		});
+		await expect(filterList.getByRole("listitem")).toHaveCount(
+			initialFilters + 1,
+			{
+				timeout: 15000,
+			},
+		);
 
-		const lastFilter = page.getByRole("listitem").last();
+		const lastFilter = filterList.getByRole("listitem").last();
 
 		// Open role select dialog to add another role
 		await lastFilter.getByRole("button", { name: "役職を追加" }).click();
@@ -105,12 +113,13 @@ test.describe("Role Filter Management", () => {
 	});
 
 	test("should remove a role from filter", async ({ page }) => {
+		const filterList = page.getByRole("list", { name: "Filter List" });
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
 		await page.getByRole("button", { name: "Bakary" }).first().click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
-		const lastFilter = page.getByRole("listitem").last();
+		const lastFilter = filterList.getByRole("listitem").last();
 
 		await expect(lastFilter.getByText("Bakary", { exact: true })).toBeVisible({
 			timeout: 15000,

--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -126,10 +126,7 @@ test.describe("Role Filter Management", () => {
 		});
 
 		// Remove the role
-		const rolePin = lastFilter
-			.getByText("Bakary", { exact: true })
-			.locator("xpath=..");
-		await rolePin.getByLabel("Remove Bakary").click();
+		await lastFilter.getByLabel("Remove Bakary").click();
 
 		// Confirmation dialog
 		await expect(page.getByText("役職の削除")).toBeVisible();

--- a/src/components/blocks/RoleFilterCardLayout.tsx
+++ b/src/components/blocks/RoleFilterCardLayout.tsx
@@ -16,7 +16,7 @@ export function RoleFilterCardLayout({
 	children,
 }: RoleFilterCardLayoutProps) {
 	return (
-		<div className="bg-white shadow rounded-lg p-4 border border-gray-200 flex flex-col gap-3 relative">
+		<li className="bg-white shadow rounded-lg p-4 border border-gray-200 flex flex-col gap-3 relative list-none">
 			<button
 				type="button"
 				onClick={onDelete}
@@ -31,6 +31,6 @@ export function RoleFilterCardLayout({
 			</div>
 
 			<div className="flex flex-wrap gap-2">{children}</div>
-		</div>
+		</li>
 	);
 }

--- a/src/components/parts/RolePin.tsx
+++ b/src/components/parts/RolePin.tsx
@@ -10,10 +10,7 @@ interface RolePinProps {
  */
 export function RolePin({ name, onDelete }: RolePinProps) {
 	return (
-		<div
-			data-role-name={name}
-			className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200"
-		>
+		<div className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
 			<span>{name}</span>
 			{onDelete && (
 				<button

--- a/src/feature/rolefilter/RoleFilterViewer.tsx
+++ b/src/feature/rolefilter/RoleFilterViewer.tsx
@@ -27,7 +27,10 @@ export function RoleFilterViewer() {
 					</p>
 				</div>
 			) : (
-				<ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				<ul
+					aria-label="Filter List"
+					className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+				>
 					{filterEntries.map(([guid, filterSet]) => {
 						return (
 							<RoleFilterCard key={guid} guid={guid} filterSet={filterSet} />

--- a/src/feature/rolefilter/RoleFilterViewer.tsx
+++ b/src/feature/rolefilter/RoleFilterViewer.tsx
@@ -27,13 +27,13 @@ export function RoleFilterViewer() {
 					</p>
 				</div>
 			) : (
-				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				<ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 					{filterEntries.map(([guid, filterSet]) => {
 						return (
 							<RoleFilterCard key={guid} guid={guid} filterSet={filterSet} />
 						);
 					})}
-				</div>
+				</ul>
 			)}
 		</div>
 	);


### PR DESCRIPTION
推奨されていないカスタムデータ属性の削除によって失敗していたE2Eテストを修正しました。

主な変更点:
1. `RoleFilterViewer.tsx` のコンテナを `div` から `ul` に変更。
2. `RoleFilterCardLayout.tsx` のカードを `div` から `li` に変更し、アクセシビリティを向上。
3. `RolePin.tsx` から不要な `data-role-name` 属性を削除。
4. `e2e/role_filter_management.spec.ts` および `e2e/role_filter.spec.ts` のセレクターを、削除された `data-guid` 等の代わりに `getByRole("listitem")` や `getByText()` を使用するように更新。

全てのE2Eテストおよびユニットテストがパスすることを確認済みです。

---
*PR created automatically by Jules for task [8480988339960650950](https://jules.google.com/task/8480988339960650950) started by @yukieiji*