### PR TITLE
RoleSelectDialogのレイアウト固定とUX改善

### DIFF
--- a/src/feature/rolefilter/RoleSelectDialog.tsx
+++ b/src/feature/rolefilter/RoleSelectDialog.tsx
@@ -102,7 +102,7 @@ export function RoleSelectDialog({
 	};
 
 	return (
-		<DialogContent className="max-w-5xl h-[min(80vh,600px)]">
+		<DialogContent className="flex flex-col max-w-5xl h-[min(80vh,600px)]">
 			<DialogHeader>
 				<DialogTitle>{title ?? ROLE_SELECT_DEFAULT_TITLE}</DialogTitle>
 			</DialogHeader>
@@ -110,7 +110,7 @@ export function RoleSelectDialog({
 				onChange={setSearchQuery}
 				placeholder={ROLE_SELECT_SEARCH_PLACEHOLDER}
 			/>
-			<div className="-m-4 p-6 overflow-y-scroll flex-1">
+			<div className="flex-1 min-h-0 -m-4 p-6 overflow-y-auto">
 				<RoleGrid items={filteredRoles} onSelect={handleSelect} />
 			</div>
 			<DialogFooter>


### PR DESCRIPTION
RoleSelectDialogで検索を行った際、検索結果の数に応じてダイアログ全体の高さが変わり、検索バーやフッター（閉じるボタン）の位置が上下に動いてしまうUX上の問題を修正しました。

主な変更点：
- DialogContentに`flex flex-col`を追加。
- 役職リストを表示するコンテナに`flex-1`および`min-h-0`を追加し、スクロール可能な領域として固定。
- `overflow-y-scroll`を`overflow-y-auto`に変更し、不要なスクロールバーが表示されないように改善。

これにより、検索結果が少ない場合でもダイアログのサイズと各パーツの位置が一定に保たれるようになりました。

---
*PR created automatically by Jules for task [3220579711513195017](https://jules.google.com/task/3220579711513195017) started by @yukieiji*