### PR TITLE
設定ダイアログの追加

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -58,12 +58,9 @@ test("サイドバーの開閉に合わせて設定ボタンの表示が切り�
 	await toggleButton.click();
 
 	// サイドバーが閉じた状態ではテキストが表示されないことを確認
-	// transitionを待つ必要があるかもしれない
-	await page.waitForTimeout(500);
 	await expect(settingsButton).not.toContainText("設定");
 
 	// 再度開く
 	await toggleButton.click();
-	await page.waitForTimeout(500);
 	await expect(settingsButton).toContainText("設定");
 });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	// モックサーバーの状態をリセット
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	// すべてのテストで API の遅延を設定可能にする
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 100;
+	});
+
+	await page.goto("/");
+
+	// ローディング画面が消えるのを待つ
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+
+	// サイドバーが表示されるまで待機
+	await expect(page.getByLabel("オプションサイドバー")).toBeVisible({
+		timeout: 30000,
+	});
+});
+
+test("設定ダイアログが開くこと", async ({ page }) => {
+	// サイドバーの下部にある設定ボタンを探す
+	const settingsButton = page.getByTestId("sidebar-settings-button");
+	await expect(settingsButton).toBeVisible();
+
+	// 設定ボタンをクリック
+	await settingsButton.click();
+
+	// ダイアログが表示されることを確認
+	const dialog = page.getByRole("dialog");
+	await expect(dialog).toBeVisible();
+
+	// ダイアログ内に「設定」というタイトルがあることを確認
+	const title = dialog.getByText("設定", { exact: true });
+	await expect(title).toBeVisible();
+
+	// 準備中のテキストがあることを確認
+	await expect(page.getByText("設定項目は現在準備中です。")).toBeVisible();
+});
+
+test("サイドバーの開閉に合わせて設定ボタンの表示が切り替わること", async ({
+	page,
+}) => {
+	const settingsButton = page.getByTestId("sidebar-settings-button");
+
+	// 初期状態（サイドバーが開いている想定）
+	await expect(settingsButton).toContainText("設定");
+
+	// サイドバーを閉じるボタンをクリック
+	// サイドバーのトグルボタンを取得
+	const toggleButton = page.getByRole("button", {
+		name: /サイドバーを(閉じる|開く)/,
+	});
+	await toggleButton.click();
+
+	// サイドバーが閉じた状態ではテキストが表示されないことを確認
+	// transitionを待つ必要があるかもしれない
+	await page.waitForTimeout(500);
+	await expect(settingsButton).not.toContainText("設定");
+
+	// 再度開く
+	await toggleButton.click();
+	await page.waitForTimeout(500);
+	await expect(settingsButton).toContainText("設定");
+});

--- a/src/feature/BlockableDialog.tsx
+++ b/src/feature/BlockableDialog.tsx
@@ -2,6 +2,7 @@ import { ConfirmDialog } from "../components/parts/ConfirmDialog";
 import { Dialog } from "../components/ui/dialog";
 import { useStore } from "../useStore";
 import { RoleSelectDialog } from "./rolefilter/RoleSelectDialog";
+import { SettingsDialog } from "./settings/SettingsDialog";
 
 export function BlockableDialog() {
 	const blockDialog = useStore((state) => state.blockDialog);
@@ -32,6 +33,9 @@ export function BlockableDialog() {
 					}}
 					onCancel={closeDialog}
 				/>
+			)}
+			{blockDialog?.type === "settings" && (
+				<SettingsDialog title={blockDialog.title} />
 			)}
 		</Dialog>
 	);

