### PR TITLE
Add AssignNum adjustment logic to RoleFilterCardHeader

### DIFF
--- a/src/feature/rolefilter/RoleFilterCardHeader.tsx
+++ b/src/feature/rolefilter/RoleFilterCardHeader.tsx
@@ -20,7 +20,9 @@ export function RoleFilterCardHeader({
 	const decrementAssignNum = useStore((state) => state.decrementAssignNum);
 
 	const onIncrement = async () => {
-		if (assignNum >= 255) return;
+		if (assignNum >= 255) {
+			return;
+		}
 		try {
 			await postRoleFilterUpdate({
 				Op: PostExRAssignOps.FilterAssignNumIncrese,
@@ -34,7 +36,9 @@ export function RoleFilterCardHeader({
 	};
 
 	const onDecrement = async () => {
-		if (assignNum <= 1) return;
+		if (assignNum <= 1) {
+			return;
+		}
 		try {
 			await postRoleFilterUpdate({
 				Op: PostExRAssignOps.FilterAssignNumDecrese,

--- a/src/feature/rolefilter/RoleFilterCardHeader.tsx
+++ b/src/feature/rolefilter/RoleFilterCardHeader.tsx
@@ -1,4 +1,4 @@
-import { Plus } from "lucide-react";
+import { ChevronDown, ChevronUp, Plus } from "lucide-react";
 import { postRoleFilterUpdate, roleFilterMetaData } from "../../logics/api";
 import { PostExRAssignOps } from "../../type";
 import { useStore } from "../../useStore";
@@ -16,6 +16,36 @@ export function RoleFilterCardHeader({
 }: RoleFilterCardHeaderProps) {
 	const openBlockDialog = useStore((state) => state.openBlockDialog);
 	const addRoleToFilter = useStore((state) => state.addRoleToFilter);
+	const incrementAssignNum = useStore((state) => state.incrementAssignNum);
+	const decrementAssignNum = useStore((state) => state.decrementAssignNum);
+
+	const onIncrement = async () => {
+		if (assignNum >= 255) return;
+		try {
+			await postRoleFilterUpdate({
+				Op: PostExRAssignOps.FilterAssignNumIncrese,
+				FilterId: guid,
+				MapRoleId: null,
+			});
+			incrementAssignNum(guid);
+		} catch (error) {
+			console.error("Failed to increment AssignNum:", error);
+		}
+	};
+
+	const onDecrement = async () => {
+		if (assignNum <= 1) return;
+		try {
+			await postRoleFilterUpdate({
+				Op: PostExRAssignOps.FilterAssignNumDecrese,
+				FilterId: guid,
+				MapRoleId: null,
+			});
+			decrementAssignNum(guid);
+		} catch (error) {
+			console.error("Failed to decrement AssignNum:", error);
+		}
+	};
 
 	const onOpenRoleSelect = () => {
 		openBlockDialog({
@@ -51,9 +81,31 @@ export function RoleFilterCardHeader({
 
 	return (
 		<>
-			<span className="text-sm font-semibold text-gray-700">
-				AssignNum: {assignNum}
-			</span>
+			<div className="flex items-center gap-2">
+				<span className="text-sm font-semibold text-gray-700">
+					AssignNum: {assignNum}
+				</span>
+				<div className="flex flex-col">
+					<button
+						type="button"
+						onClick={onIncrement}
+						disabled={assignNum >= 255}
+						className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:hover:bg-transparent"
+						aria-label="Increment AssignNum"
+					>
+						<ChevronUp size={14} />
+					</button>
+					<button
+						type="button"
+						onClick={onDecrement}
+						disabled={assignNum <= 1}
+						className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:hover:bg-transparent"
+						aria-label="Decrement AssignNum"
+					>
+						<ChevronDown size={14} />
+					</button>
+				</div>
+			</div>
 			<button
 				type="button"
 				onClick={onOpenRoleSelect}

--- a/src/feature/rolefilter/RoleFilterCardHeader.tsx
+++ b/src/feature/rolefilter/RoleFilterCardHeader.tsx
@@ -18,11 +18,14 @@ export function RoleFilterCardHeader({
 	const addRoleToFilter = useStore((state) => state.addRoleToFilter);
 	const incrementAssignNum = useStore((state) => state.incrementAssignNum);
 	const decrementAssignNum = useStore((state) => state.decrementAssignNum);
+	const isUpdating = useStore((state) => state.isUpdatingAssignNum[guid]);
+	const setIsUpdating = useStore((state) => state.setIsUpdatingAssignNum);
 
 	const onIncrement = async () => {
-		if (assignNum >= 255) {
+		if (assignNum >= 255 || isUpdating) {
 			return;
 		}
+		setIsUpdating(guid, true);
 		try {
 			await postRoleFilterUpdate({
 				Op: PostExRAssignOps.FilterAssignNumIncrese,
@@ -32,13 +35,16 @@ export function RoleFilterCardHeader({
 			incrementAssignNum(guid);
 		} catch (error) {
 			console.error("Failed to increment AssignNum:", error);
+		} finally {
+			setIsUpdating(guid, false);
 		}
 	};
 
 	const onDecrement = async () => {
-		if (assignNum <= 1) {
+		if (assignNum <= 1 || isUpdating) {
 			return;
 		}
+		setIsUpdating(guid, true);
 		try {
 			await postRoleFilterUpdate({
 				Op: PostExRAssignOps.FilterAssignNumDecrese,
@@ -48,6 +54,8 @@ export function RoleFilterCardHeader({
 			decrementAssignNum(guid);
 		} catch (error) {
 			console.error("Failed to decrement AssignNum:", error);
+		} finally {
+			setIsUpdating(guid, false);
 		}
 	};
 
@@ -93,7 +101,7 @@ export function RoleFilterCardHeader({
 					<button
 						type="button"
 						onClick={onIncrement}
-						disabled={assignNum >= 255}
+						disabled={assignNum >= 255 || isUpdating}
 						className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:hover:bg-transparent"
 						aria-label="Increment AssignNum"
 					>
@@ -102,7 +110,7 @@ export function RoleFilterCardHeader({
 					<button
 						type="button"
 						onClick={onDecrement}
-						disabled={assignNum <= 1}
+						disabled={assignNum <= 1 || isUpdating}
 						className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:hover:bg-transparent"
 						aria-label="Decrement AssignNum"
 					>

--- a/src/slices/roleFilterSlice.ts
+++ b/src/slices/roleFilterSlice.ts
@@ -13,6 +13,8 @@ export interface RoleFilterSlice {
 	removeRoleFromFilter: (guid: string, roleId: number) => void;
 	incrementAssignNum: (guid: string) => void;
 	decrementAssignNum: (guid: string) => void;
+	isUpdatingAssignNum: Record<string, boolean>;
+	setIsUpdatingAssignNum: (guid: string, isUpdating: boolean) => void;
 }
 
 /**
@@ -21,6 +23,7 @@ export interface RoleFilterSlice {
 export const createRoleFilterSlice: StateCreator<RoleFilterSlice> = (set) => {
 	return {
 		roleFilterSet: {},
+		isUpdatingAssignNum: {},
 		setRoleFilterSet: (data: Record<string, RoleAssignFilterSetUI>) => {
 			set({ roleFilterSet: data });
 		},
@@ -113,6 +116,16 @@ export const createRoleFilterSlice: StateCreator<RoleFilterSlice> = (set) => {
 							...filter,
 							AssignNum: filter.AssignNum - 1,
 						},
+					},
+				};
+			});
+		},
+		setIsUpdatingAssignNum: (guid: string, isUpdating: boolean) => {
+			set((state) => {
+				return {
+					isUpdatingAssignNum: {
+						...state.isUpdatingAssignNum,
+						[guid]: isUpdating,
 					},
 				};
 			});

--- a/src/slices/roleFilterSlice.ts
+++ b/src/slices/roleFilterSlice.ts
@@ -11,6 +11,8 @@ export interface RoleFilterSlice {
 	deleteRoleFilter: (guid: string) => void;
 	addRoleToFilter: (guid: string, roleId: number, roleName: string) => void;
 	removeRoleFromFilter: (guid: string, roleId: number) => void;
+	incrementAssignNum: (guid: string) => void;
+	decrementAssignNum: (guid: string) => void;
 }
 
 /**
@@ -76,6 +78,40 @@ export const createRoleFilterSlice: StateCreator<RoleFilterSlice> = (set) => {
 						[guid]: {
 							...filter,
 							Roles: filter.Roles.filter((r) => r.id !== roleId),
+						},
+					},
+				};
+			});
+		},
+		incrementAssignNum: (guid: string) => {
+			set((state) => {
+				const filter = state.roleFilterSet[guid];
+				if (!filter || filter.AssignNum >= 255) {
+					return state;
+				}
+				return {
+					roleFilterSet: {
+						...state.roleFilterSet,
+						[guid]: {
+							...filter,
+							AssignNum: filter.AssignNum + 1,
+						},
+					},
+				};
+			});
+		},
+		decrementAssignNum: (guid: string) => {
+			set((state) => {
+				const filter = state.roleFilterSet[guid];
+				if (!filter || filter.AssignNum <= 1) {
+					return state;
+				}
+				return {
+					roleFilterSet: {
+						...state.roleFilterSet,
+						[guid]: {
+							...filter,
+							AssignNum: filter.AssignNum - 1,
 						},
 					},
 				};

--- a/tests/RoleFilterAssignNum.test.tsx
+++ b/tests/RoleFilterAssignNum.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RoleFilterViewer } from "../src/feature/rolefilter/RoleFilterViewer";
 import { postRoleFilterUpdate } from "../src/logics/api";
@@ -34,6 +40,7 @@ describe("RoleFilter AssignNum Adjustment", () => {
 				roleFilterSet: {
 					[guid]: { AssignNum: 5, Roles: [] },
 				},
+				isUpdatingAssignNum: {},
 			});
 		});
 
@@ -67,6 +74,46 @@ describe("RoleFilter AssignNum Adjustment", () => {
 			MapRoleId: null,
 		});
 		expect(screen.getByText("AssignNum: 5")).toBeInTheDocument();
+	});
+
+	it("disables buttons while updating", async () => {
+		const guid = "test-guid";
+		// biome-ignore lint/suspicious/noExplicitAny: Mocking API function
+		let resolveUpdate: any;
+		// biome-ignore lint/suspicious/noExplicitAny: Mocking API function
+		(postRoleFilterUpdate as any).mockReturnValue(
+			new Promise((resolve) => {
+				resolveUpdate = resolve;
+			}),
+		);
+
+		act(() => {
+			useStore.setState({
+				roleFilterSet: {
+					[guid]: { AssignNum: 5, Roles: [] },
+				},
+				isUpdatingAssignNum: {},
+			});
+		});
+
+		render(<RoleFilterViewer />);
+
+		const incrementButton = screen.getByLabelText("Increment AssignNum");
+
+		await act(async () => {
+			fireEvent.click(incrementButton);
+		});
+
+		// Button should be disabled while promise is pending
+		expect(incrementButton).toBeDisabled();
+
+		await act(async () => {
+			resolveUpdate();
+		});
+
+		await waitFor(() => {
+			expect(incrementButton).not.toBeDisabled();
+		});
 	});
 
 	it("disables decrement button at minimum value (1)", async () => {

--- a/tests/RoleFilterAssignNum.test.tsx
+++ b/tests/RoleFilterAssignNum.test.tsx
@@ -1,0 +1,123 @@
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RoleFilterViewer } from "../src/feature/rolefilter/RoleFilterViewer";
+import { postRoleFilterUpdate } from "../src/logics/api";
+import { useStore } from "../src/useStore";
+import { PostExRAssignOps } from "../src/type";
+
+// Mock api.ts
+vi.mock("../src/logics/api", () => ({
+	postRoleFilterUpdate: vi.fn().mockResolvedValue(undefined),
+	roleFilterMetaData: {
+		FilterRoleId: [1, 2],
+		NormalRoleId: { 1: "Crewmate", 2: "Impostor" },
+		CombinationId: {},
+		GhostRoleId: {},
+	},
+}));
+
+describe("RoleFilter AssignNum Adjustment", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		act(() => {
+			useStore.setState({
+				roleFilterSet: {},
+				blockDialog: undefined,
+			});
+		});
+	});
+
+	it("increments and decrements AssignNum", async () => {
+		const guid = "test-guid";
+		act(() => {
+			useStore.setState({
+				roleFilterSet: {
+					[guid]: { AssignNum: 5, Roles: [] },
+				},
+			});
+		});
+
+		render(<RoleFilterViewer />);
+
+		expect(screen.getByText("AssignNum: 5")).toBeInTheDocument();
+
+		const incrementButton = screen.getByLabelText("Increment AssignNum");
+		const decrementButton = screen.getByLabelText("Decrement AssignNum");
+
+		// Increment
+		await act(async () => {
+			fireEvent.click(incrementButton);
+		});
+
+		expect(postRoleFilterUpdate).toHaveBeenCalledWith({
+			Op: PostExRAssignOps.FilterAssignNumIncrese,
+			FilterId: guid,
+			MapRoleId: null,
+		});
+		expect(screen.getByText("AssignNum: 6")).toBeInTheDocument();
+
+		// Decrement
+		await act(async () => {
+			fireEvent.click(decrementButton);
+		});
+
+		expect(postRoleFilterUpdate).toHaveBeenCalledWith({
+			Op: PostExRAssignOps.FilterAssignNumDecrese,
+			FilterId: guid,
+			MapRoleId: null,
+		});
+		expect(screen.getByText("AssignNum: 5")).toBeInTheDocument();
+	});
+
+	it("disables decrement button at minimum value (1)", async () => {
+		const guid = "test-guid";
+		act(() => {
+			useStore.setState({
+				roleFilterSet: {
+					[guid]: { AssignNum: 1, Roles: [] },
+				},
+			});
+		});
+
+		render(<RoleFilterViewer />);
+
+		const decrementButton = screen.getByLabelText("Decrement AssignNum");
+		expect(decrementButton).toBeDisabled();
+
+		await act(async () => {
+			fireEvent.click(decrementButton);
+		});
+
+		expect(postRoleFilterUpdate).not.toHaveBeenCalled();
+		expect(screen.getByText("AssignNum: 1")).toBeInTheDocument();
+	});
+
+	it("disables increment button at maximum value (255)", async () => {
+		const guid = "test-guid";
+		act(() => {
+			useStore.setState({
+				roleFilterSet: {
+					[guid]: { AssignNum: 255, Roles: [] },
+				},
+			});
+		});
+
+		render(<RoleFilterViewer />);
+
+		const incrementButton = screen.getByLabelText("Increment AssignNum");
+		expect(incrementButton).toBeDisabled();
+
+		await act(async () => {
+			fireEvent.click(incrementButton);
+		});
+
+		expect(postRoleFilterUpdate).not.toHaveBeenCalled();
+		expect(screen.getByText("AssignNum: 255")).toBeInTheDocument();
+	});
+});

--- a/tests/RoleFilterAssignNum.test.tsx
+++ b/tests/RoleFilterAssignNum.test.tsx
@@ -1,15 +1,9 @@
-import {
-	act,
-	fireEvent,
-	render,
-	screen,
-	waitFor,
-} from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RoleFilterViewer } from "../src/feature/rolefilter/RoleFilterViewer";
 import { postRoleFilterUpdate } from "../src/logics/api";
-import { useStore } from "../src/useStore";
 import { PostExRAssignOps } from "../src/type";
+import { useStore } from "../src/useStore";
 
 // Mock api.ts
 vi.mock("../src/logics/api", () => ({


### PR DESCRIPTION
This change adds the ability to adjust the `AssignNum` value for role filters in the `RoleFilterCardHeader` component. 

Users can now use up/down arrow buttons to increment or decrement the value within the range of 1 to 255. Each adjustment triggers an API call (`postRoleFilterUpdate`) and updates the local state upon success. The buttons are visually disabled when the limits are reached.

Changes:
- `src/slices/roleFilterSlice.ts`: Added state management for incrementing and decrementing `AssignNum`.
- `src/feature/rolefilter/RoleFilterCardHeader.tsx`: Added the UI buttons and logic for the adjustment.
- `tests/RoleFilterAssignNum.test.tsx`: Added tests to verify the new functionality and boundary constraints.

---
*PR created automatically by Jules for task [18402704164220581379](https://jules.google.com/task/18402704164220581379) started by @yukieiji*