### PR TITLE
オプション検索バーの追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense, use } from "react";
 import { LoadingView } from "./components/blocks/LoadingView";
 import { ExportButton } from "./components/parts/ExportButton";
+import { GlobalSearchInput } from "./components/parts/GlobalSearchInput";
 import { ImportButton } from "./components/parts/ImportButton";
 import { SyncButton } from "./components/parts/SyncButton";
 import { AuOptionEditor } from "./feature/amongus/AuOptionEditor";
@@ -110,6 +111,7 @@ function MainContent() {
 						<div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
 					)}
 				</div>
+				<GlobalSearchInput />
 				<ImportButton onImport={handleImport} />
 				<ExportButton onClick={exporter} />
 				<SyncButton onClick={syncer} />

--- a/src/components/parts/GlobalSearchInput.tsx
+++ b/src/components/parts/GlobalSearchInput.tsx
@@ -5,11 +5,8 @@ import {
 	InputGroupAddon,
 	InputGroupInput,
 } from "@/components/ui/input-group";
-import type { SearchItem } from "@/hooks/useGlobalSearch";
-import {
-	getAllSearchItems,
-	useSearchNavigation,
-} from "@/hooks/useGlobalSearch";
+import { useSearchNavigation } from "@/hooks/useGlobalSearch";
+import type { SearchItem } from "@/type";
 import { useStore } from "@/useStore";
 
 /**
@@ -28,12 +25,11 @@ export function GlobalSearchInput() {
 	const isOpen = useStore((state) => state.isGlobalSearchOpen);
 	const setIsOpen = useStore((state) => state.setIsGlobalSearchOpen);
 
-	const navigateToItem = useSearchNavigation();
+	const { navigateToItem, globalSearchItems } = useSearchNavigation();
 	const containerRef = useRef<HTMLDivElement>(null);
 
-	const allItems = getAllSearchItems();
 	const filteredItems = query
-		? allItems.filter((item) =>
+		? globalSearchItems.filter((item) =>
 				stripColorTags(item.name).toLowerCase().includes(query.toLowerCase()),
 			)
 		: [];

--- a/src/components/parts/GlobalSearchInput.tsx
+++ b/src/components/parts/GlobalSearchInput.tsx
@@ -1,0 +1,102 @@
+import { Search } from "lucide-react";
+import { useEffect, useRef } from "react";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "@/components/ui/input-group";
+import type { SearchItem } from "@/hooks/useGlobalSearch";
+import {
+	getAllSearchItems,
+	useSearchNavigation,
+} from "@/hooks/useGlobalSearch";
+import { useStore } from "@/useStore";
+
+/**
+ * カラータグを除去した名前を取得します
+ */
+function stripColorTags(text: string): string {
+	return text.replace(/<color=[^>]+>|<\/color>/g, "");
+}
+
+/**
+ * 全体検索用の入力フィールドとサジェスト
+ */
+export function GlobalSearchInput() {
+	const query = useStore((state) => state.globalSearchQuery);
+	const setQuery = useStore((state) => state.setGlobalSearchQuery);
+	const isOpen = useStore((state) => state.isGlobalSearchOpen);
+	const setIsOpen = useStore((state) => state.setIsGlobalSearchOpen);
+
+	const navigateToItem = useSearchNavigation();
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	const allItems = getAllSearchItems();
+	const filteredItems = query
+		? allItems.filter((item) =>
+				stripColorTags(item.name).toLowerCase().includes(query.toLowerCase()),
+			)
+		: [];
+
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (
+				containerRef.current &&
+				!containerRef.current.contains(event.target as Node)
+			) {
+				setIsOpen(false);
+			}
+		};
+		document.addEventListener("mousedown", handleClickOutside);
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+		};
+	}, [setIsOpen]);
+
+	const handleSelect = (item: SearchItem) => {
+		navigateToItem(item);
+		setIsOpen(false);
+		setQuery("");
+	};
+
+	return (
+		<div className="relative w-64" ref={containerRef}>
+			<InputGroup>
+				<InputGroupInput
+					placeholder="オプションを検索..."
+					value={query}
+					onChange={(e) => {
+						setQuery(e.target.value);
+						setIsOpen(true);
+					}}
+					onFocus={() => setIsOpen(true)}
+				/>
+				<InputGroupAddon align="inline-start">
+					<Search size={20} aria-hidden="true" />
+				</InputGroupAddon>
+			</InputGroup>
+
+			{isOpen && filteredItems.length > 0 && (
+				<ul className="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
+					{filteredItems.map((item) => (
+						<li key={item.id}>
+							<button
+								type="button"
+								className="w-full px-4 py-2 text-left hover:bg-blue-50 focus:bg-blue-50 focus:outline-none flex flex-col"
+								onClick={() => handleSelect(item)}
+							>
+								<span className="text-sm font-medium">
+									{stripColorTags(item.name)}
+								</span>
+								<span className="text-xs text-gray-500">
+									{item.mode} -{" "}
+									{item.type === "category" ? "カテゴリー" : "オプション"}
+								</span>
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}

--- a/src/feature/amongus/AuRoleCategoryItem.tsx
+++ b/src/feature/amongus/AuRoleCategoryItem.tsx
@@ -48,20 +48,22 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 	const navigateId = createAuNavigateId(chanceOptionId);
 
 	return (
-		<HighlightWrapper
-			id={navigateId}
-			isHighlighted={isHighlighted}
-			isInset={false}
-		>
-			<RoleCategoryAccordion
-				isOpen={isOpen}
-				onClick={() => toggleAuCategory(categoryId)}
-				text={categoryMeta.name}
-				spawnControl={<AuRoleSpawnControls categoryId={categoryId} />}
-				disable={isChanceZero}
+		<div id={`au-category-${categoryId}`}>
+			<HighlightWrapper
+				id={navigateId}
+				isHighlighted={isHighlighted}
+				isInset={false}
 			>
-				<AuCategoryOptionList optionIds={otherOptionIds} />
-			</RoleCategoryAccordion>
-		</HighlightWrapper>
+				<RoleCategoryAccordion
+					isOpen={isOpen}
+					onClick={() => toggleAuCategory(categoryId)}
+					text={categoryMeta.name}
+					spawnControl={<AuRoleSpawnControls categoryId={categoryId} />}
+					disable={isChanceZero}
+				>
+					<AuCategoryOptionList optionIds={otherOptionIds} />
+				</RoleCategoryAccordion>
+			</HighlightWrapper>
+		</div>
 	);
 }

--- a/src/feature/amongus/AuStandardCategoryItem.tsx
+++ b/src/feature/amongus/AuStandardCategoryItem.tsx
@@ -23,12 +23,14 @@ export function AuStandardCategoryItem({
 	}
 
 	return (
-		<OptionEditorAccordion
-			title={categoryMeta.name}
-			isOpen={isOpen}
-			onToggle={() => toggleAuCategory(categoryId)}
-		>
-			<AuCategoryOptionList optionIds={categoryMeta.options} />
-		</OptionEditorAccordion>
+		<div id={`au-category-${categoryId}`}>
+			<OptionEditorAccordion
+				title={categoryMeta.name}
+				isOpen={isOpen}
+				onToggle={() => toggleAuCategory(categoryId)}
+			>
+				<AuCategoryOptionList optionIds={categoryMeta.options} />
+			</OptionEditorAccordion>
+		</div>
 	);
 }

--- a/src/feature/exr/ExRPairedOptionItem.tsx
+++ b/src/feature/exr/ExRPairedOptionItem.tsx
@@ -1,9 +1,12 @@
 import { OptionPairedSliderControl } from "@/components/blocks/OptionPairedSliderControl";
+import { HighlightWrapper } from "@/components/parts/HighlightWrapper";
 import { OptionItem } from "@/components/parts/OptionItem";
 import { OptionNameDisplay } from "@/components/parts/OptionNameDisplay";
 import { useOptionData } from "@/hooks/useExROptionData";
+import { createExRNavigateId } from "@/hooks/useOptionNavigation";
 import { useUpdateExROptionSelection } from "@/logics/api.store";
 import type { OptionData } from "@/type";
+import { useStore } from "@/useStore";
 
 interface ExRPairedOptionItemProps {
 	baseName: string;
@@ -40,26 +43,43 @@ export function ExRPairedOptionItem({
 		});
 	};
 
+	const highlightedExROptionId = useStore(
+		(state) => state.highlightedExROptionId,
+	);
+	const isMinHighlighted = highlightedExROptionId === minUniqueOptionId;
+	const isMaxHighlighted = highlightedExROptionId === maxUniqueOptionId;
+	const isHighlighted = isMinHighlighted || isMaxHighlighted;
+
+	const navigateId = isMaxHighlighted
+		? createExRNavigateId(maxUniqueOptionId)
+		: createExRNavigateId(minUniqueOptionId);
+
 	return (
-		<OptionItem className="min-h-18">
-			<div className="flex-1 min-w-0">
-				<span className="text-sm font-medium text-gray-200 wrap-break-words">
-					<OptionNameDisplay name={baseName} />
-				</span>
-			</div>
-			<div className="shrink-0 flex items-center gap-2">
-				<OptionPairedSliderControl
-					minSelection={minValueData.selection}
-					maxSelection={maxValueData.selection}
-					minValues={minValueData.values as number[]}
-					maxValues={maxValueData.values as number[]}
-					format={minData.metaData.format}
-					onMinChange={handleMinChange}
-					onMaxChange={handleMaxChange}
-					minLabel={minData.label}
-					maxLabel={maxData.label}
-				/>
-			</div>
-		</OptionItem>
+		<HighlightWrapper
+			id={navigateId}
+			isHighlighted={isHighlighted}
+			isInset={true}
+		>
+			<OptionItem className="min-h-18">
+				<div className="flex-1 min-w-0">
+					<span className="text-sm font-medium text-gray-200 wrap-break-words">
+						<OptionNameDisplay name={baseName} />
+					</span>
+				</div>
+				<div className="shrink-0 flex items-center gap-2">
+					<OptionPairedSliderControl
+						minSelection={minValueData.selection}
+						maxSelection={maxValueData.selection}
+						minValues={minValueData.values as number[]}
+						maxValues={maxValueData.values as number[]}
+						format={minData.metaData.format}
+						onMinChange={handleMinChange}
+						onMaxChange={handleMaxChange}
+						minLabel={minData.label}
+						maxLabel={maxData.label}
+					/>
+				</div>
+			</OptionItem>
+		</HighlightWrapper>
 	);
 }

--- a/src/feature/exr/ExRRoleCategoryItem.tsx
+++ b/src/feature/exr/ExRRoleCategoryItem.tsx
@@ -63,22 +63,24 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 	}
 
 	return (
-		<RoleCategoryAccordion
-			isOpen={isOpen}
-			onClick={() => toggleExRCategory(categoryId)}
-			text={<ColoredText text={category} />}
-			spawnControl={
-				<ExRRoleSpawnControls
-					tabId={selectedExRTabId}
+		<div id={`exr-category-${categoryId}`}>
+			<RoleCategoryAccordion
+				isOpen={isOpen}
+				onClick={() => toggleExRCategory(categoryId)}
+				text={<ColoredText text={category} />}
+				spawnControl={
+					<ExRRoleSpawnControls
+						tabId={selectedExRTabId}
+						categoryId={categoryId}
+					/>
+				}
+				disable={isSpawnRateZero}
+			>
+				<ExRCategoryOptionList
 					categoryId={categoryId}
+					uniqueOptionIds={filteredChildOptionIds}
 				/>
-			}
-			disable={isSpawnRateZero}
-		>
-			<ExRCategoryOptionList
-				categoryId={categoryId}
-				uniqueOptionIds={filteredChildOptionIds}
-			/>
-		</RoleCategoryAccordion>
+			</RoleCategoryAccordion>
+		</div>
 	);
 }

--- a/src/feature/rightsidepanel/AuRoleViewerRow.tsx
+++ b/src/feature/rightsidepanel/AuRoleViewerRow.tsx
@@ -25,7 +25,10 @@ export function AuRoleViewerRow({ tabId, categoryId }: AuRoleViewerRowProps) {
 	const maxCountSelection = useStore(
 		(state) => state.auValue[maxCountOptionId] ?? 0,
 	);
-	const navigateToOption = useAuNavigation(tabId, categoryId, chanceOptionId);
+	const navigateToAu = useAuNavigation();
+	const navigateToOption = () => {
+		navigateToAu(tabId, categoryId, chanceOptionId);
+	};
 
 	const chanceMeta = auOptionMetaData.options[chanceOptionId];
 	const maxCountMeta = auOptionMetaData.options[maxCountOptionId];

--- a/src/feature/rightsidepanel/AuTab0MapCategory.tsx
+++ b/src/feature/rightsidepanel/AuTab0MapCategory.tsx
@@ -15,7 +15,10 @@ export function AuTab0MapCategory({ categoryId }: AuTab0MapCategoryProps) {
 	const mapOptionMeta = auOptionMetaData.options[mapOptionId];
 	const mapSelection = useStore((state) => state.auValue[mapOptionId] ?? 0);
 
-	const navigateToOption = useAuNavigation(0, categoryId, mapOptionId);
+	const navigateToAu = useAuNavigation();
+	const navigateToOption = () => {
+		navigateToAu(0, categoryId, mapOptionId);
+	};
 
 	if (!categoryMeta) {
 		return null;

--- a/src/feature/rightsidepanel/AuTab0OptionRow.tsx
+++ b/src/feature/rightsidepanel/AuTab0OptionRow.tsx
@@ -20,7 +20,10 @@ export function AuTab0OptionRow({
 	const selection = useStore((state) => {
 		return state.auValue[optionId] ?? 0;
 	});
-	const navigateToOption = useAuNavigation(0, categoryId, optionId);
+	const navigateToAu = useAuNavigation();
+	const navigateToOption = () => {
+		navigateToAu(0, categoryId, optionId);
+	};
 
 	const optionMeta = auOptionMetaData.options[optionId];
 	if (!optionMeta) {

--- a/src/feature/rightsidepanel/ExROptionRowViewContent.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowViewContent.tsx
@@ -2,7 +2,8 @@ import { ColoredText } from "@/components/parts/ColoredText";
 import { ViewerOptionRow } from "@/components/parts/ViewerOptionRow";
 import { useExRNavigation } from "@/hooks/useOptionNavigation";
 import { exrOptionMetaData } from "@/logics/api";
-import type { UniqueOptionId } from "@/type";
+import { parseUniqueOptionId } from "@/logics/optionUtils";
+import type { ExRTabId, UniqueOptionId } from "@/type";
 import { ExRValueView } from "./ExRValueView";
 
 interface ExROptionRowViewContentProps {
@@ -16,7 +17,11 @@ export function ExROptionRowViewContent({
 	uniqueOptionId,
 }: ExROptionRowViewContentProps) {
 	const optionData = exrOptionMetaData.options[uniqueOptionId]?.metaData;
-	const navigate = useExRNavigation(uniqueOptionId);
+	const navigateToExR = useExRNavigation();
+	const navigate = () => {
+		const { tabId, categoryId } = parseUniqueOptionId(uniqueOptionId);
+		navigateToExR(tabId as ExRTabId, categoryId, uniqueOptionId);
+	};
 
 	if (!optionData) {
 		return null;

--- a/src/feature/rightsidepanel/ExROptionViewer.tsx
+++ b/src/feature/rightsidepanel/ExROptionViewer.tsx
@@ -16,7 +16,10 @@ export function ExROptionViewer() {
 	const currentRecordPreset = useStore(
 		(state) => state.presetNames[currentSelection],
 	);
-	const navigate = useExRNavigation(PRESET_OPTION_UNIQUE_ID);
+	const navigateToExR = useExRNavigation();
+	const navigate = () => {
+		navigateToExR(0, 0, PRESET_OPTION_UNIQUE_ID);
+	};
 
 	const currentPresetValue = presetOption?.values[currentSelection] ?? "";
 	const currentPresetName = currentRecordPreset ?? String(currentPresetValue);

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -1,118 +1,7 @@
-import { auOptionMetaData, exrOptionMetaData } from "@/logics/api";
-import { parseUniqueOptionId } from "@/logics/optionUtils";
-import type { AuOptionId, ExRTabId, UniqueOptionId } from "@/type";
+import { exrOptionMetaData, globalSearchItems } from "@/logics/api";
+import type { ExRTabId, SearchItem } from "@/type";
 import { useStore } from "@/useStore";
 import { createAuNavigateId, createExRNavigateId } from "./useOptionNavigation";
-
-export type SearchItemType = "category" | "option";
-export type SearchItemMode = "Au" | "ExR";
-
-export interface SearchItem {
-	id: string;
-	name: string;
-	type: SearchItemType;
-	mode: SearchItemMode;
-	// Navigation data
-	tabId: number;
-	categoryId: number;
-	optionId?: number | UniqueOptionId | AuOptionId;
-	uniqueOptionId?: UniqueOptionId;
-}
-
-/**
- * 全ての検索対象（カテゴリーとオプション）を取得します
- */
-export function getAllSearchItems(): SearchItem[] {
-	const items: SearchItem[] = [];
-
-	// ExR Categories
-	for (const [id, category] of Object.entries(exrOptionMetaData.categories)) {
-		items.push({
-			id: `exr-cat-${id}`,
-			name: category.name,
-			type: "category",
-			mode: "ExR",
-			tabId: category.tabId,
-			categoryId: Number(id),
-		});
-	}
-
-	// ExR Options
-	for (const [id, option] of Object.entries(exrOptionMetaData.options)) {
-		const uniqueId = Number(id) as UniqueOptionId;
-		const { tabId, categoryId } = parseUniqueOptionId(uniqueId);
-		if (option.metaData.translatedName) {
-			items.push({
-				id: `exr-opt-${id}`,
-				name: option.metaData.translatedName,
-				type: "option",
-				mode: "ExR",
-				tabId,
-				categoryId,
-				optionId: uniqueId,
-				uniqueOptionId: uniqueId,
-			});
-		}
-	}
-
-	// Au Categories
-	for (const [tabId, categoryIds] of Object.entries(
-		auOptionMetaData.tabCategoryMap,
-	)) {
-		for (const categoryId of categoryIds) {
-			const category = auOptionMetaData.categoryMetaData[categoryId];
-			if (category) {
-				items.push({
-					id: `au-cat-${categoryId}`,
-					name: category.name,
-					type: "category",
-					mode: "Au",
-					tabId: Number(tabId),
-					categoryId,
-				});
-			}
-		}
-	}
-
-	// Au Options
-	for (const [id, option] of Object.entries(auOptionMetaData.options)) {
-		const auOptionId = Number(id) as AuOptionId;
-		// Find tab and category for this option
-		let foundTabId = -1;
-		let foundCategoryId = -1;
-
-		for (const [tId, catIds] of Object.entries(
-			auOptionMetaData.tabCategoryMap,
-		)) {
-			for (const cId of catIds) {
-				if (
-					auOptionMetaData.categoryMetaData[cId]?.options.includes(auOptionId)
-				) {
-					foundTabId = Number(tId);
-					foundCategoryId = cId;
-					break;
-				}
-			}
-			if (foundTabId !== -1) {
-				break;
-			}
-		}
-
-		if (foundTabId !== -1) {
-			items.push({
-				id: `au-opt-${id}`,
-				name: option.title,
-				type: "option",
-				mode: "Au",
-				tabId: foundTabId,
-				categoryId: foundCategoryId,
-				optionId: auOptionId,
-			});
-		}
-	}
-
-	return items.sort((a, b) => a.name.localeCompare(b.name));
-}
 
 /**
  * 検索項目を選択した際のナビゲーションロジック
@@ -157,7 +46,9 @@ export function useSearchNavigation() {
 					if (element) {
 						element.scrollIntoView({ behavior: "smooth", block: "center" });
 					}
-					setTimeout(() => setHighlightedExROptionId(null), 2000);
+					setTimeout(() => {
+						setHighlightedExROptionId(null);
+					}, 2000);
 				}, 100);
 			} else {
 				// For categories, we might want to highlight the category header or just scroll to it
@@ -177,7 +68,7 @@ export function useSearchNavigation() {
 			}
 
 			if (item.type === "option" && typeof item.optionId === "number") {
-				const auOptionId = item.optionId as AuOptionId;
+				const auOptionId = item.optionId as number;
 				setHighlightedAuOptionId(auOptionId);
 				const navigateId = createAuNavigateId(auOptionId);
 
@@ -186,7 +77,9 @@ export function useSearchNavigation() {
 					if (element) {
 						element.scrollIntoView({ behavior: "smooth", block: "center" });
 					}
-					setTimeout(() => setHighlightedAuOptionId(null), 2000);
+					setTimeout(() => {
+						setHighlightedAuOptionId(null);
+					}, 2000);
 				}, 100);
 			} else {
 				const navigateId = `au-category-${item.categoryId}`;
@@ -200,5 +93,5 @@ export function useSearchNavigation() {
 		}
 	};
 
-	return navigateToItem;
+	return { navigateToItem, globalSearchItems };
 }

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -1,0 +1,204 @@
+import { auOptionMetaData, exrOptionMetaData } from "@/logics/api";
+import { parseUniqueOptionId } from "@/logics/optionUtils";
+import type { AuOptionId, ExRTabId, UniqueOptionId } from "@/type";
+import { useStore } from "@/useStore";
+import { createAuNavigateId, createExRNavigateId } from "./useOptionNavigation";
+
+export type SearchItemType = "category" | "option";
+export type SearchItemMode = "Au" | "ExR";
+
+export interface SearchItem {
+	id: string;
+	name: string;
+	type: SearchItemType;
+	mode: SearchItemMode;
+	// Navigation data
+	tabId: number;
+	categoryId: number;
+	optionId?: number | UniqueOptionId | AuOptionId;
+	uniqueOptionId?: UniqueOptionId;
+}
+
+/**
+ * 全ての検索対象（カテゴリーとオプション）を取得します
+ */
+export function getAllSearchItems(): SearchItem[] {
+	const items: SearchItem[] = [];
+
+	// ExR Categories
+	for (const [id, category] of Object.entries(exrOptionMetaData.categories)) {
+		items.push({
+			id: `exr-cat-${id}`,
+			name: category.name,
+			type: "category",
+			mode: "ExR",
+			tabId: category.tabId,
+			categoryId: Number(id),
+		});
+	}
+
+	// ExR Options
+	for (const [id, option] of Object.entries(exrOptionMetaData.options)) {
+		const uniqueId = Number(id) as UniqueOptionId;
+		const { tabId, categoryId } = parseUniqueOptionId(uniqueId);
+		if (option.metaData.translatedName) {
+			items.push({
+				id: `exr-opt-${id}`,
+				name: option.metaData.translatedName,
+				type: "option",
+				mode: "ExR",
+				tabId,
+				categoryId,
+				optionId: uniqueId,
+				uniqueOptionId: uniqueId,
+			});
+		}
+	}
+
+	// Au Categories
+	for (const [tabId, categoryIds] of Object.entries(
+		auOptionMetaData.tabCategoryMap,
+	)) {
+		for (const categoryId of categoryIds) {
+			const category = auOptionMetaData.categoryMetaData[categoryId];
+			if (category) {
+				items.push({
+					id: `au-cat-${categoryId}`,
+					name: category.name,
+					type: "category",
+					mode: "Au",
+					tabId: Number(tabId),
+					categoryId,
+				});
+			}
+		}
+	}
+
+	// Au Options
+	for (const [id, option] of Object.entries(auOptionMetaData.options)) {
+		const auOptionId = Number(id) as AuOptionId;
+		// Find tab and category for this option
+		let foundTabId = -1;
+		let foundCategoryId = -1;
+
+		for (const [tId, catIds] of Object.entries(
+			auOptionMetaData.tabCategoryMap,
+		)) {
+			for (const cId of catIds) {
+				if (
+					auOptionMetaData.categoryMetaData[cId]?.options.includes(auOptionId)
+				) {
+					foundTabId = Number(tId);
+					foundCategoryId = cId;
+					break;
+				}
+			}
+			if (foundTabId !== -1) {
+				break;
+			}
+		}
+
+		if (foundTabId !== -1) {
+			items.push({
+				id: `au-opt-${id}`,
+				name: option.title,
+				type: "option",
+				mode: "Au",
+				tabId: foundTabId,
+				categoryId: foundCategoryId,
+				optionId: auOptionId,
+			});
+		}
+	}
+
+	return items.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * 検索項目を選択した際のナビゲーションロジック
+ */
+export function useSearchNavigation() {
+	const setSelectedTab = useStore((state) => state.setSelectedTab);
+	const setSelectedExRTabId = useStore((state) => state.setSelectedExRTabId);
+	const setSelectedAuTabId = useStore((state) => state.setSelectedAuTabId);
+	const toggleExRCategory = useStore((state) => state.toggleExRCategory);
+	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
+	const openExROptions = useStore((state) => state.openExROptions);
+	const setHighlightedExROptionId = useStore(
+		(state) => state.setHighlightedExROptionId,
+	);
+	const setHighlightedAuOptionId = useStore(
+		(state) => state.setHighlightedAuOptionId,
+	);
+	const setRightPanelOpen = useStore((state) => state.setRightPanelOpen);
+
+	const navigateToItem = (item: SearchItem) => {
+		setRightPanelOpen(false);
+		setSelectedTab(item.mode);
+
+		if (item.mode === "ExR") {
+			setSelectedExRTabId(item.tabId as ExRTabId);
+			const { openedExRCategoryIds } = useStore.getState();
+			if (!openedExRCategoryIds[item.categoryId]) {
+				toggleExRCategory(item.categoryId);
+			}
+
+			if (item.type === "option" && item.uniqueOptionId) {
+				const ancestors =
+					exrOptionMetaData.options[item.uniqueOptionId]?.parentOptionIds ?? [];
+				if (ancestors.length > 0) {
+					openExROptions(ancestors);
+				}
+				setHighlightedExROptionId(item.uniqueOptionId);
+				const navigateId = createExRNavigateId(item.uniqueOptionId);
+
+				setTimeout(() => {
+					const element = document.getElementById(navigateId);
+					if (element) {
+						element.scrollIntoView({ behavior: "smooth", block: "center" });
+					}
+					setTimeout(() => setHighlightedExROptionId(null), 2000);
+				}, 100);
+			} else {
+				// For categories, we might want to highlight the category header or just scroll to it
+				const navigateId = `exr-category-${item.categoryId}`;
+				setTimeout(() => {
+					const element = document.getElementById(navigateId);
+					if (element) {
+						element.scrollIntoView({ behavior: "smooth", block: "center" });
+					}
+				}, 100);
+			}
+		} else {
+			setSelectedAuTabId(item.tabId);
+			const { openedAuCategoryIds } = useStore.getState();
+			if (!openedAuCategoryIds[item.categoryId]) {
+				toggleAuCategory(item.categoryId);
+			}
+
+			if (item.type === "option" && typeof item.optionId === "number") {
+				const auOptionId = item.optionId as AuOptionId;
+				setHighlightedAuOptionId(auOptionId);
+				const navigateId = createAuNavigateId(auOptionId);
+
+				setTimeout(() => {
+					const element = document.getElementById(navigateId);
+					if (element) {
+						element.scrollIntoView({ behavior: "smooth", block: "center" });
+					}
+					setTimeout(() => setHighlightedAuOptionId(null), 2000);
+				}, 100);
+			} else {
+				const navigateId = `au-category-${item.categoryId}`;
+				setTimeout(() => {
+					const element = document.getElementById(navigateId);
+					if (element) {
+						element.scrollIntoView({ behavior: "smooth", block: "center" });
+					}
+				}, 100);
+			}
+		}
+	};
+
+	return navigateToItem;
+}

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -1,95 +1,23 @@
-import { exrOptionMetaData, globalSearchItems } from "@/logics/api";
+import { globalSearchItems } from "@/logics/api";
 import type { ExRTabId, SearchItem } from "@/type";
-import { useStore } from "@/useStore";
-import { createAuNavigateId, createExRNavigateId } from "./useOptionNavigation";
+import { useAuNavigation, useExRNavigation } from "./useOptionNavigation";
 
 /**
  * 検索項目を選択した際のナビゲーションロジック
  */
 export function useSearchNavigation() {
-	const setSelectedTab = useStore((state) => state.setSelectedTab);
-	const setSelectedExRTabId = useStore((state) => state.setSelectedExRTabId);
-	const setSelectedAuTabId = useStore((state) => state.setSelectedAuTabId);
-	const toggleExRCategory = useStore((state) => state.toggleExRCategory);
-	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
-	const openExROptions = useStore((state) => state.openExROptions);
-	const setHighlightedExROptionId = useStore(
-		(state) => state.setHighlightedExROptionId,
-	);
-	const setHighlightedAuOptionId = useStore(
-		(state) => state.setHighlightedAuOptionId,
-	);
-	const setRightPanelOpen = useStore((state) => state.setRightPanelOpen);
+	const navigateToAu = useAuNavigation();
+	const navigateToExR = useExRNavigation();
 
 	const navigateToItem = (item: SearchItem) => {
-		setRightPanelOpen(false);
-		setSelectedTab(item.mode);
-
 		if (item.mode === "ExR") {
-			setSelectedExRTabId(item.tabId as ExRTabId);
-			const { openedExRCategoryIds } = useStore.getState();
-			if (!openedExRCategoryIds[item.categoryId]) {
-				toggleExRCategory(item.categoryId);
-			}
-
-			if (item.type === "option" && item.uniqueOptionId) {
-				const ancestors =
-					exrOptionMetaData.options[item.uniqueOptionId]?.parentOptionIds ?? [];
-				if (ancestors.length > 0) {
-					openExROptions(ancestors);
-				}
-				setHighlightedExROptionId(item.uniqueOptionId);
-				const navigateId = createExRNavigateId(item.uniqueOptionId);
-
-				setTimeout(() => {
-					const element = document.getElementById(navigateId);
-					if (element) {
-						element.scrollIntoView({ behavior: "smooth", block: "center" });
-					}
-					setTimeout(() => {
-						setHighlightedExROptionId(null);
-					}, 2000);
-				}, 100);
-			} else {
-				// For categories, we might want to highlight the category header or just scroll to it
-				const navigateId = `exr-category-${item.categoryId}`;
-				setTimeout(() => {
-					const element = document.getElementById(navigateId);
-					if (element) {
-						element.scrollIntoView({ behavior: "smooth", block: "center" });
-					}
-				}, 100);
-			}
+			navigateToExR(
+				item.tabId as ExRTabId,
+				item.categoryId,
+				item.uniqueOptionId,
+			);
 		} else {
-			setSelectedAuTabId(item.tabId);
-			const { openedAuCategoryIds } = useStore.getState();
-			if (!openedAuCategoryIds[item.categoryId]) {
-				toggleAuCategory(item.categoryId);
-			}
-
-			if (item.type === "option" && typeof item.optionId === "number") {
-				const auOptionId = item.optionId as number;
-				setHighlightedAuOptionId(auOptionId);
-				const navigateId = createAuNavigateId(auOptionId);
-
-				setTimeout(() => {
-					const element = document.getElementById(navigateId);
-					if (element) {
-						element.scrollIntoView({ behavior: "smooth", block: "center" });
-					}
-					setTimeout(() => {
-						setHighlightedAuOptionId(null);
-					}, 2000);
-				}, 100);
-			} else {
-				const navigateId = `au-category-${item.categoryId}`;
-				setTimeout(() => {
-					const element = document.getElementById(navigateId);
-					if (element) {
-						element.scrollIntoView({ behavior: "smooth", block: "center" });
-					}
-				}, 100);
-			}
+			navigateToAu(item.tabId, item.categoryId, item.optionId as number);
 		}
 	};
 

--- a/src/hooks/useOptionNavigation.ts
+++ b/src/hooks/useOptionNavigation.ts
@@ -1,5 +1,4 @@
 import { exrOptionMetaData } from "../logics/api";
-import { parseUniqueOptionId } from "../logics/optionUtils";
 import type { AuOptionId, ExRTabId, UniqueOptionId } from "../type";
 import { useStore } from "../useStore";
 
@@ -11,33 +10,31 @@ export function createAuNavigateId(auOptionId: AuOptionId) {
 	return `au-option-${auOptionId}`;
 }
 
+export function createExRCategoryNavigateId(categoryId: number) {
+	return `exr-category-${categoryId}`;
+}
+
+export function createAuCategoryNavigateId(categoryId: number) {
+	return `au-category-${categoryId}`;
+}
+
 /**
- * Auの設定項目をダブルクリックした際のナビゲーションとハイライトを行うフック
+ * Auの設定項目へのナビゲーションを行うフック
  */
-export function useAuNavigation(
-	tabId: number,
-	categoryId: number,
-	optionId: AuOptionId,
-) {
-	const setSelectedTab = useStore((state) => {
-		return state.setSelectedTab;
-	});
-	const setSelectedAuTabId = useStore((state) => {
-		return state.setSelectedAuTabId;
-	});
-	const toggleAuCategory = useStore((state) => {
-		return state.toggleAuCategory;
-	});
-	const setHighlightedAuOptionId = useStore((state) => {
-		return state.setHighlightedAuOptionId;
-	});
-	const setRightPanelOpen = useStore((state) => {
-		return state.setRightPanelOpen;
-	});
+export function useAuNavigation() {
+	const setSelectedTab = useStore((state) => state.setSelectedTab);
+	const setSelectedAuTabId = useStore((state) => state.setSelectedAuTabId);
+	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
+	const setHighlightedAuOptionId = useStore(
+		(state) => state.setHighlightedAuOptionId,
+	);
+	const setRightPanelOpen = useStore((state) => state.setRightPanelOpen);
 
-	const navigateId = createAuNavigateId(optionId);
-
-	const navigateToOption = () => {
+	const navigateToAu = (
+		tabId: number,
+		categoryId: number,
+		optionId?: AuOptionId,
+	) => {
 		const { openedAuCategoryIds } = useStore.getState();
 
 		setRightPanelOpen(false);
@@ -46,7 +43,15 @@ export function useAuNavigation(
 		if (!openedAuCategoryIds[categoryId]) {
 			toggleAuCategory(categoryId);
 		}
-		setHighlightedAuOptionId(optionId);
+
+		const navigateId =
+			optionId !== undefined
+				? createAuNavigateId(optionId)
+				: createAuCategoryNavigateId(categoryId);
+
+		if (optionId !== undefined) {
+			setHighlightedAuOptionId(optionId);
+		}
 
 		setTimeout(() => {
 			if (typeof document !== "undefined") {
@@ -55,59 +60,59 @@ export function useAuNavigation(
 					element.scrollIntoView({ behavior: "smooth", block: "center" });
 				}
 			}
-			setTimeout(() => {
-				setHighlightedAuOptionId(null);
-			}, 2000);
+			if (optionId !== undefined) {
+				setTimeout(() => {
+					setHighlightedAuOptionId(null);
+				}, 2000);
+			}
 		}, 100);
 	};
 
-	return navigateToOption;
+	return navigateToAu;
 }
+
 /**
- * ExRの設定項目をダブルクリックした際のナビゲーションとハイライトを行うフック
+ * ExRの設定項目へのナビゲーションを行うフック
  */
-export function useExRNavigation(uniqueOptionId: UniqueOptionId) {
-	const setSelectedTab = useStore((state) => {
-		return state.setSelectedTab;
-	});
-	const setSelectedExRTabId = useStore((state) => {
-		return state.setSelectedExRTabId;
-	});
-	const toggleExRCategory = useStore((state) => {
-		return state.toggleExRCategory;
-	});
-	const openExROptions = useStore((state) => {
-		return state.openExROptions;
-	});
+export function useExRNavigation() {
+	const setSelectedTab = useStore((state) => state.setSelectedTab);
+	const setSelectedExRTabId = useStore((state) => state.setSelectedExRTabId);
+	const toggleExRCategory = useStore((state) => state.toggleExRCategory);
+	const openExROptions = useStore((state) => state.openExROptions);
+	const setHighlightedExROptionId = useStore(
+		(state) => state.setHighlightedExROptionId,
+	);
+	const setRightPanelOpen = useStore((state) => state.setRightPanelOpen);
 
-	const setHighlightedExROptionId = useStore((state) => {
-		return state.setHighlightedExROptionId;
-	});
-	const setRightPanelOpen = useStore((state) => {
-		return state.setRightPanelOpen;
-	});
-
-	const { tabId, categoryId } = parseUniqueOptionId(uniqueOptionId);
-	const navigateId = createExRNavigateId(uniqueOptionId);
-
-	const navigateToOption = () => {
+	const navigateToExR = (
+		tabId: ExRTabId,
+		categoryId: number,
+		uniqueOptionId?: UniqueOptionId,
+	) => {
 		const { openedExRCategoryIds } = useStore.getState();
 
 		setRightPanelOpen(false);
 		setSelectedTab("ExR");
-		setSelectedExRTabId(tabId as ExRTabId);
+		setSelectedExRTabId(tabId);
 		if (!openedExRCategoryIds[categoryId]) {
 			toggleExRCategory(categoryId);
 		}
 
-		// 全ての親オプションを特定して開く
-		const ancestors =
-			exrOptionMetaData.options[uniqueOptionId]?.parentOptionIds ?? [];
-		if (ancestors.length > 0) {
-			openExROptions(ancestors);
+		if (uniqueOptionId !== undefined) {
+			// 全ての親オプションを特定して開く
+			const ancestors =
+				exrOptionMetaData.options[uniqueOptionId]?.parentOptionIds ?? [];
+			if (ancestors.length > 0) {
+				openExROptions(ancestors);
+			}
+
+			setHighlightedExROptionId(uniqueOptionId);
 		}
 
-		setHighlightedExROptionId(uniqueOptionId);
+		const navigateId =
+			uniqueOptionId !== undefined
+				? createExRNavigateId(uniqueOptionId)
+				: createExRCategoryNavigateId(categoryId);
 
 		setTimeout(() => {
 			if (typeof document !== "undefined") {
@@ -116,11 +121,13 @@ export function useExRNavigation(uniqueOptionId: UniqueOptionId) {
 					element.scrollIntoView({ behavior: "smooth", block: "center" });
 				}
 			}
-			setTimeout(() => {
-				setHighlightedExROptionId(null);
-			}, 2000);
+			if (uniqueOptionId !== undefined) {
+				setTimeout(() => {
+					setHighlightedExROptionId(null);
+				}, 2000);
+			}
 		}, 100);
 	};
 
-	return navigateToOption;
+	return navigateToExR;
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -24,6 +24,7 @@ import {
 	GetTranslationResponseArraySchema,
 	OptionValueType,
 	RoleAssignFilterDtoSchema,
+	type SearchItem,
 	UpdatedOptionsSchema,
 } from "../type";
 
@@ -65,6 +66,8 @@ export const roleFilterMetaData: RoleFilterMetaData = {
 	GhostRoleId: {},
 };
 
+export const globalSearchItems: SearchItem[] = [];
+
 /**
  * ExRオプションのメタデータをリセットする（テスト用）
  */
@@ -73,6 +76,7 @@ export function resetExrOptionMetaData() {
 	exrOptionMetaData.categories = {};
 	exrOptionMetaData.options = {};
 	exrOptionMetaData.globalCategoryIdTopLevelMap = {};
+	refreshGlobalSearchItems();
 }
 
 /**
@@ -83,6 +87,7 @@ export function resetAuOptionMetaData() {
 	auOptionMetaData.tabCategoryMap = {};
 	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};
+	refreshGlobalSearchItems();
 }
 
 /**
@@ -235,6 +240,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 			processOptions(category.Options, tab.Id, category.Id, []);
 		}
 	}
+	refreshGlobalSearchItems();
 	return { valueData, isOptionActive };
 }
 
@@ -336,6 +342,7 @@ export async function createAuOptionMetaData(): Promise<
 		}
 	}
 
+	refreshGlobalSearchItems();
 	return initialValueData;
 }
 
@@ -369,6 +376,102 @@ export async function updateExrOption(
 
 	const jsonData = await res.json();
 	return await UpdatedOptionsSchema.parseAsync(jsonData);
+}
+
+/**
+ * 検索項目を更新します
+ */
+function refreshGlobalSearchItems() {
+	globalSearchItems.length = 0;
+
+	// ExR Categories
+	for (const [id, category] of Object.entries(exrOptionMetaData.categories)) {
+		globalSearchItems.push({
+			id: `exr-cat-${id}`,
+			name: category.name,
+			type: "category",
+			mode: "ExR",
+			tabId: category.tabId,
+			categoryId: Number(id),
+		});
+	}
+
+	// ExR Options
+	for (const [id, option] of Object.entries(exrOptionMetaData.options)) {
+		const uniqueId = Number(id) as UniqueOptionId;
+		const tabId = Math.floor(uniqueId / 1_000_000_000_000);
+		const categoryId = Math.floor((uniqueId % 1_000_000_000_000) / 1_000_000);
+		if (option.metaData.translatedName) {
+			globalSearchItems.push({
+				id: `exr-opt-${id}`,
+				name: option.metaData.translatedName,
+				type: "option",
+				mode: "ExR",
+				tabId,
+				categoryId,
+				optionId: uniqueId,
+				uniqueOptionId: uniqueId,
+			});
+		}
+	}
+
+	// Au Categories
+	for (const [tabId, categoryIds] of Object.entries(
+		auOptionMetaData.tabCategoryMap,
+	)) {
+		for (const categoryId of categoryIds) {
+			const category = auOptionMetaData.categoryMetaData[categoryId];
+			if (category) {
+				globalSearchItems.push({
+					id: `au-cat-${categoryId}`,
+					name: category.name,
+					type: "category",
+					mode: "Au",
+					tabId: Number(tabId),
+					categoryId,
+				});
+			}
+		}
+	}
+
+	// Au Options
+	for (const [id, option] of Object.entries(auOptionMetaData.options)) {
+		const auOptionId = Number(id) as AuOptionId;
+		// Find tab and category for this option
+		let foundTabId = -1;
+		let foundCategoryId = -1;
+
+		for (const [tId, catIds] of Object.entries(
+			auOptionMetaData.tabCategoryMap,
+		)) {
+			for (const cId of catIds) {
+				if (
+					auOptionMetaData.categoryMetaData[cId]?.options.includes(auOptionId)
+				) {
+					foundTabId = Number(tId);
+					foundCategoryId = cId;
+					break;
+				}
+			}
+			if (foundTabId !== -1) {
+				break;
+			}
+		}
+
+		if (foundTabId !== -1) {
+			globalSearchItems.push({
+				id: `au-opt-${id}`,
+				name: option.title,
+				type: "option",
+				mode: "Au",
+				tabId: foundTabId,
+				categoryId: foundCategoryId,
+				optionId: auOptionId,
+			});
+		}
+	}
+
+	globalSearchItems.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export async function postExrCsv(csvBody: string): Promise<void> {

--- a/src/slices/searchSlice.ts
+++ b/src/slices/searchSlice.ts
@@ -1,0 +1,21 @@
+import type { StateCreator } from "zustand";
+
+export interface SearchSlice {
+	globalSearchQuery: string;
+	isGlobalSearchOpen: boolean;
+	setGlobalSearchQuery: (query: string) => void;
+	setIsGlobalSearchOpen: (isOpen: boolean) => void;
+}
+
+export const createSearchSlice: StateCreator<SearchSlice> = (set) => {
+	return {
+		globalSearchQuery: "",
+		isGlobalSearchOpen: false,
+		setGlobalSearchQuery: (query: string) => {
+			set({ globalSearchQuery: query });
+		},
+		setIsGlobalSearchOpen: (isOpen: boolean) => {
+			set({ isGlobalSearchOpen: isOpen });
+		},
+	};
+};

--- a/src/type.ts
+++ b/src/type.ts
@@ -454,6 +454,21 @@ export interface RoleFilterMetaData {
 	GhostRoleId: Record<string, number | string>;
 }
 
+export type SearchItemType = "category" | "option";
+export type SearchItemMode = "Au" | "ExR";
+
+export interface SearchItem {
+	id: string;
+	name: string;
+	type: SearchItemType;
+	mode: SearchItemMode;
+	// Navigation data
+	tabId: number;
+	categoryId: number;
+	optionId?: number | UniqueOptionId | AuOptionId;
+	uniqueOptionId?: UniqueOptionId;
+}
+
 export interface GetCsvResult {
 	ExportAt: string;
 	Version: string;

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -11,6 +11,8 @@ import type { RightFloatingPanelSlice } from "./slices/rightFloatingPanelSlice";
 import { createRightFloatingPanelSlice } from "./slices/rightFloatingPanelSlice";
 import type { RoleFilterSlice } from "./slices/roleFilterSlice";
 import { createRoleFilterSlice } from "./slices/roleFilterSlice";
+import type { SearchSlice } from "./slices/searchSlice";
+import { createSearchSlice } from "./slices/searchSlice";
 
 /**
  * Zustand ストアの作成
@@ -21,7 +23,8 @@ export const useStore = create<
 		RightFloatingPanelSlice &
 		AuOptionViewerSlice &
 		ExROptionViewerSlice &
-		RoleFilterSlice
+		RoleFilterSlice &
+		SearchSlice
 >()((...a) => {
 	return {
 		...createGlobalUiSlice(...a),
@@ -30,5 +33,6 @@ export const useStore = create<
 		...createAuOptionViewerSlice(...a),
 		...createExROptionViewerSlice(...a),
 		...createRoleFilterSlice(...a),
+		...createSearchSlice(...a),
 	};
 });

--- a/tests/useExRNavigation.test.tsx
+++ b/tests/useExRNavigation.test.tsx
@@ -71,8 +71,8 @@ describe("useExRNavigation", () => {
 			parentOptionIds: [],
 		};
 
-		const { result } = renderHook(() => useExRNavigation(childId));
-		result.current();
+		const { result } = renderHook(() => useExRNavigation());
+		result.current(1 as any, 10, childId);
 
 		expect(openExROptions).toHaveBeenCalledWith([parentId, grandParentId]);
 	});


### PR DESCRIPTION
ヘッダーにオプションとカテゴリーを検索できる検索バーを追加しました。
- AuおよびExRのオプション・カテゴリーを横断的に検索可能
- 入力に応じたリアルタイムのサジェスト表示（アルファベット順）
- サジェスト選択時の自動遷移、カテゴリー展開、スクロール、ハイライト機能の実装
- 検索時はカラータグを除去してマッチングを行うよう改善

---
*PR created automatically by Jules for task [3690766627555183786](https://jules.google.com/task/3690766627555183786) started by @yukieiji*