### PR TITLE
E2Eテストの役職選択セレクターの修正

### DIFF
--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -98,12 +98,12 @@ test.describe("Role Filter Management", () => {
 
 		// Select a role from the grid
 		// 検索結果が表示されるのを待つ
-		const roleButton = page.getByRole("checkbox", {
+		const roleCheckbox = page.getByRole("checkbox", {
 			name: "Opener",
 			exact: true,
 		});
-		await expect(roleButton).toBeVisible({ timeout: 10000 });
-		await roleButton.click();
+		await expect(roleCheckbox).toBeVisible({ timeout: 10000 });
+		await roleCheckbox.click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// ダイアログが閉じるのを待つ

--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -31,7 +31,7 @@ test.describe("Role Filter Management", () => {
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
 		await expect(page.getByText("フィルター追加: 役職の選択")).toBeVisible();
-		await page.getByRole("button", { name: "Bakary" }).first().click();
+		await page.getByRole("checkbox", { name: "Bakary" }).first().click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// Verify new filter is added
@@ -63,7 +63,7 @@ test.describe("Role Filter Management", () => {
 
 		// Add a new filter first (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
-		await page.getByRole("button", { name: "Bakary" }).first().click();
+		await page.getByRole("checkbox", { name: "Bakary" }).first().click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// ダイアログが閉じるのを待つ
@@ -92,7 +92,7 @@ test.describe("Role Filter Management", () => {
 
 		// Select a role from the grid
 		// 検索結果が表示されるのを待つ
-		const roleButton = page.getByRole("button", {
+		const roleButton = page.getByRole("checkbox", {
 			name: "Opener",
 			exact: true,
 		});
@@ -116,7 +116,7 @@ test.describe("Role Filter Management", () => {
 		const filterList = page.getByRole("list", { name: "Filter List" });
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
-		await page.getByRole("button", { name: "Bakary" }).first().click();
+		await page.getByRole("checkbox", { name: "Bakary" }).first().click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		const lastFilter = filterList.getByRole("listitem").last();

--- a/e2e/role_filter_management.spec.ts
+++ b/e2e/role_filter_management.spec.ts
@@ -31,7 +31,10 @@ test.describe("Role Filter Management", () => {
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
 		await expect(page.getByText("フィルター追加: 役職の選択")).toBeVisible();
-		await page.getByRole("checkbox", { name: "Bakary" }).first().click();
+		await page
+			.getByRole("checkbox", { name: "Bakary", exact: true })
+			.first()
+			.click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// Verify new filter is added
@@ -63,7 +66,10 @@ test.describe("Role Filter Management", () => {
 
 		// Add a new filter first (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
-		await page.getByRole("checkbox", { name: "Bakary" }).first().click();
+		await page
+			.getByRole("checkbox", { name: "Bakary", exact: true })
+			.first()
+			.click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		// ダイアログが閉じるのを待つ
@@ -116,7 +122,10 @@ test.describe("Role Filter Management", () => {
 		const filterList = page.getByRole("list", { name: "Filter List" });
 		// Add a new filter (triggers role selection)
 		await page.getByRole("button", { name: "フィルターを追加" }).click();
-		await page.getByRole("checkbox", { name: "Bakary" }).first().click();
+		await page
+			.getByRole("checkbox", { name: "Bakary", exact: true })
+			.first()
+			.click();
 		await page.getByRole("button", { name: /確定/ }).click();
 
 		const lastFilter = filterList.getByRole("listitem").last();


### PR DESCRIPTION
E2Eテスト `e2e/role_filter_management.spec.ts` において、役職選択のセレクターが `getByRole("button")` となっていたため、テストがタイムアウトしていました。
実際のUI（RoleGridコンポーネント）では `Checkbox` が使用されているため、セレクターを `getByRole("checkbox")` に修正することでテストがパスするようにしました。

---
*PR created automatically by Jules for task [15960270644639653077](https://jules.google.com/task/15960270644639653077) started by @yukieiji*