### PR TITLE
ネストされたオプションのナビゲーション修正

### DIFF
--- a/src/hooks/useOptionNavigation.ts
+++ b/src/hooks/useOptionNavigation.ts
@@ -101,15 +101,7 @@ export function useExRNavigation(uniqueOptionId: UniqueOptionId) {
 		}
 
 		// 全ての親オプションを特定して開く
-		const ancestors: UniqueOptionId[] = [];
-		let currentId: UniqueOptionId | undefined = uniqueOptionId;
-		while (currentId) {
-			const parentId = exrOptionMetaData.options[currentId]?.parentOptionId;
-			if (parentId) {
-				ancestors.push(parentId);
-			}
-			currentId = parentId;
-		}
+		const ancestors = exrOptionMetaData.options[uniqueOptionId]?.parentOptionIds ?? [];
 		if (ancestors.length > 0) {
 			openExROptions(ancestors);
 		}

--- a/src/hooks/useOptionNavigation.ts
+++ b/src/hooks/useOptionNavigation.ts
@@ -101,7 +101,8 @@ export function useExRNavigation(uniqueOptionId: UniqueOptionId) {
 		}
 
 		// 全ての親オプションを特定して開く
-		const ancestors = exrOptionMetaData.options[uniqueOptionId]?.parentOptionIds ?? [];
+		const ancestors =
+			exrOptionMetaData.options[uniqueOptionId]?.parentOptionIds ?? [];
 		if (ancestors.length > 0) {
 			openExROptions(ancestors);
 		}

--- a/src/hooks/useOptionNavigation.ts
+++ b/src/hooks/useOptionNavigation.ts
@@ -1,3 +1,4 @@
+import { exrOptionMetaData } from "../logics/api";
 import { parseUniqueOptionId } from "../logics/optionUtils";
 import type { AuOptionId, ExRTabId, UniqueOptionId } from "../type";
 import { useStore } from "../useStore";
@@ -75,6 +76,9 @@ export function useExRNavigation(uniqueOptionId: UniqueOptionId) {
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
 	});
+	const openExROptions = useStore((state) => {
+		return state.openExROptions;
+	});
 
 	const setHighlightedExROptionId = useStore((state) => {
 		return state.setHighlightedExROptionId;
@@ -95,6 +99,21 @@ export function useExRNavigation(uniqueOptionId: UniqueOptionId) {
 		if (!openedExRCategoryIds[categoryId]) {
 			toggleExRCategory(categoryId);
 		}
+
+		// 全ての親オプションを特定して開く
+		const ancestors: UniqueOptionId[] = [];
+		let currentId: UniqueOptionId | undefined = uniqueOptionId;
+		while (currentId) {
+			const parentId = exrOptionMetaData.options[currentId]?.parentOptionId;
+			if (parentId) {
+				ancestors.push(parentId);
+			}
+			currentId = parentId;
+		}
+		if (ancestors.length > 0) {
+			openExROptions(ancestors);
+		}
+
 		setHighlightedExROptionId(uniqueOptionId);
 
 		setTimeout(() => {

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -207,7 +207,10 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 			}
 
 			if (opt.Childs && opt.Childs.length > 0) {
-				processOptions(opt.Childs, tabId, categoryId, [uniqueId, ...ancestorIds]);
+				processOptions(opt.Childs, tabId, categoryId, [
+					uniqueId,
+					...ancestorIds,
+				]);
 			}
 		}
 	};

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -159,7 +159,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 		options: ExROptionDto[],
 		tabId: ExRTabId,
 		categoryId: number,
-		parentUniqueOptionId: UniqueOptionId | null,
+		ancestorIds: UniqueOptionId[],
 	) => {
 		for (const opt of options) {
 			const uniqueId = getUniqueOptionId(tabId, categoryId, opt.Id);
@@ -174,7 +174,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 				},
 				childOptionIds:
 					exrOptionMetaData.options[uniqueId]?.childOptionIds ?? [],
-				parentOptionId: parentUniqueOptionId ?? undefined,
+				parentOptionIds: ancestorIds,
 			};
 
 			valueData[uniqueId] = {
@@ -182,7 +182,8 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 				values: opt.RangeMeta.Values,
 			};
 			isOptionActive[uniqueId] = opt.IsActive;
-			if (parentUniqueOptionId !== null) {
+			if (ancestorIds.length > 0) {
+				const parentUniqueOptionId = ancestorIds[0];
 				if (!exrOptionMetaData.options[parentUniqueOptionId]) {
 					exrOptionMetaData.options[parentUniqueOptionId] = {
 						metaData: {
@@ -191,7 +192,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 							type: "",
 						},
 						childOptionIds: [],
-						parentOptionId: undefined,
+						parentOptionIds: [],
 					};
 				}
 				if (
@@ -206,7 +207,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 			}
 
 			if (opt.Childs && opt.Childs.length > 0) {
-				processOptions(opt.Childs, tabId, categoryId, uniqueId);
+				processOptions(opt.Childs, tabId, categoryId, [uniqueId, ...ancestorIds]);
 			}
 		}
 	};
@@ -228,7 +229,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 						getUniqueOptionId(tab.Id, category.Id, o.Id),
 					); // カテゴリIDとそのカテゴリに属するオプションIDの対応を保存
 			}
