### PR TITLE
Refactor standalone buttons to shadcn/ui Button

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -28,5 +28,10 @@
 				}
 			}
 		}
+	},
+	"css": {
+		"parser": {
+			"tailwindDirectives": true
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,14 @@
     "setup:dev": "pnpm lefthook install"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/vite": "^4.2.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.4",
     "zod": "^4.4.3",
     "zustand": "^5.0.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.5)
@@ -20,6 +29,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -28,7 +40,7 @@ importers:
         version: 4.4.3
       zustand:
         specifier: ^5.0.12
-        version: 5.0.12(@types/react@19.2.14)(react@19.2.5)
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
@@ -77,7 +89,7 @@ importers:
         version: 10.1.0
       jsdom:
         specifier: ^29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@1.8.0)
       lefthook:
         specifier: ^2.1.6
         version: 2.1.6
@@ -98,7 +110,7 @@ importers:
         version: 5.1.1(vue@3.5.33(typescript@6.0.3))
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.6.0)(@vitest/ui@4.1.0)(jsdom@29.1.1)(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+        version: 4.1.0(@types/node@25.6.0)(@vitest/ui@4.1.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
 
 packages:
 
@@ -222,24 +234,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.14':
     resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.14':
     resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.14':
     resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.14':
     resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
@@ -375,6 +391,10 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
@@ -397,6 +417,24 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -433,36 +471,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -551,24 +595,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -811,6 +859,9 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -818,6 +869,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1175,24 +1230,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1469,6 +1528,9 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
@@ -1545,6 +1607,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite-plugin-singlefile@2.3.3:
     resolution: {integrity: sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==}
@@ -1933,7 +2000,9 @@ snapshots:
 
   '@epic-web/invariant@1.0.0': {}
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@inquirer/ansi@2.0.5': {}
 
@@ -1997,6 +2066,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@noble/hashes@1.8.0':
+    optional: true
+
   '@open-draft/deferred-promise@2.2.0': {}
 
   '@open-draft/deferred-promise@3.0.0': {}
@@ -2015,6 +2087,19 @@ snapshots:
       playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
@@ -2253,7 +2338,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.6.0)(@vitest/ui@4.1.0)(jsdom@29.1.1)(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+      vitest: 4.1.0(@types/node@25.6.0)(@vitest/ui@4.1.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -2300,7 +2385,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.6.0)(@vitest/ui@4.1.0)(jsdom@29.1.1)(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+      vitest: 4.1.0(@types/node@25.6.0)(@vitest/ui@4.1.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -2412,6 +2497,10 @@ snapshots:
 
   chai@6.2.2: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   cli-width@4.1.0: {}
 
   cliui@8.0.1:
@@ -2419,6 +2508,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -2476,10 +2567,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -2585,9 +2676,9 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -2624,17 +2715,17 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsdom@29.1.1:
+  jsdom@29.1.1(@noble/hashes@1.8.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.6
       parse5: 8.0.1
@@ -2645,7 +2736,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -2764,7 +2855,7 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
@@ -2989,6 +3080,8 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tailwind-merge@3.5.0: {}
+
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
@@ -3050,6 +3143,11 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+    optional: true
+
   vite-plugin-singlefile@2.3.3(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)):
     dependencies:
       micromatch: 4.0.8
@@ -3075,7 +3173,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.0(@types/node@25.6.0)(@vitest/ui@4.1.0)(jsdom@29.1.1)(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)):
+  vitest@4.1.0(@types/node@25.6.0)(@vitest/ui@4.1.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
@@ -3100,7 +3198,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       '@vitest/ui': 4.1.0(vitest@4.1.0)
-      jsdom: 29.1.1
+      jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
 
@@ -3122,9 +3220,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -3167,7 +3265,8 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@5.0.12(@types/react@19.2.14)(react@19.2.5):
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)

--- a/src/components/parts/ConfirmDialog.tsx
+++ b/src/components/parts/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { CANCEL } from "../../noTrans";
+import { Button } from "@/components/ui/button";
 
 interface ConfirmDialogProps {
 	title: string;
@@ -25,20 +26,10 @@ export function ConfirmDialog({
 				<p className="text-gray-600 leading-relaxed">{message}</p>
 			</div>
 			<div className="px-6 py-4 bg-gray-50 flex justify-end gap-3">
-				<button
-					type="button"
-					onClick={onCancel}
-					className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-				>
+				<Button variant="outline" onClick={onCancel}>
 					{CANCEL}
-				</button>
-				<button
-					type="button"
-					onClick={onConfirm}
-					className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors shadow-sm"
-				>
-					OK
-				</button>
+				</Button>
+				<Button onClick={onConfirm}>OK</Button>
 			</div>
 		</div>
 	);

--- a/src/components/parts/ConfirmDialog.tsx
+++ b/src/components/parts/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
-import { CANCEL } from "../../noTrans";
 import { Button } from "@/components/ui/button";
+import { CANCEL } from "../../noTrans";
 
 interface ConfirmDialogProps {
 	title: string;

--- a/src/components/parts/ConfirmDialog.tsx
+++ b/src/components/parts/ConfirmDialog.tsx
@@ -26,9 +26,7 @@ export function ConfirmDialog({
 				<p className="text-gray-600 leading-relaxed">{message}</p>
 			</div>
 			<div className="px-6 py-4 bg-gray-50 flex justify-end gap-3">
-				<Button variant="outline" onClick={onCancel}>
-					{CANCEL}
-				</Button>
+				<Button onClick={onCancel}>{CANCEL}</Button>
 				<Button onClick={onConfirm}>OK</Button>
 			</div>
 		</div>

--- a/src/components/parts/ExportButton.tsx
+++ b/src/components/parts/ExportButton.tsx
@@ -1,6 +1,6 @@
 import { Download } from "lucide-react";
-import { EXPORT_CSV_LABEL, EXPORT_CSV_TITLE } from "../../noTrans";
 import { Button } from "@/components/ui/button";
+import { EXPORT_CSV_LABEL, EXPORT_CSV_TITLE } from "../../noTrans";
 
 interface ExportButtonProps {
 	onClick: () => void;

--- a/src/components/parts/ExportButton.tsx
+++ b/src/components/parts/ExportButton.tsx
@@ -1,5 +1,6 @@
 import { Download } from "lucide-react";
 import { EXPORT_CSV_LABEL, EXPORT_CSV_TITLE } from "../../noTrans";
+import { Button } from "@/components/ui/button";
 
 interface ExportButtonProps {
 	onClick: () => void;
@@ -12,19 +13,14 @@ interface ExportButtonProps {
  */
 export function ExportButton({ onClick, disabled }: ExportButtonProps) {
 	return (
-		<button
-			type="button"
+		<Button
 			onClick={onClick}
 			disabled={disabled}
-			className={`
-        flex items-center gap-2 px-3 py-2 rounded-full transition-all duration-200
-        ${disabled ? "text-gray-400 cursor-not-allowed bg-gray-50 border-gray-100" : "text-green-600 hover:bg-green-50 active:bg-green-100 shadow-sm border border-gray-200 bg-white"}
-      `}
 			title={EXPORT_CSV_TITLE}
 			aria-label={EXPORT_CSV_TITLE}
 		>
 			<Download size={18} aria-hidden="true" />
-			<span className="text-sm font-medium">{EXPORT_CSV_LABEL}</span>
-		</button>
+			{EXPORT_CSV_LABEL}
+		</Button>
 	);
 }

--- a/src/components/parts/ImportButton.tsx
+++ b/src/components/parts/ImportButton.tsx
@@ -1,6 +1,7 @@
 import { Upload } from "lucide-react";
 import { useRef } from "react";
 import { IMPORT_BUTTON_ARIA, IMPORT_BUTTON_TITLE } from "../../noTrans";
+import { Button } from "@/components/ui/button";
 
 interface ImportButtonProps {
 	onImport: (csvContent: string) => void;
@@ -51,20 +52,15 @@ export function ImportButton({ onImport, disabled }: ImportButtonProps) {
 				onChange={handleFileChange}
 				className="hidden"
 			/>
-			<button
-				type="button"
+			<Button
 				onClick={handleClick}
 				disabled={disabled}
-				className={`
-          flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-200 font-medium
-          ${disabled ? "text-gray-400 cursor-not-allowed bg-gray-50 border-gray-200" : "text-blue-600 hover:bg-blue-50 active:bg-blue-100 shadow-sm border border-gray-200 bg-white"}
-        `}
 				title={IMPORT_BUTTON_TITLE}
 				aria-label={IMPORT_BUTTON_ARIA}
 			>
 				<Upload size={18} aria-hidden="true" />
-				<span>{IMPORT_BUTTON_TITLE}</span>
-			</button>
+				{IMPORT_BUTTON_TITLE}
+			</Button>
 		</>
 	);
 }

--- a/src/components/parts/ImportButton.tsx
+++ b/src/components/parts/ImportButton.tsx
@@ -1,7 +1,7 @@
 import { Upload } from "lucide-react";
 import { useRef } from "react";
-import { IMPORT_BUTTON_ARIA, IMPORT_BUTTON_TITLE } from "../../noTrans";
 import { Button } from "@/components/ui/button";
+import { IMPORT_BUTTON_ARIA, IMPORT_BUTTON_TITLE } from "../../noTrans";
 
 interface ImportButtonProps {
 	onImport: (csvContent: string) => void;

--- a/src/components/parts/OptionGroupToggleSidebarToggleButton.tsx
+++ b/src/components/parts/OptionGroupToggleSidebarToggleButton.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { SIDEBAR_CLOSE_ARIA, SIDEBAR_OPEN_ARIA } from "../../noTrans";
 
 interface OptionGroupToggleSidebarToggleButtonProps {
@@ -13,13 +14,14 @@ export function OptionGroupToggleSidebarToggleButton({
 	isOpen,
 }: OptionGroupToggleSidebarToggleButtonProps) {
 	return (
-		<button
-			type="button"
+		<Button
+			variant="secondary"
+			size="icon"
 			onClick={onClick}
-			className="p-2 bg-gray-200 hover:bg-gray-300 rounded-md transition-colors"
+			className="h-8 w-8"
 			aria-label={isOpen ? SIDEBAR_CLOSE_ARIA : SIDEBAR_OPEN_ARIA}
 		>
 			{isOpen ? "◀" : "▶"}
-		</button>
+		</Button>
 	);
 }

--- a/src/components/parts/OptionGroupToggleSidebarToggleButton.tsx
+++ b/src/components/parts/OptionGroupToggleSidebarToggleButton.tsx
@@ -15,10 +15,7 @@ export function OptionGroupToggleSidebarToggleButton({
 }: OptionGroupToggleSidebarToggleButtonProps) {
 	return (
 		<Button
-			variant="secondary"
-			size="icon"
 			onClick={onClick}
-			className="h-8 w-8"
 			aria-label={isOpen ? SIDEBAR_CLOSE_ARIA : SIDEBAR_OPEN_ARIA}
 		>
 			{isOpen ? "◀" : "▶"}

--- a/src/components/parts/RolePin.tsx
+++ b/src/components/parts/RolePin.tsx
@@ -1,4 +1,5 @@
 import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface RolePinProps {
 	name: string;
@@ -13,17 +14,18 @@ export function RolePin({ name, onDelete }: RolePinProps) {
 		<div className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
 			<span>{name}</span>
 			{onDelete && (
-				<button
-					type="button"
+				<Button
+					variant="ghost"
+					size="icon"
 					onClick={(e) => {
 						e.stopPropagation();
 						onDelete();
 					}}
-					className="hover:text-blue-600 focus:outline-none"
+					className="h-3 w-3 p-0 hover:text-blue-600 focus:outline-none"
 					aria-label={`Remove ${name}`}
 				>
 					<X size={12} aria-hidden="true" />
-				</button>
+				</Button>
 			)}
 		</div>
 	);

--- a/src/components/parts/RolePin.tsx
+++ b/src/components/parts/RolePin.tsx
@@ -15,13 +15,10 @@ export function RolePin({ name, onDelete }: RolePinProps) {
 			<span>{name}</span>
 			{onDelete && (
 				<Button
-					variant="ghost"
-					size="icon"
 					onClick={(e) => {
 						e.stopPropagation();
 						onDelete();
 					}}
-					className="h-3 w-3 p-0 hover:text-blue-600 focus:outline-none"
 					aria-label={`Remove ${name}`}
 				>
 					<X size={12} aria-hidden="true" />

--- a/src/components/parts/SyncButton.tsx
+++ b/src/components/parts/SyncButton.tsx
@@ -18,7 +18,6 @@ export function SyncButton({ onClick, disabled }: SyncButtonProps) {
 			disabled={disabled}
 			title={SYNC_BUTTON_TITLE}
 			aria-label={SYNC_BUTTON_ARIA}
-			size="icon"
 		>
 			<RefreshCw size={20} aria-hidden="true" />
 		</Button>

--- a/src/components/parts/SyncButton.tsx
+++ b/src/components/parts/SyncButton.tsx
@@ -1,6 +1,6 @@
 import { RefreshCw } from "lucide-react";
-import { SYNC_BUTTON_ARIA, SYNC_BUTTON_TITLE } from "../../noTrans";
 import { Button } from "@/components/ui/button";
+import { SYNC_BUTTON_ARIA, SYNC_BUTTON_TITLE } from "../../noTrans";
 
 interface SyncButtonProps {
 	onClick: () => void;

--- a/src/components/parts/SyncButton.tsx
+++ b/src/components/parts/SyncButton.tsx
@@ -1,5 +1,6 @@
 import { RefreshCw } from "lucide-react";
 import { SYNC_BUTTON_ARIA, SYNC_BUTTON_TITLE } from "../../noTrans";
+import { Button } from "@/components/ui/button";
 
 interface SyncButtonProps {
 	onClick: () => void;
@@ -12,18 +13,14 @@ interface SyncButtonProps {
  */
 export function SyncButton({ onClick, disabled }: SyncButtonProps) {
 	return (
-		<button
-			type="button"
+		<Button
 			onClick={onClick}
 			disabled={disabled}
-			className={`
-        p-2 rounded-full transition-all duration-200
-        ${disabled ? "text-gray-400 cursor-not-allowed" : "text-blue-600 hover:bg-blue-50 active:bg-blue-100 shadow-sm border border-gray-200 bg-white"}
-      `}
 			title={SYNC_BUTTON_TITLE}
 			aria-label={SYNC_BUTTON_ARIA}
+			size="icon"
 		>
 			<RefreshCw size={20} aria-hidden="true" />
-		</button>
+		</Button>
 	);
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-8 has-[>svg]:px-7",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,58 +1,58 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-8 has-[>svg]:px-7",
-        icon: "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+	{
+		variants: {
+			variant: {
+				default:
+					"bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+				destructive:
+					"bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+				outline:
+					"border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+				secondary:
+					"bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+				ghost: "hover:bg-accent hover:text-accent-foreground",
+				link: "text-primary underline-offset-4 hover:underline",
+			},
+			size: {
+				default: "h-9 px-4 py-2 has-[>svg]:px-3",
+				sm: "h-8 rounded-md px-3 has-[>svg]:px-2.5",
+				lg: "h-10 rounded-md px-8 has-[>svg]:px-7",
+				icon: "size-9",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	},
+);
 
 function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
+	className,
+	variant,
+	size,
+	asChild = false,
+	...props
 }: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
-  const Comp = asChild ? Slot : "button"
+	VariantProps<typeof buttonVariants> & {
+		asChild?: boolean;
+	}) {
+	const Comp = asChild ? Slot : "button";
 
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  )
+	return (
+		<Comp
+			data-slot="button"
+			className={cn(buttonVariants({ variant, size, className }))}
+			{...props}
+		/>
+	);
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/feature/rolefilter/RoleFilterAddButton.tsx
+++ b/src/feature/rolefilter/RoleFilterAddButton.tsx
@@ -2,6 +2,7 @@ import { Plus } from "lucide-react";
 import { postRoleFilterUpdate, roleFilterMetaData } from "../../logics/api";
 import { PostExRAssignOps } from "../../type";
 import { useStore } from "../../useStore";
+import { Button } from "@/components/ui/button";
 
 /**
  * フィルターを追加するためのボタンコンポーネント (ビジネスロジックを含む)
@@ -54,13 +55,9 @@ export function RoleFilterAddButton() {
 	};
 
 	return (
-		<button
-			type="button"
-			onClick={onAddFilter}
-			className="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none"
-		>
+		<Button onClick={onAddFilter}>
 			<Plus size={20} className="mr-1" aria-hidden="true" />
 			フィルターを追加
-		</button>
+		</Button>
 	);
 }

--- a/src/feature/rolefilter/RoleFilterAddButton.tsx
+++ b/src/feature/rolefilter/RoleFilterAddButton.tsx
@@ -1,8 +1,8 @@
 import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { postRoleFilterUpdate, roleFilterMetaData } from "../../logics/api";
 import { PostExRAssignOps } from "../../type";
 import { useStore } from "../../useStore";
-import { Button } from "@/components/ui/button";
 
 /**
  * フィルターを追加するためのボタンコンポーネント (ビジネスロジックを含む)

--- a/src/feature/rolefilter/RoleFilterCardHeader.tsx
+++ b/src/feature/rolefilter/RoleFilterCardHeader.tsx
@@ -1,8 +1,8 @@
 import { ChevronDown, ChevronUp, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { postRoleFilterUpdate, roleFilterMetaData } from "../../logics/api";
 import { PostExRAssignOps } from "../../type";
 import { useStore } from "../../useStore";
-import { Button } from "@/components/ui/button";
 
 interface RoleFilterCardHeaderProps {
 	guid: string;

--- a/src/feature/rolefilter/RoleFilterCardHeader.tsx
+++ b/src/feature/rolefilter/RoleFilterCardHeader.tsx
@@ -100,33 +100,22 @@ export function RoleFilterCardHeader({
 				</span>
 				<div className="flex flex-col gap-0.5">
 					<Button
-						variant="ghost"
-						size="icon"
 						onClick={onIncrement}
 						disabled={assignNum >= 255 || isUpdating}
-						className="h-5 w-5 p-0"
 						aria-label="Increment AssignNum"
 					>
 						<ChevronUp size={14} />
 					</Button>
 					<Button
-						variant="ghost"
-						size="icon"
 						onClick={onDecrement}
 						disabled={assignNum <= 1 || isUpdating}
-						className="h-5 w-5 p-0"
 						aria-label="Decrement AssignNum"
 					>
 						<ChevronDown size={14} />
 					</Button>
 				</div>
 			</div>
-			<Button
-				variant="secondary"
-				size="sm"
-				onClick={onOpenRoleSelect}
-				className="mt-1 self-start h-7 text-xs px-2"
-			>
+			<Button onClick={onOpenRoleSelect}>
 				<Plus size={12} className="mr-1" aria-hidden="true" />
 				役職を追加
 			</Button>

--- a/src/feature/rolefilter/RoleFilterCardHeader.tsx
+++ b/src/feature/rolefilter/RoleFilterCardHeader.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronUp, Plus } from "lucide-react";
 import { postRoleFilterUpdate, roleFilterMetaData } from "../../logics/api";
 import { PostExRAssignOps } from "../../type";
 import { useStore } from "../../useStore";
+import { Button } from "@/components/ui/button";
 
 interface RoleFilterCardHeaderProps {
 	guid: string;
@@ -97,35 +98,38 @@ export function RoleFilterCardHeader({
 				<span className="text-sm font-semibold text-gray-700">
 					AssignNum: {assignNum}
 				</span>
-				<div className="flex flex-col">
-					<button
-						type="button"
+				<div className="flex flex-col gap-0.5">
+					<Button
+						variant="ghost"
+						size="icon"
 						onClick={onIncrement}
 						disabled={assignNum >= 255 || isUpdating}
-						className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:hover:bg-transparent"
+						className="h-5 w-5 p-0"
 						aria-label="Increment AssignNum"
 					>
 						<ChevronUp size={14} />
-					</button>
-					<button
-						type="button"
+					</Button>
+					<Button
+						variant="ghost"
+						size="icon"
 						onClick={onDecrement}
 						disabled={assignNum <= 1 || isUpdating}
-						className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:hover:bg-transparent"
+						className="h-5 w-5 p-0"
 						aria-label="Decrement AssignNum"
 					>
 						<ChevronDown size={14} />
-					</button>
+					</Button>
 				</div>
 			</div>
-			<button
-				type="button"
+			<Button
+				variant="secondary"
+				size="sm"
 				onClick={onOpenRoleSelect}
-				className="mt-1 self-start inline-flex items-center px-2 py-1 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none"
+				className="mt-1 self-start h-7 text-xs px-2"
 			>
 				<Plus size={12} className="mr-1" aria-hidden="true" />
 				役職を追加
-			</button>
+			</Button>
 		</>
 	);
 }

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -4,6 +4,7 @@ import { RoleSearchInput } from "../../components/parts/RoleSearchInput";
 import { roleFilterMetaData } from "../../logics/api";
 import { CLOSE, CONFIRM } from "../../noTrans";
 import { useStore } from "../../useStore";
+import { Button } from "@/components/ui/button";
 
 interface RoleSelectDialogProps {
 	onSelect: (roleIds: number[]) => void;
@@ -89,13 +90,14 @@ export function RoleSelectDialog({
 		<div className="bg-white rounded-lg shadow-2xl w-full max-w-5xl overflow-hidden animate-in fade-in zoom-in duration-200 flex flex-col h-[min(80vh,600px)]">
 			<div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center">
 				<h3 className="text-xl font-bold text-gray-900">役職の選択</h3>
-				<button
-					type="button"
+				<Button
+					variant="ghost"
+					size="icon"
 					onClick={onCancel}
-					className="text-gray-400 hover:text-gray-600 transition-colors"
+					className="text-gray-400 hover:text-gray-600"
 				>
 					<X size={24} aria-label="Close icon" />
-				</button>
+				</Button>
 			</div>
 			<div className="px-6 py-3 border-b border-gray-50">
 				<RoleSearchInput
@@ -113,21 +115,15 @@ export function RoleSelectDialog({
 				/>
 			</div>
 			<div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end gap-3">
-				<button
-					type="button"
-					onClick={onCancel}
-					className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-				>
+				<Button variant="outline" onClick={onCancel}>
 					{CLOSE}
-				</button>
-				<button
-					type="button"
+				</Button>
+				<Button
 					disabled={selectedRoleIds.length === 0}
 					onClick={() => onSelect(selectedRoleIds)}
-					className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
 				>
 					{CONFIRM} ({selectedRoleIds.length})
-				</button>
+				</Button>
 			</div>
 		</div>
 	);

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -1,10 +1,10 @@
 import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { RoleGrid } from "../../components/blocks/RoleGrid";
 import { RoleSearchInput } from "../../components/parts/RoleSearchInput";
 import { roleFilterMetaData } from "../../logics/api";
 import { CLOSE, CONFIRM } from "../../noTrans";
 import { useStore } from "../../useStore";
-import { Button } from "@/components/ui/button";
 
 interface RoleSelectDialogProps {
 	onSelect: (roleIds: number[]) => void;

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -90,12 +90,7 @@ export function RoleSelectDialog({
 		<div className="bg-white rounded-lg shadow-2xl w-full max-w-5xl overflow-hidden animate-in fade-in zoom-in duration-200 flex flex-col h-[min(80vh,600px)]">
 			<div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center">
 				<h3 className="text-xl font-bold text-gray-900">役職の選択</h3>
-				<Button
-					variant="ghost"
-					size="icon"
-					onClick={onCancel}
-					className="text-gray-400 hover:text-gray-600"
-				>
+				<Button onClick={onCancel}>
 					<X size={24} aria-label="Close icon" />
 				</Button>
 			</div>
@@ -115,9 +110,7 @@ export function RoleSelectDialog({
 				/>
 			</div>
 			<div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end gap-3">
-				<Button variant="outline" onClick={onCancel}>
-					{CLOSE}
-				</Button>
+				<Button onClick={onCancel}>{CLOSE}</Button>
 				<Button
 					disabled={selectedRoleIds.length === 0}
 					onClick={() => onSelect(selectedRoleIds)}

--- a/src/index.css
+++ b/src/index.css
@@ -1,32 +1,32 @@
 @import "tailwindcss";
 
 @theme {
-  --color-background: oklch(1 0 0);
-  --color-foreground: oklch(0.145 0 0);
-  --color-card: oklch(1 0 0);
-  --color-card-foreground: oklch(0.145 0 0);
-  --color-popover: oklch(1 0 0);
-  --color-popover-foreground: oklch(0.145 0 0);
-  --color-primary: oklch(0.205 0 0);
-  --color-primary-foreground: oklch(0.985 0 0);
-  --color-secondary: oklch(0.97 0 0);
-  --color-secondary-foreground: oklch(0.205 0 0);
-  --color-muted: oklch(0.97 0 0);
-  --color-muted-foreground: oklch(0.556 0 0);
-  --color-accent: oklch(0.97 0 0);
-  --color-accent-foreground: oklch(0.205 0 0);
-  --color-destructive: oklch(0.577 0.245 27.325);
-  --color-destructive-foreground: oklch(0.985 0 0);
-  --color-border: oklch(0.922 0 0);
-  --color-input: oklch(0.922 0 0);
-  --color-ring: oklch(0.708 0 0);
+	--color-background: oklch(1 0 0);
+	--color-foreground: oklch(0.145 0 0);
+	--color-card: oklch(1 0 0);
+	--color-card-foreground: oklch(0.145 0 0);
+	--color-popover: oklch(1 0 0);
+	--color-popover-foreground: oklch(0.145 0 0);
+	--color-primary: oklch(0.205 0 0);
+	--color-primary-foreground: oklch(0.985 0 0);
+	--color-secondary: oklch(0.97 0 0);
+	--color-secondary-foreground: oklch(0.205 0 0);
+	--color-muted: oklch(0.97 0 0);
+	--color-muted-foreground: oklch(0.556 0 0);
+	--color-accent: oklch(0.97 0 0);
+	--color-accent-foreground: oklch(0.205 0 0);
+	--color-destructive: oklch(0.577 0.245 27.325);
+	--color-destructive-foreground: oklch(0.985 0 0);
+	--color-border: oklch(0.922 0 0);
+	--color-input: oklch(0.922 0 0);
+	--color-ring: oklch(0.708 0 0);
 }
 
 @layer base {
-  * {
-    @apply border-border;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
+	* {
+		@apply border-border;
+	}
+	body {
+		@apply bg-background text-foreground;
+	}
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,32 @@
 @import "tailwindcss";
+
+@theme {
+  --color-background: oklch(1 0 0);
+  --color-foreground: oklch(0.145 0 0);
+  --color-card: oklch(1 0 0);
+  --color-card-foreground: oklch(0.145 0 0);
+  --color-popover: oklch(1 0 0);
+  --color-popover-foreground: oklch(0.145 0 0);
+  --color-primary: oklch(0.205 0 0);
+  --color-primary-foreground: oklch(0.985 0 0);
+  --color-secondary: oklch(0.97 0 0);
+  --color-secondary-foreground: oklch(0.205 0 0);
+  --color-muted: oklch(0.97 0 0);
+  --color-muted-foreground: oklch(0.556 0 0);
+  --color-accent: oklch(0.97 0 0);
+  --color-accent-foreground: oklch(0.205 0 0);
+  --color-destructive: oklch(0.577 0.245 27.325);
+  --color-destructive-foreground: oklch(0.985 0 0);
+  --color-border: oklch(0.922 0 0);
+  --color-input: oklch(0.922 0 0);
+  --color-ring: oklch(0.708 0 0);
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+	return twMerge(clsx(inputs));
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/tests/ImportButton.test.tsx
+++ b/tests/ImportButton.test.tsx
@@ -18,7 +18,6 @@ describe("ImportButton", () => {
 
 		const button = screen.getByRole("button", { name: IMPORT_BUTTON_ARIA });
 		expect(button).toBeDisabled();
-		expect(button).toHaveClass("cursor-not-allowed");
 	});
 
 	it("triggers file input click when button is clicked", () => {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,7 +22,10 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 /// <reference types="vitest/config" />
+import path from "node:path"
 import { defineConfig } from 'vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import { viteSingleFile } from "vite-plugin-singlefile"
@@ -10,6 +11,11 @@ const port = process.env.VITE_USE_MOCK ? 67700 : 57700
 
 // https://vite.dev/config/
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   server: {
     proxy: {
       '/exr/option/': `http://localhost:${port}`,


### PR DESCRIPTION
Migrated standalone buttons to the shadcn/ui Button component. This included setting up the necessary design system infrastructure (Tailwind CSS v4 variables, utility functions, and component definition) and refactoring target components to use the new Button while maintaining functionality. Verified with Vitest and visual inspection.

---
*PR created automatically by Jules for task [4667713619073884607](https://jules.google.com/task/4667713619073884607) started by @yukieiji*