### PR TITLE
e2e/error_handling.spec.tsのテスト修正

### DIFF
--- a/e2e/error_handling.spec.ts
+++ b/e2e/error_handling.spec.ts
@@ -9,8 +9,21 @@ test("初期ロード時にフェッチが失敗した場合、エラー画面�
 	page,
 }) => {
 	// APIリクエストを失敗させる
-	await page.route("**/au/translation/batch/**", (route) => {
-		return route.abort("failed");
+	// Service Workerが有効な場合、page.routeでは捕捉できないことがあるため
+	// ブラウザ側でfetchをモックする
+	await page.addInitScript(() => {
+		// @ts-ignore
+		window._nativeFetch = window.fetch;
+		window.fetch = function (...args) {
+			if (
+				typeof args[0] === "string" &&
+				args[0].includes("au/translation/batch")
+			) {
+				return Promise.reject(new TypeError("Failed to fetch (simulated)"));
+			}
+			// @ts-ignore
+			return window._nativeFetch.apply(this, args);
+		};
 	});
 
 	await page.goto("/");
@@ -23,10 +36,14 @@ test("初期ロード時にフェッチが失敗した場合、エラー画面�
 	await expect(retryButton).toBeVisible();
 
 	// 再試行で成功するようにルートを解除
-	await page.unroute("**/au/translation/batch/**");
-	await page.unroute("**/exr/option/");
-	await page.unroute("**/au/option/");
-	await page.unroute("**/exr/role/filter/");
+	await page.evaluate(() => {
+		// fetchのモックを解除（元のfetchに戻す）
+		// @ts-ignore
+		if (window._nativeFetch) {
+			// @ts-ignore
+			window.fetch = window._nativeFetch;
+		}
+	});
 
 	await retryButton.click();
 
@@ -38,8 +55,17 @@ test("再試行してもフェッチが失敗し続ける場合、エラー画�
 	page,
 }) => {
 	// APIリクエストを永続的に失敗させる
-	await page.route("**/au/translation/batch/**", (route) => {
-		return route.abort("failed");
+	await page.addInitScript(() => {
+		const nativeFetch = window.fetch;
+		window.fetch = function (...args) {
+			if (
+				typeof args[0] === "string" &&
+				args[0].includes("au/translation/batch")
+			) {
+				return Promise.reject(new TypeError("Failed to fetch (simulated)"));
+			}
+			return nativeFetch.apply(this, args);
+		};
 	});
 
 	await page.goto("/");

--- a/e2e/error_handling.spec.ts
+++ b/e2e/error_handling.spec.ts
@@ -15,10 +15,18 @@ test("初期ロード時にフェッチが失敗した場合、エラー画面�
 		// @ts-ignore
 		window._nativeFetch = window.fetch;
 		window.fetch = function (...args) {
-			if (
-				typeof args[0] === "string" &&
-				args[0].includes("au/translation/batch")
-			) {
+			const input = args[0];
+			let url = "";
+			if (typeof input === "string") {
+				url = input;
+			} else if (input instanceof URL) {
+				url = input.href;
+			} else if (input && typeof input === "object" && "url" in input) {
+				// Request-like object
+				url = (input as any).url;
+			}
+
+			if (url.includes("au/translation/batch")) {
 				return Promise.reject(new TypeError("Failed to fetch (simulated)"));
 			}
 			// @ts-ignore
@@ -56,15 +64,25 @@ test("再試行してもフェッチが失敗し続ける場合、エラー画�
 }) => {
 	// APIリクエストを永続的に失敗させる
 	await page.addInitScript(() => {
-		const nativeFetch = window.fetch;
+		// @ts-ignore
+		window._nativeFetch = window.fetch;
 		window.fetch = function (...args) {
-			if (
-				typeof args[0] === "string" &&
-				args[0].includes("au/translation/batch")
-			) {
+			const input = args[0];
+			let url = "";
+			if (typeof input === "string") {
+				url = input;
+			} else if (input instanceof URL) {
+				url = input.href;
+			} else if (input && typeof input === "object" && "url" in input) {
+				// Request-like object
+				url = (input as any).url;
+			}
+
+			if (url.includes("au/translation/batch")) {
 				return Promise.reject(new TypeError("Failed to fetch (simulated)"));
 			}
-			return nativeFetch.apply(this, args);
+			// @ts-ignore
+			return window._nativeFetch.apply(this, args);
 		};
 	});
 


### PR DESCRIPTION
e2e/error_handling.spec.ts のテストが失敗していた問題を修正しました。

原因:
アプリケーションで MSW (Mock Service Worker) が有効になっており、Playwright の `page.route` によるネットワーク遮断が Service Worker 経由のリクエストに対して正しく機能していなかったため、エラー画面がトリガーされていませんでした。

修正内容:
- `page.addInitScript` を使用して、ブラウザ実行時に `window.fetch` を直接上書きする方式に変更しました。
- `au/translation/batch` へのリクエストを検知して `TypeError` (Failed to fetch) を投げることで、確実にアプリケーションのエラーハンドリングを動作させるようにしました。
- 再試行のテストケースでは、元の `fetch` を保存し、必要に応じて復元するようにしました。

検証結果:
- `pnpm run e2e e2e/error_handling.spec.ts` を実行し、chromium, firefox, webkit の全ての環境でパスすることを確認しました。
- `pnpm run check` および `pnpm run test` で既存の機能に影響がないことを確認しました。

---
*PR created automatically by Jules for task [2720862001649084365](https://jules.google.com/task/2720862001649084365) started by @yukieiji*