### PR TITLE
Migrate BlockDialog to shadcn/ui Dialog

### DIFF
--- a/src/components/parts/ConfirmDialog.tsx
+++ b/src/components/parts/ConfirmDialog.tsx
@@ -25,15 +25,13 @@ export function ConfirmDialog({
 	onCancel,
 }: ConfirmDialogProps) {
 	return (
-		<DialogContent showCloseButton={false} className="sm:max-w-md">
+		<DialogContent className="sm:max-w-md">
 			<DialogHeader>
 				<DialogTitle>{title}</DialogTitle>
 				<DialogDescription>{message}</DialogDescription>
 			</DialogHeader>
 			<DialogFooter>
-				<Button variant="outline" onClick={onCancel}>
-					{CANCEL}
-				</Button>
+				<Button onClick={onCancel}>{CANCEL}</Button>
 				<Button onClick={onConfirm}>OK</Button>
 			</DialogFooter>
 		</DialogContent>

--- a/src/components/parts/ConfirmDialog.tsx
+++ b/src/components/parts/ConfirmDialog.tsx
@@ -1,4 +1,11 @@
 import { Button } from "@/components/ui/button";
+import {
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { CANCEL } from "@/noTrans";
 
 interface ConfirmDialogProps {
@@ -18,17 +25,17 @@ export function ConfirmDialog({
 	onCancel,
 }: ConfirmDialogProps) {
 	return (
-		<div className="bg-white rounded-lg shadow-2xl w-full max-w-md overflow-hidden animate-in fade-in zoom-in duration-200">
-			<div className="px-6 py-4 border-b border-gray-100">
-				<h3 className="text-xl font-bold text-gray-900">{title}</h3>
-			</div>
-			<div className="px-6 py-6">
-				<p className="text-gray-600 leading-relaxed">{message}</p>
-			</div>
-			<div className="px-6 py-4 bg-gray-50 flex justify-end gap-3">
-				<Button onClick={onCancel}>{CANCEL}</Button>
+		<DialogContent showCloseButton={false} className="sm:max-w-md">
+			<DialogHeader>
+				<DialogTitle>{title}</DialogTitle>
+				<DialogDescription>{message}</DialogDescription>
+			</DialogHeader>
+			<DialogFooter>
+				<Button variant="outline" onClick={onCancel}>
+					{CANCEL}
+				</Button>
 				<Button onClick={onConfirm}>OK</Button>
-			</div>
-		</div>
+			</DialogFooter>
+		</DialogContent>
 	);
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,158 +1,156 @@
-import * as React from "react"
-import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
-
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
-  className,
-  ...props
+	className,
+	...props
 }: DialogPrimitive.Backdrop.Props) {
-  return (
-    <DialogPrimitive.Backdrop
-      data-slot="dialog-overlay"
-      className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
-      )}
-      {...props}
-    />
-  )
+	return (
+		<DialogPrimitive.Backdrop
+			data-slot="dialog-overlay"
+			className={cn(
+				"fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
 }
 
 function DialogContent({
-  className,
-  children,
-  showCloseButton = true,
-  ...props
+	className,
+	children,
+	showCloseButton = true,
+	...props
 }: DialogPrimitive.Popup.Props & {
-  showCloseButton?: boolean
+	showCloseButton?: boolean;
 }) {
-  return (
-    <DialogPortal>
-      <DialogOverlay />
-      <DialogPrimitive.Popup
-        data-slot="dialog-content"
-        className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
-        )}
-        {...props}
-      >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            render={
-              <Button
-                variant="ghost"
-                className="absolute top-2 right-2"
-                size="icon-sm"
-              />
-            }
-          >
-            <XIcon
-            />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Popup>
-    </DialogPortal>
-  )
+	return (
+		<DialogPortal>
+			<DialogOverlay />
+			<DialogPrimitive.Popup
+				data-slot="dialog-content"
+				className={cn(
+					"fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				{showCloseButton && (
+					<DialogPrimitive.Close
+						data-slot="dialog-close"
+						render={
+							<Button
+								variant="ghost"
+								className="absolute top-2 right-2"
+								size="icon-sm"
+							/>
+						}
+					>
+						<XIcon />
+						<span className="sr-only">Close</span>
+					</DialogPrimitive.Close>
+				)}
+			</DialogPrimitive.Popup>
+		</DialogPortal>
+	);
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="dialog-header"
-      className={cn("flex flex-col gap-2", className)}
-      {...props}
-    />
-  )
+	return (
+		<div
+			data-slot="dialog-header"
+			className={cn("flex flex-col gap-2", className)}
+			{...props}
+		/>
+	);
 }
 
 function DialogFooter({
-  className,
-  showCloseButton = false,
-  children,
-  ...props
+	className,
+	showCloseButton = false,
+	children,
+	...props
 }: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+	showCloseButton?: boolean;
 }) {
-  return (
-    <div
-      data-slot="dialog-footer"
-      className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      {showCloseButton && (
-        <DialogPrimitive.Close render={<Button variant="outline" />}>
-          Close
-        </DialogPrimitive.Close>
-      )}
-    </div>
-  )
+	return (
+		<div
+			data-slot="dialog-footer"
+			className={cn(
+				"-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			{showCloseButton && (
+				<DialogPrimitive.Close render={<Button variant="outline" />}>
+					Close
+				</DialogPrimitive.Close>
+			)}
+		</div>
+	);
 }
 
 function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