--- a/src/feature/OptionGroupToggleSidebar.tsx
+++ b/src/feature/OptionGroupToggleSidebar.tsx
@@ -150,7 +150,7 @@ export function OptionGroupToggleSidebar() {
             w-full flex items-center gap-2 p-2 rounded-md hover:bg-gray-200 transition-colors
             ${isSidebarOpen ? "justify-start" : "justify-center"}
           `}
-					title={SETTINGS_TITLE}
+					title={isSidebarOpen ? undefined : SETTINGS_TITLE}
 				>
 					<Settings className="w-5 h-5" />
 					{isSidebarOpen && <span>{SETTINGS_TITLE}</span>}

--- a/src/feature/OptionGroupToggleSidebar.tsx
+++ b/src/feature/OptionGroupToggleSidebar.tsx
@@ -1,3 +1,4 @@
+import { Settings } from "lucide-react";
 import { useEffect, useTransition } from "react";
 import { OptionGroupToggleSidebarToggleButton } from "../components/parts/OptionGroupToggleSidebarToggleButton";
 import {
@@ -8,6 +9,7 @@ import {
 	OPTION_SIDEBAR_ARIA,
 	ROLE_FILTER_SHORT_LABEL,
 	ROLE_FILTER_TITLE,
+	SETTINGS_TITLE,
 } from "../noTrans";
 import type { SelectedTab } from "../slices/optionGroupToggleSidebarSlice";
 import { useStore } from "../useStore";
@@ -50,6 +52,9 @@ export function OptionGroupToggleSidebar() {
 	const setIsSidebarPending = useStore((state) => {
 		return state.setIsSidebarPending;
 	});
+	const openDialog = useStore((state) => {
+		return state.openBlockDialog;
+	});
 	const [isPending, startTransition] = useTransition();
 
 	const handleTabChange = (tab: SelectedTab) => {
@@ -73,7 +78,7 @@ export function OptionGroupToggleSidebar() {
 	return (
 		<aside
 			className={`
-        fixed left-0 top-0 h-full bg-gray-100 border-r border-gray-300 transition-all duration-300 z-10
+        fixed left-0 top-0 h-full bg-gray-100 border-r border-gray-300 transition-all duration-300 z-10 flex flex-col
         ${isSidebarOpen ? "w-64" : "w-12"}
       `}
 			aria-label={OPTION_SIDEBAR_ARIA}
@@ -86,51 +91,71 @@ export function OptionGroupToggleSidebar() {
 				/>
 			</div>
 
-			{isSidebarOpen ? (
-				<nav className="p-4 flex flex-col gap-4">
-					<ul className="flex flex-col gap-2">
+			<div className="flex-1 overflow-y-auto">
+				{isSidebarOpen ? (
+					<nav className="p-4 flex flex-col gap-4">
+						<ul className="flex flex-col gap-2">
+							{TABS.map((tab) => {
+								return (
+									<li key={tab.id}>
+										<button
+											type="button"
+											onClick={() => {
+												handleTabChange(tab.id);
+											}}
+											className={`
+                        w-full text-left p-2 rounded-md transition-colors
+                        ${selectedTab === tab.id ? "bg-blue-500 text-white" : "hover:bg-gray-200"}
+                      `}
+										>
+											{tab.label}
+										</button>
+									</li>
+								);
+							})}
+						</ul>
+					</nav>
+				) : (
+					<div className="flex flex-col items-center pt-8 gap-4">
 						{TABS.map((tab) => {
 							return (
-								<li key={tab.id}>
-									<button
-										type="button"
-										onClick={() => {
-											handleTabChange(tab.id);
-										}}
-										className={`
-                      w-full text-left p-2 rounded-md transition-colors
-                      ${selectedTab === tab.id ? "bg-blue-500 text-white" : "hover:bg-gray-200"}
-                    `}
-									>
-										{tab.label}
-									</button>
-								</li>
+								<button
+									key={tab.id}
+									type="button"
+									onClick={() => {
+										handleTabChange(tab.id);
+									}}
+									title={tab.label}
+									className={`
+                    w-8 h-8 rounded-full transition-colors flex items-center justify-center font-bold
+                    ${selectedTab === tab.id ? "bg-blue-500 text-white" : "bg-gray-200 hover:bg-gray-300 text-gray-700"}
+                  `}
+								>
+									{tab.shortLabel}
+								</button>
 							);
 						})}
-					</ul>
-				</nav>
-			) : (
-				<div className="flex flex-col items-center pt-8 gap-4">
-					{TABS.map((tab) => {
-						return (
-							<button
-								key={tab.id}
-								type="button"
-								onClick={() => {
-									handleTabChange(tab.id);
-								}}
-								title={tab.label}
-								className={`
-                  w-8 h-8 rounded-full transition-colors flex items-center justify-center font-bold
-                  ${selectedTab === tab.id ? "bg-blue-500 text-white" : "bg-gray-200 hover:bg-gray-300 text-gray-700"}
-                `}
-							>
-								{tab.shortLabel}
-							</button>
-						);
-					})}
-				</div>
-			)}
+					</div>
+				)}
+			</div>
+
+			<div className="p-2 border-t border-gray-200">
+				<button
+					type="button"
+					data-testid="sidebar-settings-button"
+					onClick={() => {
+						openDialog({ type: "settings", title: SETTINGS_TITLE });
+					}}
+					className={`
+            w-full flex items-center gap-2 p-2 rounded-md hover:bg-gray-200 transition-colors
+            ${isSidebarOpen ? "justify-start" : "justify-center"}
+          `}
+					title={SETTINGS_TITLE}
+				>
+					<Settings className="w-5 h-5" />
+					{isSidebarOpen && <span>{SETTINGS_TITLE}</span>}
+				</button>
+			</div>
 		</aside>
 	);
 }

--- a/src/feature/OptionGroupToggleSidebar.tsx
+++ b/src/feature/OptionGroupToggleSidebar.tsx
@@ -1,6 +1,7 @@
 import { Settings } from "lucide-react";
 import { useEffect, useTransition } from "react";
 import { OptionGroupToggleSidebarToggleButton } from "../components/parts/OptionGroupToggleSidebarToggleButton";
+import { Button } from "../components/ui/button";
 import {
 	AU_OPTIONS_TITLE,
 	AU_SHORT_LABEL,
@@ -140,21 +141,21 @@ export function OptionGroupToggleSidebar() {
 			</div>
 
 			<div className="p-2 border-t border-gray-200">
-				<button
-					type="button"
+				<Button
+					variant="ghost"
 					data-testid="sidebar-settings-button"
 					onClick={() => {
 						openDialog({ type: "settings", title: SETTINGS_TITLE });
 					}}
 					className={`
-            w-full flex items-center gap-2 p-2 rounded-md hover:bg-gray-200 transition-colors
+            w-full flex items-center gap-2 p-2 rounded-md
             ${isSidebarOpen ? "justify-start" : "justify-center"}
           `}
 					title={isSidebarOpen ? undefined : SETTINGS_TITLE}
 				>
 					<Settings className="w-5 h-5" />
 					{isSidebarOpen && <span>{SETTINGS_TITLE}</span>}
-				</button>
+				</Button>
 			</div>
 		</aside>
 	);

--- a/src/feature/OptionGroupToggleSidebar.tsx
+++ b/src/feature/OptionGroupToggleSidebar.tsx
@@ -140,20 +140,16 @@ export function OptionGroupToggleSidebar() {
 				)}
 			</div>
 
-			<div className="p-2 border-t border-gray-200">
+			<div>
 				<Button
-					variant="ghost"
+					size={isSidebarOpen ? "default" : "icon"}
 					data-testid="sidebar-settings-button"
 					onClick={() => {
 						openDialog({ type: "settings", title: SETTINGS_TITLE });
 					}}
-					className={`
-            w-full flex items-center
-            ${isSidebarOpen ? "justify-start" : "justify-center"}
-          `}
 					title={isSidebarOpen ? undefined : SETTINGS_TITLE}
 				>
-					<Settings className="w-5 h-5" />
+					<Settings />
 					{isSidebarOpen && <span>{SETTINGS_TITLE}</span>}
 				</Button>
 			</div>

--- a/src/feature/OptionGroupToggleSidebar.tsx
+++ b/src/feature/OptionGroupToggleSidebar.tsx
@@ -148,7 +148,7 @@ export function OptionGroupToggleSidebar() {
 						openDialog({ type: "settings", title: SETTINGS_TITLE });
 					}}
 					className={`
-            w-full flex items-center gap-2 p-2 rounded-md
+            w-full flex items-center
             ${isSidebarOpen ? "justify-start" : "justify-center"}
           `}
 					title={isSidebarOpen ? undefined : SETTINGS_TITLE}

--- a/src/feature/settings/SettingsDialog.tsx
+++ b/src/feature/settings/SettingsDialog.tsx
@@ -1,0 +1,25 @@
+import {
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "../../components/ui/dialog";
+
+interface SettingsDialogProps {
+	title: string;
+}
+
+/**
+ * 設定ダイアログのコンテンツコンポーネント
+ */
+export function SettingsDialog({ title }: SettingsDialogProps) {
+	return (
+		<DialogContent className="sm:max-w-[425px]">
+			<DialogHeader>
+				<DialogTitle>{title}</DialogTitle>
+			</DialogHeader>
+			<div className="grid gap-4 py-4">
+				<p className="text-sm text-gray-500">設定項目は現在準備中です。</p>
+			</div>
+		</DialogContent>
+	);
+}

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -43,6 +43,7 @@ export const RIGHT_PANEL_TITLE = "Right Panel";
 export const AU_OPTIONS_TITLE = "Au Options";
 export const EXR_OPTIONS_TITLE = "ExR Options";
 export const ROLE_FILTER_TITLE = "Role Filter";
+export const SETTINGS_TITLE = "設定";
 export const AU_SHORT_LABEL = "A";
 export const EXR_SHORT_LABEL = "E";
 export const ROLE_FILTER_SHORT_LABEL = "R";

--- a/src/type.ts
+++ b/src/type.ts
@@ -367,7 +367,15 @@ export interface RoleSelectDialogData {
 	lastClickedId: number | null;
 }
 
-export type BlockDialog = ConfirmDialogData | RoleSelectDialogData;
+export interface SettingsDialogData {
+	type: "settings";
+	title: string;
+}
+
+export type BlockDialog =
+	| ConfirmDialogData
+	| RoleSelectDialogData
+	| SettingsDialogData;
 
 export interface GetTranslationResponse {
 	Key: string | number;

--- a/tests/SettingsButton.test.tsx
+++ b/tests/SettingsButton.test.tsx
@@ -13,15 +13,18 @@ vi.mock("lucide-react", () => ({
 
 describe("OptionGroupToggleSidebar", () => {
 	it("設定ボタンが表示されていること", () => {
+		useStore.setState({ isSidebarOpen: false });
 		render(<OptionGroupToggleSidebar />);
-		const settingsButton = screen.getByTitle(SETTINGS_TITLE);
+		const settingsButton = screen.getByTestId("sidebar-settings-button");
 		expect(settingsButton).toBeDefined();
 		expect(screen.getByTestId("settings-icon")).toBeDefined();
+		expect(settingsButton.getAttribute("title")).toBe(SETTINGS_TITLE);
 	});
 
 	it("設定ボタンをクリックするとダイアログが開くこと", () => {
+		useStore.setState({ isSidebarOpen: false });
 		render(<OptionGroupToggleSidebar />);
-		const settingsButton = screen.getByTitle(SETTINGS_TITLE);
+		const settingsButton = screen.getByTestId("sidebar-settings-button");
 
 		fireEvent.click(settingsButton);
 
@@ -31,19 +34,21 @@ describe("OptionGroupToggleSidebar", () => {
 		expect(state.blockDialog?.title).toBe(SETTINGS_TITLE);
 	});
 
-	it("サイドバーが閉じているとき、設定ボタンのテキストが表示されないこと", () => {
+	it("サイドバーが閉じているとき、設定ボタンのテキストが表示されず、titleが表示されること", () => {
 		useStore.setState({ isSidebarOpen: false });
 		render(<OptionGroupToggleSidebar />);
 
-		const settingsButton = screen.getByTitle(SETTINGS_TITLE);
+		const settingsButton = screen.getByTestId("sidebar-settings-button");
 		expect(settingsButton.textContent).not.toContain(SETTINGS_TITLE);
+		expect(settingsButton.getAttribute("title")).toBe(SETTINGS_TITLE);
 	});
 
-	it("サイドバーが開いているとき、設定ボタンのテキストが表示されること", () => {
+	it("サイドバーが開いているとき、設定ボタンのテキストが表示され、titleが設定されないこと", () => {
 		useStore.setState({ isSidebarOpen: true });
 		render(<OptionGroupToggleSidebar />);
 
-		const settingsButton = screen.getByTitle(SETTINGS_TITLE);
+		const settingsButton = screen.getByTestId("sidebar-settings-button");
 		expect(settingsButton.textContent).toContain(SETTINGS_TITLE);
+		expect(settingsButton.getAttribute("title")).toBeNull();
 	});
 });

--- a/tests/SettingsButton.test.tsx
+++ b/tests/SettingsButton.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { OptionGroupToggleSidebar } from "@/feature/OptionGroupToggleSidebar";
+import { SETTINGS_TITLE } from "@/noTrans";
+import { useStore } from "@/useStore";
+
+// Lucideアイコンのモック
+vi.mock("lucide-react", () => ({
+	Settings: () => <div data-testid="settings-icon" />,
+	ChevronLeft: () => <div data-testid="chevron-left-icon" />,
+	ChevronRight: () => <div data-testid="chevron-right-icon" />,
+}));
+
+describe("OptionGroupToggleSidebar", () => {
+	it("設定ボタンが表示されていること", () => {
+		render(<OptionGroupToggleSidebar />);
+		const settingsButton = screen.getByTitle(SETTINGS_TITLE);
+		expect(settingsButton).toBeDefined();
+		expect(screen.getByTestId("settings-icon")).toBeDefined();
+	});
+
+	it("設定ボタンをクリックするとダイアログが開くこと", () => {
+		render(<OptionGroupToggleSidebar />);
+		const settingsButton = screen.getByTitle(SETTINGS_TITLE);
+
+		fireEvent.click(settingsButton);
+
+		const state = useStore.getState();
+		expect(state.blockDialog).toBeDefined();
+		expect(state.blockDialog?.type).toBe("settings");
+		expect(state.blockDialog?.title).toBe(SETTINGS_TITLE);
+	});
+
+	it("サイドバーが閉じているとき、設定ボタンのテキストが表示されないこと", () => {
+		useStore.setState({ isSidebarOpen: false });
+		render(<OptionGroupToggleSidebar />);
+
+		const settingsButton = screen.getByTitle(SETTINGS_TITLE);
+		expect(settingsButton.textContent).not.toContain(SETTINGS_TITLE);
+	});
+
+	it("サイドバーが開いているとき、設定ボタンのテキストが表示されること", () => {
+		useStore.setState({ isSidebarOpen: true });
+		render(<OptionGroupToggleSidebar />);
+
+		const settingsButton = screen.getByTitle(SETTINGS_TITLE);
+		expect(settingsButton.textContent).toContain(SETTINGS_TITLE);
+	});
+});


### PR DESCRIPTION
設定ダイアログを追加しました。
設定を開くボタンは左サイドバーの下部に追加され、歯車アイコンを使用しています。
サイドバーの開閉に合わせて表示が切り替わる（閉じているときはアイコンのみ、開いているときはアイコンとラベル）ように実装しました。
ダイアログ自体は現在はプレースホルダーのテキストを表示する空の状態で、shadcn/uiのDialogと既存のBlockDialogの仕組みを利用しています。

主な変更点:
- 型定義の更新 (SettingsDialogData)
- 日本語定数の追加 (SETTINGS_TITLE)
- 設定ダイアログコンポーネントの新規作成 (SettingsDialog)
- サイドバーへのボタン追加とダイアログ表示の統合
- 関連する単体テストおよびE2Eテストの追加
- Biomeによるコードスタイルの適用

---
*PR created automatically by Jules for task [2898796346154458530](https://jules.google.com/task/2898796346154458530) started by @yukieiji*