### PR TITLE
RoleSelectDialogの役職ピンの高さ修正

### DIFF
--- a/src/components/blocks/RoleGrid.tsx
+++ b/src/components/blocks/RoleGrid.tsx
@@ -68,14 +68,7 @@ export function RoleGrid({
 								/>
 							)}
 						</div>
-						<div className="flex flex-col gap-0.5 overflow-hidden">
-							<span className="truncate">{roleName}</span>
-							{isExcluded && (
-								<span className="text-[9px] text-gray-400 font-normal uppercase tracking-wider">
-									追加済み
-								</span>
-							)}
-						</div>
+						<span className="truncate">{roleName}</span>
 					</button>
 				);
 			})}

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -65,11 +65,12 @@ export function RoleSelectDialog({
 		return { roleId, roleName };
 	});
 
-	const filteredRoles = allRoles
-		.filter(({ roleId }) => !excludeRoleIds.includes(roleId))
-		.filter(({ roleName }) =>
-			roleName.toLowerCase().includes(searchQuery.toLowerCase()),
-		);
+	const excludeSet = new Set(excludeRoleIds);
+	const lowerQuery = searchQuery.toLowerCase();
+	const filteredRoles = allRoles.filter(
+		({ roleId, roleName }) =>
+			!excludeSet.has(roleId) && roleName.toLowerCase().includes(lowerQuery),
+	);
 
 	const handleSelect = (roleId: number, event: React.MouseEvent) => {
 		if (event.shiftKey && lastClickedId !== null) {

--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -65,9 +65,11 @@ export function RoleSelectDialog({
 		return { roleId, roleName };
 	});
 
-	const filteredRoles = allRoles.filter(({ roleName }) =>
-		roleName.toLowerCase().includes(searchQuery.toLowerCase()),
-	);
+	const filteredRoles = allRoles
+		.filter(({ roleId }) => !excludeRoleIds.includes(roleId))
+		.filter(({ roleName }) =>
+			roleName.toLowerCase().includes(searchQuery.toLowerCase()),
+		);
 
 	const handleSelect = (roleId: number, event: React.MouseEvent) => {
 		if (event.shiftKey && lastClickedId !== null) {


### PR DESCRIPTION
RoleSelectDialogにおいて、既に追加されている役職がある場合に「追加済み」というラベルが表示され、その分ボタンの高さが他のボタンとズレる問題が発生していました。

ユーザーの要望に基づき、以下の修正を行いました：
1. `RoleSelectDialog.tsx` にて、`excludeRoleIds` に含まれる役職を `filteredRoles` から除外するようにし、二重に追加できない（かつ表示されない）ようにしました。
2. `RoleGrid.tsx` から「追加済み」ラベルの表示ロジックとそれを包んでいた `flex-col` コンテナを削除しました。これにより、全てのボタンのレイアウトが単一行に統一され、高さが一定になります。

テストを実施し、意図通りに追加済みの役職が表示されないこと、およびラベルが削除されていることを確認しました。

---
*PR created automatically by Jules for task [14820853590039717945](https://jules.google.com/task/14820853590039717945) started by @yukieiji*