-  return (
-    <DialogPrimitive.Title
-      data-slot="dialog-title"
-      className={cn(
-        "font-heading text-base leading-none font-medium",
-        className
-      )}
-      {...props}
-    />
-  )
+	return (
+		<DialogPrimitive.Title
+			data-slot="dialog-title"
+			className={cn(
+				"font-heading text-base leading-none font-medium",
+				className,
+			)}
+			{...props}
+		/>
+	);
 }
 
 function DialogDescription({
-  className,
-  ...props
+	className,
+	...props
 }: DialogPrimitive.Description.Props) {
-  return (
-    <DialogPrimitive.Description
-      data-slot="dialog-description"
-      className={cn(
-        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
-        className
-      )}
-      {...props}
-    />
-  )
+	return (
+		<DialogPrimitive.Description
+			data-slot="dialog-description"
+			className={cn(
+				"text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+				className,
+			)}
+			{...props}
+		/>
+	);
 }
 
 export {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogOverlay,
-  DialogPortal,
-  DialogTitle,
-  DialogTrigger,
-}
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogOverlay,
+	DialogPortal,
+	DialogTitle,
+	DialogTrigger,
+};

--- a/src/feature/BlockableDialog.tsx
+++ b/src/feature/BlockableDialog.tsx
@@ -8,7 +8,10 @@ export function BlockableDialog() {
 	const closeDialog = useStore((state) => state.closeBlockDialog);
 
 	return (
-		<Dialog open={!!blockDialog} onOpenChange={(open) => !open && closeDialog()}>
+		<Dialog
+			open={!!blockDialog}
+			onOpenChange={(open) => !open && closeDialog()}
+		>
 			{blockDialog?.type === "confirm" && (
 				<ConfirmDialog
 					title={blockDialog.title}

--- a/src/feature/BlockableDialog.tsx
+++ b/src/feature/BlockableDialog.tsx
@@ -1,4 +1,5 @@
 import { ConfirmDialog } from "../components/parts/ConfirmDialog";
+import { Dialog } from "../components/ui/dialog";
 import { useStore } from "../useStore";
 import { RoleSelectDialog } from "./rolefilter/RoleSelectDialog";
 
@@ -6,13 +7,9 @@ export function BlockableDialog() {
 	const blockDialog = useStore((state) => state.blockDialog);
 	const closeDialog = useStore((state) => state.closeBlockDialog);
 
-	if (!blockDialog) {
-		return null;
-	}
-
 	return (
-		<div className="fixed inset-0 z-200 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-			{blockDialog.type === "confirm" && (
+		<Dialog open={!!blockDialog} onOpenChange={(open) => !open && closeDialog()}>
+			{blockDialog?.type === "confirm" && (
 				<ConfirmDialog
 					title={blockDialog.title}
 					message={blockDialog.message}
@@ -23,7 +20,7 @@ export function BlockableDialog() {
 					onCancel={closeDialog}
 				/>
 			)}
-			{blockDialog.type === "roleSelect" && (
+			{blockDialog?.type === "roleSelect" && (
 				<RoleSelectDialog
 					excludeRoleIds={blockDialog.excludeRoleIds}
 					onSelect={async (roleIds) => {
@@ -33,6 +30,6 @@ export function BlockableDialog() {
 					onCancel={closeDialog}
 				/>
 			)}
-		</div>
+		</Dialog>
 	);
 }

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -92,18 +92,16 @@ export function RoleSelectDialog({
 	};
 
 	return (
-		<DialogContent className="max-w-5xl h-[min(80vh,600px)] flex flex-col p-0 overflow-hidden">
-			<DialogHeader className="px-6 py-4 border-b">
+		<DialogContent className="max-w-5xl h-[min(80vh,600px)]">
+			<DialogHeader>
 				<DialogTitle>役職の選択</DialogTitle>
 			</DialogHeader>
-			<div className="px-6 py-3 border-b">
-				<RoleSearchInput
-					value={searchQuery}
-					onChange={setSearchQuery}
-					placeholder="役職を検索..."
-				/>
-			</div>
-			<div className="px-6 py-4 overflow-y-auto flex-1">
+			<RoleSearchInput
+				value={searchQuery}
+				onChange={setSearchQuery}
+				placeholder="役職を検索..."
+			/>
+			<div className="-m-4 p-6 overflow-y-scroll flex-1">
 				<RoleGrid
 					items={filteredRoles}
 					onSelect={handleSelect}
@@ -111,7 +109,7 @@ export function RoleSelectDialog({
 					excludeRoleIds={excludeRoleIds}
 				/>
 			</div>
-			<DialogFooter className="px-6 py-4 border-t bg-muted/50 m-0 rounded-none">
+			<DialogFooter>
 				<Button variant="outline" onClick={onCancel}>
 					{CLOSE}
 				</Button>

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -1,7 +1,12 @@
-import { X } from "lucide-react";
 import { RoleGrid } from "@/components/blocks/RoleGrid";
 import { RoleSearchInput } from "@/components/parts/RoleSearchInput";
 import { Button } from "@/components/ui/button";
+import {
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { roleFilterMetaData } from "@/logics/api";
 import { CLOSE, CONFIRM } from "@/noTrans";
 import { useStore } from "@/useStore";
@@ -87,21 +92,18 @@ export function RoleSelectDialog({
 	};
 
 	return (
-		<div className="bg-white rounded-lg shadow-2xl w-full max-w-5xl overflow-hidden animate-in fade-in zoom-in duration-200 flex flex-col h-[min(80vh,600px)]">
-			<div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center">
-				<h3 className="text-xl font-bold text-gray-900">役職の選択</h3>
-				<Button onClick={onCancel}>
-					<X aria-label="Close icon" />
-				</Button>
-			</div>
-			<div className="px-6 py-3 border-b border-gray-50">
+		<DialogContent className="max-w-5xl h-[min(80vh,600px)] flex flex-col p-0 overflow-hidden">
+			<DialogHeader className="px-6 py-4 border-b">
+				<DialogTitle>役職の選択</DialogTitle>
+			</DialogHeader>
+			<div className="px-6 py-3 border-b">
 				<RoleSearchInput
 					value={searchQuery}
 					onChange={setSearchQuery}
 					placeholder="役職を検索..."
 				/>
 			</div>
-			<div className="px-6 py-4 overflow-y-scroll flex-1">
+			<div className="px-6 py-4 overflow-y-auto flex-1">
 				<RoleGrid
 					items={filteredRoles}
 					onSelect={handleSelect}
@@ -109,15 +111,17 @@ export function RoleSelectDialog({
 					excludeRoleIds={excludeRoleIds}
 				/>
 			</div>
-			<div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end gap-3">
-				<Button onClick={onCancel}>{CLOSE}</Button>
+			<DialogFooter className="px-6 py-4 border-t bg-muted/50 m-0 rounded-none">
+				<Button variant="outline" onClick={onCancel}>
+					{CLOSE}
+				</Button>
 				<Button
 					disabled={selectedRoleIds.length === 0}
 					onClick={() => onSelect(selectedRoleIds)}
 				>
 					{CONFIRM} ({selectedRoleIds.length})
 				</Button>
-			</div>
-		</div>
+			</DialogFooter>
+		</DialogContent>
 	);
 }


### PR DESCRIPTION
This PR migrates the custom dialog implementation to use shadcn/ui's Dialog component.
- Added `src/components/ui/dialog.tsx`.
- Updated `ConfirmDialog.tsx` and `RoleSelectDialog.tsx` to use the new UI components.
- Modified `BlockableDialog.tsx` to integrate with shadcn/ui's open state management.
- Ensured wide dialogs (like RoleSelect) are correctly displayed by relaxing default max-width constraints in the UI component.

---
*PR created automatically by Jules for task [14503170743738594480](https://jules.google.com/task/14503170743738594480) started by @yukieiji*