-			processOptions(category.Options, tab.Id, category.Id, null);
+			processOptions(category.Options, tab.Id, category.Id, []);
 		}
 	}
 	return { valueData, isOptionActive };

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -174,6 +174,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 				},
 				childOptionIds:
 					exrOptionMetaData.options[uniqueId]?.childOptionIds ?? [],
+				parentOptionId: parentUniqueOptionId ?? undefined,
 			};
 
 			valueData[uniqueId] = {
@@ -190,6 +191,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 							type: "",
 						},
 						childOptionIds: [],
+						parentOptionId: undefined,
 					};
 				}
 				if (

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -29,6 +29,7 @@ export interface ExROptionViewerSlice {
 	setIsExRTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
 	toggleExROption: (uniqueOptionId: UniqueOptionId) => void;
+	openExROptions: (uniqueOptionIds: UniqueOptionId[]) => void;
 	updateExROption: (updateOptions: (UpdatedOptions | null)[]) => void;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setPresetDropdownOpen: (isOpen: boolean) => void;
@@ -80,6 +81,15 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 						[categoryId]: !state.openedExRCategoryIds[categoryId],
 					},
 				};
+			});
+		},
+		openExROptions: (uniqueOptionIds: UniqueOptionId[]) => {
+			set((state) => {
+				const nextOpenedExROptionIds = { ...state.openedExROptionIds };
+				for (const id of uniqueOptionIds) {
+					nextOpenedExROptionIds[id] = true;
+				}
+				return { openedExROptionIds: nextOpenedExROptionIds };
 			});
 		},
 		toggleExROption: (uniqueOptionId: number) => {

--- a/src/type.ts
+++ b/src/type.ts
@@ -40,7 +40,7 @@ export interface ExRCategoryMetaData {
 export interface ExROptionMetaDataDetail {
 	metaData: ExROptionMetaData;
 	childOptionIds: UniqueOptionId[];
-	parentOptionId?: UniqueOptionId;
+	parentOptionIds: UniqueOptionId[];
 }
 
 export interface ExROptionMetaDataRecords {

--- a/src/type.ts
+++ b/src/type.ts
@@ -40,6 +40,7 @@ export interface ExRCategoryMetaData {
 export interface ExROptionMetaDataDetail {
 	metaData: ExROptionMetaData;
 	childOptionIds: UniqueOptionId[];
+	parentOptionId?: UniqueOptionId;
 }
 
 export interface ExROptionMetaDataRecords {

--- a/tests/useExRNavigation.test.tsx
+++ b/tests/useExRNavigation.test.tsx
@@ -1,9 +1,9 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useExRNavigation } from "../src/hooks/useOptionNavigation";
-import { useStore } from "../src/useStore";
 import * as api from "../src/logics/api";
-import type { UniqueOptionId } from "../src/type";
+import type { ExROptionMetaData, UniqueOptionId } from "../src/type";
+import { useStore } from "../src/useStore";
 
 vi.mock("../src/useStore", () => ({
 	useStore: vi.fn(),
@@ -16,7 +16,9 @@ vi.mock("../src/logics/api", () => ({
 }));
 
 vi.mock("../src/logics/optionUtils", () => ({
-	parseUniqueOptionId: vi.fn().mockReturnValue({ tabId: 1, categoryId: 10, optionId: 100 }),
+	parseUniqueOptionId: vi
+		.fn()
+		.mockReturnValue({ tabId: 1, categoryId: 10, optionId: 100 }),
 }));
 
 describe("useExRNavigation", () => {
@@ -29,7 +31,7 @@ describe("useExRNavigation", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.mocked(useStore).mockImplementation((selector: any) => {
+		vi.mocked(useStore).mockImplementation((selector: unknown) => {
 			const state = {
 				setSelectedTab,
 				setSelectedExRTabId,
@@ -38,8 +40,9 @@ describe("useExRNavigation", () => {
 				setHighlightedExROptionId,
 				setRightPanelOpen,
 			};
-			return selector(state);
+			return (selector as (s: typeof state) => unknown)(state);
 		});
+		// biome-ignore lint/suspicious/noExplicitAny: mock useStore.getState
 		(useStore as any).getState = vi.fn().mockReturnValue({
 			openedExRCategoryIds: {},
 		});
@@ -50,18 +53,20 @@ describe("useExRNavigation", () => {
 		const parentId = 200 as UniqueOptionId;
 		const grandParentId = 300 as UniqueOptionId;
 
+		const emptyMeta = {} as ExROptionMetaData;
+
 		api.exrOptionMetaData.options[childId] = {
-			metaData: {} as any,
+			metaData: emptyMeta,
 			childOptionIds: [],
 			parentOptionId: parentId,
 		};
 		api.exrOptionMetaData.options[parentId] = {
-			metaData: {} as any,
+			metaData: emptyMeta,
 			childOptionIds: [childId],
 			parentOptionId: grandParentId,
 		};
 		api.exrOptionMetaData.options[grandParentId] = {
-			metaData: {} as any,
+			metaData: emptyMeta,
 			childOptionIds: [parentId],
 			parentOptionId: undefined,
 		};

--- a/tests/useExRNavigation.test.tsx
+++ b/tests/useExRNavigation.test.tsx
@@ -58,17 +58,17 @@ describe("useExRNavigation", () => {
 		api.exrOptionMetaData.options[childId] = {
 			metaData: emptyMeta,
 			childOptionIds: [],
-			parentOptionId: parentId,
+			parentOptionIds: [parentId, grandParentId],
 		};
 		api.exrOptionMetaData.options[parentId] = {
 			metaData: emptyMeta,
 			childOptionIds: [childId],
-			parentOptionId: grandParentId,
+			parentOptionIds: [grandParentId],
 		};
 		api.exrOptionMetaData.options[grandParentId] = {
 			metaData: emptyMeta,
 			childOptionIds: [parentId],
-			parentOptionId: undefined,
+			parentOptionIds: [],
 		};
 
 		const { result } = renderHook(() => useExRNavigation(childId));

--- a/tests/useExRNavigation.test.tsx
+++ b/tests/useExRNavigation.test.tsx
@@ -1,0 +1,74 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useExRNavigation } from "../src/hooks/useOptionNavigation";
+import { useStore } from "../src/useStore";
+import * as api from "../src/logics/api";
+import type { UniqueOptionId } from "../src/type";
+
+vi.mock("../src/useStore", () => ({
+	useStore: vi.fn(),
+}));
+
+vi.mock("../src/logics/api", () => ({
+	exrOptionMetaData: {
+		options: {},
+	},
+}));
+
+vi.mock("../src/logics/optionUtils", () => ({
+	parseUniqueOptionId: vi.fn().mockReturnValue({ tabId: 1, categoryId: 10, optionId: 100 }),
+}));
+
+describe("useExRNavigation", () => {
+	const setSelectedTab = vi.fn();
+	const setSelectedExRTabId = vi.fn();
+	const toggleExRCategory = vi.fn();
+	const openExROptions = vi.fn();
+	const setHighlightedExROptionId = vi.fn();
+	const setRightPanelOpen = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(useStore).mockImplementation((selector: any) => {
+			const state = {
+				setSelectedTab,
+				setSelectedExRTabId,
+				toggleExRCategory,
+				openExROptions,
+				setHighlightedExROptionId,
+				setRightPanelOpen,
+			};
+			return selector(state);
+		});
+		(useStore as any).getState = vi.fn().mockReturnValue({
+			openedExRCategoryIds: {},
+		});
+	});
+
+	it("should open all ancestor options when navigating to a child option", () => {
+		const childId = 100 as UniqueOptionId;
+		const parentId = 200 as UniqueOptionId;
+		const grandParentId = 300 as UniqueOptionId;
+
+		api.exrOptionMetaData.options[childId] = {
+			metaData: {} as any,
+			childOptionIds: [],
+			parentOptionId: parentId,
+		};
+		api.exrOptionMetaData.options[parentId] = {
+			metaData: {} as any,
+			childOptionIds: [childId],
+			parentOptionId: grandParentId,
+		};
+		api.exrOptionMetaData.options[grandParentId] = {
+			metaData: {} as any,
+			childOptionIds: [parentId],
+			parentOptionId: undefined,
+		};
+
+		const { result } = renderHook(() => useExRNavigation(childId));
+		result.current();
+
+		expect(openExROptions).toHaveBeenCalledWith([parentId, grandParentId]);
+	});
+});


### PR DESCRIPTION
右サイドパネルでChildOptionViewAccordionの子要素オプション（2世代以上の親を持つオプション）をダブルクリックした際に、メインパネル側で親アコーディオンが閉じていると該当箇所までスクロールできない問題を修正しました。

主な変更点：
- オプションのメタデータに `parentOptionId` を追加し、初期化時に親子の関連付けを保持するようにしました。
- `useExRNavigation` フックを更新し、ナビゲーション時にターゲットオプションの全先祖アコーディオンを特定して自動的に展開するロジックを実装しました。
- 複数のアコーディオンを一度に開くための `openExROptions` アクションをストアに追加しました。

これにより、深い階層にあるオプションでもダブルクリックで確実にメインパネルの該当箇所まで移動できるようになります。

---
*PR created automatically by Jules for task [15556617764338913051](https://jules.google.com/task/15556617764338913051) started by @yukieiji*