### PR TITLE
RoleFilter周りのテキストのnoTrans.tsへの移行

### DIFF
--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -30,7 +30,7 @@ test.describe("Role Filter Management", () => {
 
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
-		await expect(page.getByText("役職の選択")).toBeVisible();
+		await expect(page.getByText("フィルター追加: 役職の選択")).toBeVisible();
 		await page.getByRole("button", { name: "Bakary" }).first().click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
@@ -67,7 +67,7 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// ダイアログが閉じるのを待つ
-		await expect(page.getByText("役職の選択")).not.toBeVisible({
+		await expect(page.getByText("フィルター追加: 役職の選択")).not.toBeVisible({
 			timeout: 10000,
 		});
 
@@ -83,7 +83,7 @@ test.describe("Role Filter Management", () => {
 
 		// Open role select dialog to add another role
 		await lastFilter.getByRole("button", { name: "役職を追加" }).click();
-		await expect(page.getByText("役職の選択")).toBeVisible();
+		await expect(page.getByText("役職の追加")).toBeVisible();
 
 		// Search for a role (using mock data role names: Opener)
 		const searchInput = page.getByPlaceholder("役職を検索...");
@@ -101,7 +101,7 @@ test.describe("Role Filter Management", () => {
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// ダイアログが閉じるのを待つ
-		await expect(page.getByText("役職の選択")).not.toBeVisible({
+		await expect(page.getByText("役職の追加")).not.toBeVisible({
 			timeout: 10000,
 		});
 

--- a/src/components/blocks/RoleFilterCardLayout.tsx
+++ b/src/components/blocks/RoleFilterCardLayout.tsx
@@ -1,6 +1,7 @@
 import { X } from "lucide-react";
 import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
+import { ROLE_FILTER_DELETE_ARIA } from "@/noTrans";
 
 interface RoleFilterCardLayoutProps {
 	onDelete: () => void;
@@ -21,7 +22,7 @@ export function RoleFilterCardLayout({
 			<Button
 				onClick={onDelete}
 				className="absolute top-2 right-2"
-				aria-label="Delete filter"
+				aria-label={ROLE_FILTER_DELETE_ARIA}
 			>
 				<X />
 			</Button>

--- a/src/feature/BlockableDialog.tsx
+++ b/src/feature/BlockableDialog.tsx
@@ -25,6 +25,7 @@ export function BlockableDialog() {
 			)}
 			{blockDialog?.type === "roleSelect" && (
 				<RoleSelectDialog
+					title={blockDialog.title}
 					excludeRoleIds={blockDialog.excludeRoleIds}
 					onSelect={async (roleIds) => {
 						await blockDialog.onSelect(roleIds);

--- a/src/feature/rolefilter/RoleFilterAddButton.tsx
+++ b/src/feature/rolefilter/RoleFilterAddButton.tsx
@@ -1,6 +1,11 @@
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { postRoleFilterUpdate, roleFilterMetaData } from "@/logics/api";
+import {
+	ROLE_FILTER_ADD_BUTTON,
+	ROLE_FILTER_ADD_TITLE,
+	ROLE_FILTER_UNKNOWN_ROLE,
+} from "@/noTrans";
 import { PostExRAssignOps } from "@/type";
 import { useStore } from "@/useStore";
 
@@ -15,7 +20,7 @@ export function RoleFilterAddButton() {
 	const onAddFilter = () => {
 		openBlockDialog({
 			type: "roleSelect",
-			title: "フィルター追加: 役職の選択",
+			title: ROLE_FILTER_ADD_TITLE,
 			searchQuery: "",
 			excludeRoleIds: [],
 			selectedRoleIds: [],
@@ -43,7 +48,7 @@ export function RoleFilterAddButton() {
 							(roleFilterMetaData.NormalRoleId[roleId] as string) ||
 							(roleFilterMetaData.CombinationId[roleId] as string) ||
 							(roleFilterMetaData.GhostRoleId[roleId] as string) ||
-							"Unknown Role";
+							ROLE_FILTER_UNKNOWN_ROLE;
 
 						addRoleToFilter(guid, roleId, roleName);
 					}
@@ -57,7 +62,7 @@ export function RoleFilterAddButton() {
 	return (
 		<Button onClick={onAddFilter}>
 			<Plus size={20} className="mr-1" aria-hidden="true" />
-			フィルターを追加
+			{ROLE_FILTER_ADD_BUTTON}
 		</Button>
 	);
 }

--- a/src/feature/rolefilter/RoleFilterCard.tsx
+++ b/src/feature/rolefilter/RoleFilterCard.tsx
@@ -2,12 +2,12 @@ import { RoleFilterCardLayout } from "@/components/blocks/RoleFilterCardLayout";
 import { RolePin } from "@/components/parts/RolePin";
 import { postRoleFilterUpdate } from "@/logics/api";
 import {
+	format,
 	ROLE_FILTER_DELETE_CONFIRM_MESSAGE,
 	ROLE_FILTER_DELETE_CONFIRM_TITLE,
 	ROLE_FILTER_NO_ROLES,
 	ROLE_FILTER_ROLE_DELETE_CONFIRM_MESSAGE,
 	ROLE_FILTER_ROLE_DELETE_CONFIRM_TITLE,
-	format,
 } from "@/noTrans";
 import type { RoleAssignFilterSetUI } from "@/type";
 import { PostExRAssignOps } from "@/type";

--- a/src/feature/rolefilter/RoleFilterCard.tsx
+++ b/src/feature/rolefilter/RoleFilterCard.tsx
@@ -1,6 +1,14 @@
 import { RoleFilterCardLayout } from "@/components/blocks/RoleFilterCardLayout";
 import { RolePin } from "@/components/parts/RolePin";
 import { postRoleFilterUpdate } from "@/logics/api";
+import {
+	ROLE_FILTER_DELETE_CONFIRM_MESSAGE,
+	ROLE_FILTER_DELETE_CONFIRM_TITLE,
+	ROLE_FILTER_NO_ROLES,
+	ROLE_FILTER_ROLE_DELETE_CONFIRM_MESSAGE,
+	ROLE_FILTER_ROLE_DELETE_CONFIRM_TITLE,
+	format,
+} from "@/noTrans";
 import type { RoleAssignFilterSetUI } from "@/type";
 import { PostExRAssignOps } from "@/type";
 import { useStore } from "@/useStore";
@@ -22,8 +30,8 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 	const onDeleteFilter = () => {
 		openBlockDialog({
 			type: "confirm",
-			title: "フィルターの削除",
-			message: "このフィルターを削除してもよろしいですか？",
+			title: ROLE_FILTER_DELETE_CONFIRM_TITLE,
+			message: ROLE_FILTER_DELETE_CONFIRM_MESSAGE,
 			onConfirm: async () => {
 				try {
 					await postRoleFilterUpdate({
@@ -42,8 +50,8 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 	const onDeleteRole = (roleId: number, roleName: string) => {
 		openBlockDialog({
 			type: "confirm",
-			title: "役職の削除",
-			message: `役職「${roleName}」をフィルターから削除してもよろしいですか？`,
+			title: ROLE_FILTER_ROLE_DELETE_CONFIRM_TITLE,
+			message: format(ROLE_FILTER_ROLE_DELETE_CONFIRM_MESSAGE, roleName),
 			onConfirm: async () => {
 				try {
 					await postRoleFilterUpdate({
@@ -79,7 +87,9 @@ export function RoleFilterCard({ guid, filterSet }: RoleFilterCardProps) {
 				);
 			})}
 			{filterSet.Roles.length === 0 && (
-				<span className="text-sm text-gray-400 italic">No roles selected</span>
+				<span className="text-sm text-gray-400 italic">
+					{ROLE_FILTER_NO_ROLES}
+				</span>
 			)}
 		</RoleFilterCardLayout>
 	);

--- a/src/feature/rolefilter/RoleFilterCardHeader.tsx
+++ b/src/feature/rolefilter/RoleFilterCardHeader.tsx
@@ -1,6 +1,15 @@
 import { ChevronDown, ChevronUp, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { postRoleFilterUpdate, roleFilterMetaData } from "@/logics/api";
+import {
+	ROLE_FILTER_ASSIGN_NUM_LABEL,
+	ROLE_FILTER_DECREMENT_ARIA,
+	ROLE_FILTER_INCREMENT_ARIA,
+	ROLE_FILTER_ROLE_ADD_BUTTON,
+	ROLE_FILTER_ROLE_ADD_TITLE,
+	ROLE_FILTER_UNKNOWN_ROLE,
+	format,
+} from "@/noTrans";
 import { PostExRAssignOps } from "@/type";
 import { useStore } from "@/useStore";
 
@@ -63,7 +72,7 @@ export function RoleFilterCardHeader({
 	const onOpenRoleSelect = () => {
 		openBlockDialog({
 			type: "roleSelect",
-			title: "役職の追加",
+			title: ROLE_FILTER_ROLE_ADD_TITLE,
 			searchQuery: "",
 			excludeRoleIds: excludeRoleIds,
 			selectedRoleIds: [],
@@ -81,7 +90,7 @@ export function RoleFilterCardHeader({
 							(roleFilterMetaData.NormalRoleId[roleId] as string) ||
 							(roleFilterMetaData.CombinationId[roleId] as string) ||
 							(roleFilterMetaData.GhostRoleId[roleId] as string) ||
-							"Unknown Role";
+							ROLE_FILTER_UNKNOWN_ROLE;
 
 						addRoleToFilter(guid, roleId, roleName);
 					}
@@ -96,20 +105,20 @@ export function RoleFilterCardHeader({
 		<>
 			<div className="flex items-center gap-2">
 				<span className="text-sm font-semibold text-gray-700">
-					AssignNum: {assignNum}
+					{format(ROLE_FILTER_ASSIGN_NUM_LABEL, assignNum)}
 				</span>
 				<div className="flex flex-col gap-0.5">
 					<Button
 						onClick={onIncrement}
 						disabled={assignNum >= 255 || isUpdating}
-						aria-label="Increment AssignNum"
+						aria-label={ROLE_FILTER_INCREMENT_ARIA}
 					>
 						<ChevronUp />
 					</Button>
 					<Button
 						onClick={onDecrement}
 						disabled={assignNum <= 1 || isUpdating}
-						aria-label="Decrement AssignNum"
+						aria-label={ROLE_FILTER_DECREMENT_ARIA}
 					>
 						<ChevronDown />
 					</Button>
@@ -117,7 +126,7 @@ export function RoleFilterCardHeader({
 			</div>
 			<Button onClick={onOpenRoleSelect}>
 				<Plus size={12} />
-				役職を追加
+				{ROLE_FILTER_ROLE_ADD_BUTTON}
 			</Button>
 		</>
 	);

--- a/src/feature/rolefilter/RoleFilterCardHeader.tsx
+++ b/src/feature/rolefilter/RoleFilterCardHeader.tsx
@@ -2,13 +2,13 @@ import { ChevronDown, ChevronUp, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { postRoleFilterUpdate, roleFilterMetaData } from "@/logics/api";
 import {
+	format,
 	ROLE_FILTER_ASSIGN_NUM_LABEL,
 	ROLE_FILTER_DECREMENT_ARIA,
 	ROLE_FILTER_INCREMENT_ARIA,
 	ROLE_FILTER_ROLE_ADD_BUTTON,
 	ROLE_FILTER_ROLE_ADD_TITLE,
 	ROLE_FILTER_UNKNOWN_ROLE,
-	format,
 } from "@/noTrans";
 import { PostExRAssignOps } from "@/type";
 import { useStore } from "@/useStore";

--- a/src/feature/rolefilter/RoleFilterViewer.tsx
+++ b/src/feature/rolefilter/RoleFilterViewer.tsx
@@ -1,3 +1,4 @@
+import { ROLE_FILTER_EMPTY_MESSAGE, ROLE_FILTER_LIST_ARIA } from "@/noTrans";
 import { useStore } from "@/useStore";
 import { RoleFilterAddButton } from "./RoleFilterAddButton";
 import { RoleFilterCard } from "./RoleFilterCard";
@@ -21,13 +22,11 @@ export function RoleFilterViewer() {
 
 			{filterEntries.length === 0 ? (
 				<div className="p-8 bg-gray-50 border-2 border-dashed border-gray-200 rounded-lg text-center">
-					<p className="text-gray-500">
-						フィルターがありません。「フィルターを追加」ボタンから作成してください。
-					</p>
+					<p className="text-gray-500">{ROLE_FILTER_EMPTY_MESSAGE}</p>
 				</div>
 			) : (
 				<ul
-					aria-label="Filter List"
+					aria-label={ROLE_FILTER_LIST_ARIA}
 					className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
 				>
 					{filterEntries.map(([guid, filterSet]) => {

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -8,10 +8,16 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { roleFilterMetaData } from "@/logics/api";
-import { CLOSE, CONFIRM } from "@/noTrans";
+import {
+	CLOSE,
+	CONFIRM,
+	ROLE_SELECT_DEFAULT_TITLE,
+	ROLE_SELECT_SEARCH_PLACEHOLDER,
+} from "@/noTrans";
 import { useStore } from "@/useStore";
 
 interface RoleSelectDialogProps {
+	title?: string;
 	onSelect: (roleIds: number[]) => void;
 	onCancel: () => void;
 	excludeRoleIds?: number[];
@@ -21,6 +27,7 @@ interface RoleSelectDialogProps {
  * 役職を選択するためのダイアログコンテンツ (ビジネスロジックを含む feature コンポーネント)
  */
 export function RoleSelectDialog({
+	title,
 	onSelect,
 	onCancel,
 	excludeRoleIds = [],
@@ -94,12 +101,12 @@ export function RoleSelectDialog({
 	return (
 		<DialogContent className="max-w-5xl h-[min(80vh,600px)]">
 			<DialogHeader>
-				<DialogTitle>役職の選択</DialogTitle>
+				<DialogTitle>{title ?? ROLE_SELECT_DEFAULT_TITLE}</DialogTitle>
 			</DialogHeader>
 			<RoleSearchInput
 				value={searchQuery}
 				onChange={setSearchQuery}
-				placeholder="役職を検索..."
+				placeholder={ROLE_SELECT_SEARCH_PLACEHOLDER}
 			/>
 			<div className="-m-4 p-6 overflow-y-scroll flex-1">
 				<RoleGrid

--- a/src/hooks/useBackend.ts
+++ b/src/hooks/useBackend.ts
@@ -1,4 +1,5 @@
 import { useEffect, useTransition } from "react";
+import { CSV_FILE_DESCRIPTION } from "../noTrans";
 import { fetchCsvData } from "../logics/api";
 import { refechAll, resetApiCache } from "../logics/api.store";
 import { useStore } from "../useStore";
@@ -46,7 +47,7 @@ export function useExportCsv(): () => Promise<void> {
 							suggestedName: fileName,
 							types: [
 								{
-									description: "CSV File",
+									description: CSV_FILE_DESCRIPTION,
 									accept: { "text/csv": [".csv"] },
 								},
 							],

--- a/src/hooks/useBackend.ts
+++ b/src/hooks/useBackend.ts
@@ -1,7 +1,7 @@
 import { useEffect, useTransition } from "react";
-import { CSV_FILE_DESCRIPTION } from "../noTrans";
 import { fetchCsvData } from "../logics/api";
 import { refechAll, resetApiCache } from "../logics/api.store";
+import { CSV_FILE_DESCRIPTION } from "../noTrans";
 import { useStore } from "../useStore";
 import { useBlock, useBlockAsync } from "./useManualBlock";
 

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -38,6 +38,29 @@ export const OPTION_SIDEBAR_ARIA = "オプションサイドバー";
 export const AU_OPTION_ROW_ARIA = "{0}の設定";
 export const AU_ROLE_ROW_ARIA = "{0}の役職";
 
+export const ROLE_FILTER_ADD_TITLE = "フィルター追加: 役職の選択";
+export const ROLE_FILTER_ADD_BUTTON = "フィルターを追加";
+export const ROLE_FILTER_UNKNOWN_ROLE = "Unknown Role";
+export const ROLE_FILTER_ROLE_ADD_TITLE = "役職の追加";
+export const ROLE_FILTER_ASSIGN_NUM_LABEL = "AssignNum: {0}";
+export const ROLE_FILTER_INCREMENT_ARIA = "Increment AssignNum";
+export const ROLE_FILTER_DECREMENT_ARIA = "Decrement AssignNum";
+export const ROLE_FILTER_ROLE_ADD_BUTTON = "役職を追加";
+export const ROLE_FILTER_EMPTY_MESSAGE =
+	"フィルターがありません。「フィルターを追加」ボタンから作成してください。";
+export const ROLE_FILTER_LIST_ARIA = "Filter List";
+export const ROLE_FILTER_DELETE_CONFIRM_TITLE = "フィルターの削除";
+export const ROLE_FILTER_DELETE_CONFIRM_MESSAGE =
+	"このフィルターを削除してもよろしいですか？";
+export const ROLE_FILTER_ROLE_DELETE_CONFIRM_TITLE = "役職の削除";
+export const ROLE_FILTER_ROLE_DELETE_CONFIRM_MESSAGE =
+	"役職「{0}」をフィルターから削除してもよろしいですか？";
+export const ROLE_FILTER_NO_ROLES = "No roles selected";
+export const ROLE_FILTER_DELETE_ARIA = "Delete filter";
+export const ROLE_SELECT_SEARCH_PLACEHOLDER = "役職を検索...";
+export const ROLE_SELECT_DEFAULT_TITLE = "役職の選択";
+export const CSV_FILE_DESCRIPTION = "CSV File";
+
 export const SYNCHRONIZING = "Synchronizing...";
 export const RIGHT_PANEL_TITLE = "Right Panel";
 export const AU_OPTIONS_TITLE = "Au Options";


### PR DESCRIPTION
RoleFilterに関連するテキスト（ボタンラベル、ダイアログタイトル、確認メッセージ、aria-label、フォールバックテキスト）およびCSVインポート/エクスポートに関連するテキストを、一元管理のために `noTrans.ts` へ移行しました。

主な変更点：
- `src/noTrans.ts` に新しい定数を多数追加
- `RoleFilterAddButton`, `RoleFilterCard`, `RoleFilterCardHeader`, `RoleFilterViewer` 等のコンポーネントでハードコードされていた文字列を定数に置き換え
- `RoleSelectDialog` のタイトルをプロップ経由で受け取れるように変更
- `useBackend.ts` 内のCSVファイル記述テキストを定数化
- 既存のテストがパスすることを確認済み
- Playwrightによる視覚的確認を実施済み

---
*PR created automatically by Jules for task [4062417555860061198](https://jules.google.com/task/4062417555860061198) started by @yukieiji*