### PR TITLE
Refactor CompactSlider to use shadcn/ui components

### DIFF
--- a/src/components/blocks/OptionSingleSlider.tsx
+++ b/src/components/blocks/OptionSingleSlider.tsx
@@ -1,7 +1,7 @@
 import { useId } from "react";
 import { findClosestIndex } from "@/logics/optionUtils";
 import { OptionFormat } from "../parts/OptionFormat";
-import { Field } from "../ui/field";
+import { Field, FieldLabel, FieldSet } from "../ui/field";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Slider } from "../ui/slider";
@@ -38,21 +38,19 @@ export function OptionSingleSlider({
 	};
 
 	return (
-		<div className="flex flex-col w-full">
-			<div className="flex items-center justify-between">
-				<Label>{label}</Label>
-				<Field orientation="horizontal">
-					<Input
-						id={id}
-						type="text"
-						value={currentValue}
-						onChange={handleInputChange}
-					/>
-					<Label htmlFor={id}>
-						<OptionFormat format={format} />
-					</Label>
-				</Field>
-			</div>
+		<FieldSet>
+			<Field orientation="horizontal">
+				<FieldLabel htmlFor={id}>{label}</FieldLabel>
+				<Input
+					id={id}
+					type="text"
+					value={currentValue}
+					onChange={handleInputChange}
+				/>
+				<Label htmlFor={id}>
+					<OptionFormat format={format} />
+				</Label>
+			</Field>
 			<Slider
 				min={0}
 				max={values.length - 1}
@@ -62,6 +60,6 @@ export function OptionSingleSlider({
 				aria-label={label}
 				className="cursor-pointer"
 			/>
-		</div>
+		</FieldSet>
 	);
 }

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,4 +1,7 @@
-import type React from "react";
+import React, { useId } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
 
 interface CompactSliderProps {
 	label: string;
@@ -11,8 +14,7 @@ interface CompactSliderProps {
 
 /**
  * カテゴリアコーディオンのヘッダーなどで使用する、コンパクトなスライダーとテキスト入力のセット
- * (純粋なUIコンポーネント)
- * 入力欄はスライダーの上に表示されるようにレイアウト
+ * shadcn/uiベースのコンポーネントを使用
  */
 export function CompactSlider({
 	label,
@@ -22,11 +24,11 @@ export function CompactSlider({
 	onInputChange,
 	testId,
 }: CompactSliderProps) {
+	const id = useId();
 	const currentValue = values[currentSelection] ?? values[0] ?? 0;
 
-	const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		e.stopPropagation();
-		onSelectionChange(parseInt(e.target.value, 10));
+	const handleSliderChange = (val: number | readonly number[]) => {
+		onSelectionChange(Array.isArray(val) ? val[0] : val);
 	};
 
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -37,39 +39,39 @@ export function CompactSlider({
 		}
 	};
 
-	const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-		// アコーディオンの開閉を防ぐ
+	const stopPropagation = (e: React.MouseEvent | React.KeyboardEvent) => {
 		e.stopPropagation();
 	};
 
 	return (
-		<fieldset
-			className="flex flex-col gap-1 px-2 py-1 bg-gray-900/50 rounded border border-gray-700/50 text-left cursor-default"
-			onClick={handleClick}
-			onKeyDown={handleClick}
-			aria-label={label}
+		<div
+			className="flex flex-col gap-2"
+			onClick={stopPropagation}
+			onKeyDown={stopPropagation}
 			data-testid={testId}
+			role="group"
+			aria-label={label}
 		>
-			<div className="flex items-center justify-between gap-2">
-				<span className="text-[10px] font-medium text-gray-400 whitespace-nowrap leading-none">
+			<div className="flex items-center justify-between gap-4">
+				<Label htmlFor={id} className="text-sm font-medium">
 					{label}
-				</span>
-				<input
+				</Label>
+				<Input
+					id={id}
 					type="text"
 					value={currentValue}
 					onChange={handleInputChange}
-					className="w-8 px-0.5 py-0 text-right text-[10px] bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500 leading-none"
+					className="h-8 w-16 px-2 text-right"
 				/>
 			</div>
-			<input
-				type="range"
+			<Slider
 				min={0}
 				max={values.length - 1}
 				step={1}
-				value={currentSelection}
-				onChange={handleSliderChange}
-				className="w-20 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-500"
+				value={[currentSelection]}
+				onValueChange={handleSliderChange}
+				className="cursor-pointer"
 			/>
-		</fieldset>
+		</div>
 	);
 }

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -3,6 +3,7 @@ import { useId } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
+import { Field, FieldLabel, FieldSet } from "../ui/field";
 
 interface CompactSliderProps {
 	label: string;
@@ -45,25 +46,23 @@ export function CompactSlider({
 	};
 
 	return (
-		<fieldset
-			className="flex flex-col gap-2"
+		<FieldSet
 			onClick={stopPropagation}
 			onKeyDown={stopPropagation}
 			data-testid={testId}
 			aria-label={label}
 		>
-			<div className="flex items-center justify-between gap-4">
-				<Label htmlFor={id} className="text-sm font-medium">
+			<Field orientation="horizontal">
+				<FieldLabel htmlFor={id} className="text-sm font-medium">
 					{label}
-				</Label>
+				</FieldLabel>
 				<Input
 					id={id}
 					type="text"
 					value={currentValue}
 					onChange={handleInputChange}
-					className="h-8 w-16 px-2 text-right"
 				/>
-			</div>
+			</Field>
 			<Slider
 				min={0}
 				max={values.length - 1}
@@ -72,6 +71,6 @@ export function CompactSlider({
 				onValueChange={handleSliderChange}
 				className="cursor-pointer"
 			/>
-		</fieldset>
+		</FieldSet>
 	);
 }

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,7 +1,6 @@
 import type React from "react";
 import { useId } from "react";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { Field, FieldLabel, FieldSet } from "../ui/field";
 

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,4 +1,5 @@
-import React, { useId } from "react";
+import type React from "react";
+import { useId } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
@@ -44,12 +45,11 @@ export function CompactSlider({
 	};
 
 	return (
-		<div
+		<fieldset
 			className="flex flex-col gap-2"
 			onClick={stopPropagation}
 			onKeyDown={stopPropagation}
 			data-testid={testId}
-			role="group"
 			aria-label={label}
 		>
 			<div className="flex items-center justify-between gap-4">
@@ -72,6 +72,6 @@ export function CompactSlider({
 				onValueChange={handleSliderChange}
 				className="cursor-pointer"
 			/>
-		</div>
+		</fieldset>
 	);
 }

--- a/tests/CompactSlider.test.tsx
+++ b/tests/CompactSlider.test.tsx
@@ -23,9 +23,9 @@ describe("CompactSlider", () => {
 		await act(async () => {
 			render(<CompactSlider {...defaultProps} />);
 		});
-		const slider = screen.getByRole("slider");
+		const slider = screen.getByRole("slider", { hidden: true });
 		expect(slider).toBeInTheDocument();
-		expect(slider).toHaveValue("1");
+		expect(slider).toHaveAttribute("aria-valuenow", "1");
 	});
 
 	it("calls onSelectionChange when slider value changes", async () => {
@@ -39,7 +39,7 @@ describe("CompactSlider", () => {
 			);
 		});
 
-		const slider = screen.getByRole("slider");
+		const slider = screen.getByRole("slider", { hidden: true });
 		await act(async () => {
 			fireEvent.change(slider, { target: { value: "2" } });
 		});
@@ -76,7 +76,7 @@ describe("CompactSlider", () => {
 			);
 		});
 
-		const slider = screen.getByRole("slider");
+		const slider = screen.getByRole("slider", { hidden: true });
 		await act(async () => {
 			fireEvent.change(slider, { target: { value: "2" } });
 		});
@@ -117,9 +117,9 @@ describe("CompactSlider", () => {
 			);
 		});
 
-		const fieldset = screen.getByRole("group", { name: "Test Slider" });
+		const group = screen.getByRole("group", { name: "Test Slider" });
 		await act(async () => {
-			fireEvent.click(fieldset);
+			fireEvent.click(group);
 		});
 
 		expect(onParentClick).not.toHaveBeenCalled();


### PR DESCRIPTION
The `CompactSlider` component has been refactored to use `shadcn/ui` based components, similar to `OptionSliderControl`. 

Key changes:
- Replaced native `<input type="range">` and `<input type="text">` with `Slider` and `Input` components from `@/components/ui`.
- Updated the layout to use `Label` and standardized spacing/sizing.
- Ensured event propagation is still stopped to prevent unintended interactions with parent components (like accordions).
- Updated `tests/CompactSlider.test.tsx` to work with the Radix-based slider structure (using `aria-valuenow` and `{ hidden: true }` for accessibility-hidden inputs).
- Verified the visual appearance and functionality via unit tests and manual frontend verification.

---
*PR created automatically by Jules for task [13674528904967780548](https://jules.google.com/task/13674528904967780548) started by @yukieiji*