### PR TITLE
Fix accordion hover background missing in indentation area

### DIFF
--- a/src/components/blocks/ChildOptionViewAccordion.tsx
+++ b/src/components/blocks/ChildOptionViewAccordion.tsx
@@ -23,8 +23,9 @@ export function ChildOptionViewAccordion({
 	depth,
 }: ChildOptionViewAccordionProps) {
 	return (
-		<div className={`flex flex-col ${depth > 0 ? "pl-2" : ""}`}>
+		<div className="flex flex-col">
 			<OptionRowContainer
+				containerClassName={depth > 0 ? "pl-2" : ""}
 				leading={
 					<div className="flex items-center justify-center w-full h-full">
 						<button
@@ -42,11 +43,13 @@ export function ChildOptionViewAccordion({
 			/>
 
 			{/* 子要素（ネストされたオプション） */}
-			<AccordionContentContainer isOpen={isOpen}>
-				<div className="min-h-0">
-					{isOpen && <div className="flex flex-col">{children}</div>}
-				</div>
-			</AccordionContentContainer>
+			<div className={depth > 0 ? "pl-2" : ""}>
+				<AccordionContentContainer isOpen={isOpen}>
+					<div className="min-h-0">
+						{isOpen && <div className="flex flex-col">{children}</div>}
+					</div>
+				</AccordionContentContainer>
+			</div>
 		</div>
 	);
 }

--- a/src/components/blocks/ChildOptionViewAccordion.tsx
+++ b/src/components/blocks/ChildOptionViewAccordion.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { CLOSE, OPEN } from "@/noTrans";
+import { getIndentClass } from "@/logics/indentUtils";
 import { AccordionContentContainer } from "../parts/AccordionContentContainer";
 import { AccordionSvg } from "../parts/AccordionSvg";
 import { OptionRowContainer } from "../parts/OptionRowContainer";
@@ -25,7 +26,7 @@ export function ChildOptionViewAccordion({
 	return (
 		<div className="flex flex-col">
 			<OptionRowContainer
-				containerClassName={depth > 0 ? "pl-2" : ""}
+				containerClassName={getIndentClass(depth, 2)}
 				leading={
 					<div className="flex items-center justify-center w-full h-full">
 						<button
@@ -43,13 +44,11 @@ export function ChildOptionViewAccordion({
 			/>
 
 			{/* 子要素（ネストされたオプション） */}
-			<div className={depth > 0 ? "pl-2" : ""}>
-				<AccordionContentContainer isOpen={isOpen}>
-					<div className="min-h-0">
-						{isOpen && <div className="flex flex-col">{children}</div>}
-					</div>
-				</AccordionContentContainer>
-			</div>
+			<AccordionContentContainer isOpen={isOpen}>
+				<div className="min-h-0">
+					{isOpen && <div className="flex flex-col">{children}</div>}
+				</div>
+			</AccordionContentContainer>
 		</div>
 	);
 }

--- a/src/components/blocks/ChildOptionViewAccordion.tsx
+++ b/src/components/blocks/ChildOptionViewAccordion.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { CLOSE, OPEN } from "@/noTrans";
-import { getIndentClass } from "@/logics/indentUtils";
 import { AccordionContentContainer } from "../parts/AccordionContentContainer";
 import { AccordionSvg } from "../parts/AccordionSvg";
 import { OptionRowContainer } from "../parts/OptionRowContainer";
@@ -26,7 +25,7 @@ export function ChildOptionViewAccordion({
 	return (
 		<div className="flex flex-col">
 			<OptionRowContainer
-				containerClassName={getIndentClass(depth, 2)}
+				containerClassName={depth > 0 ? "pl-2" : ""}
 				leading={
 					<div className="flex items-center justify-center w-full h-full">
 						<button
@@ -44,11 +43,13 @@ export function ChildOptionViewAccordion({
 			/>
 
 			{/* 子要素（ネストされたオプション） */}
-			<AccordionContentContainer isOpen={isOpen}>
-				<div className="min-h-0">
-					{isOpen && <div className="flex flex-col">{children}</div>}
-				</div>
-			</AccordionContentContainer>
+			<div>
+				<AccordionContentContainer isOpen={isOpen}>
+					<div className="min-h-0">
+						{isOpen && <div className="flex flex-col">{children}</div>}
+					</div>
+				</AccordionContentContainer>
+			</div>
 		</div>
 	);
 }

--- a/src/components/blocks/HighlightableAccordionRow.tsx
+++ b/src/components/blocks/HighlightableAccordionRow.tsx
@@ -10,6 +10,7 @@ interface HighlightableAccordionRowProps {
 	children: ReactNode;
 	isOpen: boolean;
 	onToggle: () => void;
+	containerClassName?: string;
 }
 
 export function HighlightableAccordionRow({
@@ -18,10 +19,12 @@ export function HighlightableAccordionRow({
 	isOpen,
 	onToggle,
 	children,
+	containerClassName,
 }: HighlightableAccordionRowProps) {
 	return (
 		<HighlightWrapper id={id} isHighlighted={isHighlight} isInset={true}>
 			<OptionRowContainer
+				containerClassName={containerClassName}
 				leading={
 					<div className="flex items-center justify-center w-full h-full">
 						<button

--- a/src/components/blocks/OptionEditableAccordion.tsx
+++ b/src/components/blocks/OptionEditableAccordion.tsx
@@ -21,13 +21,11 @@ export function RowCustomizeAccordion({
 		<div className="flex flex-col">
 			{row}
 			{/* 子要素（ネストされたオプション） */}
-			<div className={depth > 0 ? "pl-4" : ""}>
-				<AccordionContentContainer isOpen={isOpen}>
-					<div className="min-h-0">
-						{isOpen && <div className="flex flex-col">{children}</div>}
-					</div>
-				</AccordionContentContainer>
-			</div>
+			<AccordionContentContainer isOpen={isOpen}>
+				<div className="min-h-0">
+					{isOpen && <div className="flex flex-col">{children}</div>}
+				</div>
+			</AccordionContentContainer>
 		</div>
 	);
 }

--- a/src/components/blocks/OptionEditableAccordion.tsx
+++ b/src/components/blocks/OptionEditableAccordion.tsx
@@ -18,14 +18,16 @@ export function RowCustomizeAccordion({
 	depth,
 }: RowCustomizeAccordionProps) {
 	return (
-		<div className={`flex flex-col ${depth > 0 ? "pl-4" : ""}`}>
+		<div className="flex flex-col">
 			{row}
 			{/* 子要素（ネストされたオプション） */}
-			<AccordionContentContainer isOpen={isOpen}>
-				<div className="min-h-0">
-					{isOpen && <div className="flex flex-col">{children}</div>}
-				</div>
-			</AccordionContentContainer>
+			<div className={depth > 0 ? "pl-4" : ""}>
+				<AccordionContentContainer isOpen={isOpen}>
+					<div className="min-h-0">
+						{isOpen && <div className="flex flex-col">{children}</div>}
+					</div>
+				</AccordionContentContainer>
+			</div>
 		</div>
 	);
 }

--- a/src/components/blocks/OptionEditableAccordion.tsx
+++ b/src/components/blocks/OptionEditableAccordion.tsx
@@ -15,17 +15,18 @@ export function RowCustomizeAccordion({
 	isOpen,
 	row,
 	children,
-	depth,
 }: RowCustomizeAccordionProps) {
 	return (
 		<div className="flex flex-col">
 			{row}
 			{/* 子要素（ネストされたオプション） */}
-			<AccordionContentContainer isOpen={isOpen}>
-				<div className="min-h-0">
-					{isOpen && <div className="flex flex-col">{children}</div>}
-				</div>
-			</AccordionContentContainer>
+			<div>
+				<AccordionContentContainer isOpen={isOpen}>
+					<div className="min-h-0">
+						{isOpen && <div className="flex flex-col">{children}</div>}
+					</div>
+				</AccordionContentContainer>
+			</div>
 		</div>
 	);
 }

--- a/src/components/parts/OptionRowContainer.tsx
+++ b/src/components/parts/OptionRowContainer.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 interface OptionRowContainerProps {
 	leading: ReactNode;
 	content: ReactNode;
-	className?: string;
 	containerClassName?: string;
 }
 
@@ -14,14 +13,13 @@ interface OptionRowContainerProps {
 export function OptionRowContainer({
 	leading,
 	content,
-	className = "",
 	containerClassName = "",
 }: OptionRowContainerProps) {
 	return (
 		<div
 			className={`py-0.5 hover:bg-gray-800/50 transition-colors ${containerClassName}`}
 		>
-			<div className={`flex items-stretch pl-1.5 ${className}`}>
+			<div className="flex items-stretch pl-1.5">
 				{/* 左側領域（トグルボタンやスペーサー） */}
 				<div className="flex items-center justify-center w-10 shrink-0">
 					{leading}

--- a/src/components/parts/OptionRowContainer.tsx
+++ b/src/components/parts/OptionRowContainer.tsx
@@ -4,6 +4,7 @@ interface OptionRowContainerProps {
 	leading: ReactNode;
 	content: ReactNode;
 	className?: string;
+	containerClassName?: string;
 }
 
 /**
@@ -14,10 +15,13 @@ export function OptionRowContainer({
 	leading,
 	content,
 	className = "",
+	containerClassName = "",
 }: OptionRowContainerProps) {
 	return (
-		<div className="pl-1.5 py-0.5 hover:bg-gray-800/50 transition-colors">
-			<div className={`flex items-stretch ${className}`}>
+		<div
+			className={`py-0.5 hover:bg-gray-800/50 transition-colors ${containerClassName}`}
+		>
+			<div className={`flex items-stretch pl-1.5 ${className}`}>
 				{/* 左側領域（トグルボタンやスペーサー） */}
 				<div className="flex items-center justify-center w-10 shrink-0">
 					{leading}

--- a/src/components/parts/ViewerOptionRow.tsx
+++ b/src/components/parts/ViewerOptionRow.tsx
@@ -6,7 +6,6 @@ interface ViewerOptionRowProps {
 	value: ReactNode;
 	onDoubleClick: () => void;
 	indentClassName?: string;
-	noHover?: boolean;
 }
 
 /**
@@ -17,17 +16,12 @@ export function ViewerOptionRow({
 	value,
 	onDoubleClick,
 	indentClassName = "",
-	noHover = false,
 }: ViewerOptionRowProps) {
 	return (
 		<button
 			type="button"
 			onDoubleClick={onDoubleClick}
-			className={`w-full flex justify-between items-center py-1 pr-2 ${
-				noHover ? "" : "hover:bg-gray-700/50"
-			} rounded cursor-pointer select-none gap-2 group ${
-				indentClassName || "pl-2"
-			}`}
+			className={`w-full flex justify-between items-center py-1 px-2 hover:bg-gray-700/50 rounded cursor-pointer select-none gap-2 group ${indentClassName}`}
 			title={VIEWER_ROW_TITLE}
 		>
 			<span className="text-sm text-gray-300 flex-1 text-left group-hover:text-white transition-colors">

--- a/src/components/parts/ViewerOptionRow.tsx
+++ b/src/components/parts/ViewerOptionRow.tsx
@@ -5,6 +5,8 @@ interface ViewerOptionRowProps {
 	title: ReactNode;
 	value: ReactNode;
 	onDoubleClick: () => void;
+	indentClassName?: string;
+	noHover?: boolean;
 }
 
 /**
@@ -14,12 +16,18 @@ export function ViewerOptionRow({
 	title,
 	value,
 	onDoubleClick,
+	indentClassName = "",
+	noHover = false,
 }: ViewerOptionRowProps) {
 	return (
 		<button
 			type="button"
 			onDoubleClick={onDoubleClick}
-			className="w-full flex justify-between items-center py-1 px-2 hover:bg-gray-700/50 rounded cursor-pointer select-none gap-2 group"
+			className={`w-full flex justify-between items-center py-1 pr-2 ${
+				noHover ? "" : "hover:bg-gray-700/50"
+			} rounded cursor-pointer select-none gap-2 group ${
+				indentClassName || "pl-2"
+			}`}
 			title={VIEWER_ROW_TITLE}
 		>
 			<span className="text-sm text-gray-300 flex-1 text-left group-hover:text-white transition-colors">

--- a/src/feature/exr/ExRCategoryOptionList.tsx
+++ b/src/feature/exr/ExRCategoryOptionList.tsx
@@ -36,7 +36,7 @@ export function ExRCategoryOptionList({
 					<div key={key}>
 						{index !== 0 && <BorderLine />}
 						{isNumber ? (
-							<ExROptionItem uniqueOptionId={item} />
+							<ExROptionItem uniqueOptionId={item} depth={0} />
 						) : (
 							<OptionRowContainer
 								leading={<LargePoint />}

--- a/src/feature/exr/ExROptionRecursiveItem.tsx
+++ b/src/feature/exr/ExROptionRecursiveItem.tsx
@@ -2,8 +2,8 @@ import { HighlightableAccordionRow } from "@/components/blocks/HighlightableAcco
 import { RowCustomizeAccordion } from "@/components/blocks/OptionEditableAccordion";
 import { OptionEditorCategoryOptionLayout } from "@/components/blocks/OptionEditorCategoryOptionLayout";
 import { createExRNavigateId } from "@/hooks/useOptionNavigation";
-import { getIndentClass } from "@/logics/indentUtils";
 import { exrOptionMetaData } from "@/logics/api";
+import { getIndentClass } from "@/logics/indentUtils";
 import type { UniqueOptionId } from "@/type";
 import { useStore } from "@/useStore";
 import { ExROptionItem } from "./ExROptionItem";

--- a/src/feature/exr/ExROptionRecursiveItem.tsx
+++ b/src/feature/exr/ExROptionRecursiveItem.tsx
@@ -2,6 +2,7 @@ import { HighlightableAccordionRow } from "@/components/blocks/HighlightableAcco
 import { RowCustomizeAccordion } from "@/components/blocks/OptionEditableAccordion";
 import { OptionEditorCategoryOptionLayout } from "@/components/blocks/OptionEditorCategoryOptionLayout";
 import { createExRNavigateId } from "@/hooks/useOptionNavigation";
+import { getIndentClass } from "@/logics/indentUtils";
 import { exrOptionMetaData } from "@/logics/api";
 import type { UniqueOptionId } from "@/type";
 import { useStore } from "@/useStore";
@@ -47,7 +48,7 @@ export function ExROptionRecursiveItem({
 					onToggle={handleToggle}
 					isOpen={isOpen}
 					isHighlight={isHighlighted}
-					containerClassName={depth > 0 ? "pl-4" : ""}
+					containerClassName={getIndentClass(depth, 4)}
 				>
 					<ExROptionRow
 						uniqueOptionId={uniqueOptionId}

--- a/src/feature/exr/ExROptionRecursiveItem.tsx
+++ b/src/feature/exr/ExROptionRecursiveItem.tsx
@@ -47,6 +47,7 @@ export function ExROptionRecursiveItem({
 					onToggle={handleToggle}
 					isOpen={isOpen}
 					isHighlight={isHighlighted}
+					containerClassName={depth > 0 ? "pl-4" : ""}
 				>
 					<ExROptionRow
 						uniqueOptionId={uniqueOptionId}

--- a/src/feature/exr/ExROptionRow.tsx
+++ b/src/feature/exr/ExROptionRow.tsx
@@ -3,6 +3,7 @@ import { LargePoint } from "@/components/parts/LargePoint";
 import { OptionRowContainer } from "@/components/parts/OptionRowContainer";
 import { ExROptionRowContent } from "@/feature/exr/ExROptionRowContent";
 import { createExRNavigateId } from "@/hooks/useOptionNavigation";
+import { getIndentClass } from "@/logics/indentUtils";
 import type { UniqueOptionId } from "@/type";
 import { useStore } from "@/useStore";
 
@@ -36,7 +37,7 @@ function ExROptionRowInner({ uniqueOptionId, depth }: ExROptionRowInnerProps) {
 			<OptionRowContainer
 				leading={<LargePoint />}
 				content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
-				containerClassName={depth > 0 ? "pl-4" : ""}
+				containerClassName={getIndentClass(depth, 4)}
 			/>
 		</HighlightWrapper>
 	);

--- a/src/feature/exr/ExROptionRow.tsx
+++ b/src/feature/exr/ExROptionRow.tsx
@@ -36,7 +36,7 @@ function ExROptionRowInner({ uniqueOptionId, depth }: ExROptionRowInnerProps) {
 			<OptionRowContainer
 				leading={<LargePoint />}
 				content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
-				className={depth > 0 ? "pl-4" : ""}
+				containerClassName={depth > 0 ? "pl-4" : ""}
 			/>
 		</HighlightWrapper>
 	);

--- a/src/feature/rightsidepanel/ExRCategoryViewer.tsx
+++ b/src/feature/rightsidepanel/ExRCategoryViewer.tsx
@@ -47,7 +47,9 @@ export function ExRCategoryViewer({ categoryId }: ExRCategoryViewerProps) {
 			}}
 		>
 			<RightPanelContainer arr={filteredOptions} ignoreIndex={0}>
-				{(optionid) => <ExROptionItemView uniqueOptionId={optionid} />}
+				{(optionid) => (
+					<ExROptionItemView uniqueOptionId={optionid} depth={0} />
+				)}
 			</RightPanelContainer>
 		</ViewerGroupAccordion>
 	);

--- a/src/feature/rightsidepanel/ExROptionRecursiveItemView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRecursiveItemView.tsx
@@ -39,7 +39,6 @@ export function ExROptionRecursiveItemView({
 					uniqueOptionId={uniqueOptionId}
 					depth={depth}
 					isLeaf={false}
-					noHover={true}
 				/>
 			}
 			isOpen={isOpen}

--- a/src/feature/rightsidepanel/ExROptionRecursiveItemView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRecursiveItemView.tsx
@@ -39,6 +39,7 @@ export function ExROptionRecursiveItemView({
 					uniqueOptionId={uniqueOptionId}
 					depth={depth}
 					isLeaf={false}
+					noHover={true}
 				/>
 			}
 			isOpen={isOpen}
@@ -46,7 +47,9 @@ export function ExROptionRecursiveItemView({
 			depth={depth}
 		>
 			<RightPanelContainer arr={childs} ignoreIndex={-1}>
-				{(optionid) => <ExROptionItemView uniqueOptionId={optionid} />}
+				{(optionid) => (
+					<ExROptionItemView uniqueOptionId={optionid} depth={depth + 1} />
+				)}
 			</RightPanelContainer>
 		</ChildOptionViewAccordion>
 	);

--- a/src/feature/rightsidepanel/ExROptionRowView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowView.tsx
@@ -6,26 +6,22 @@ interface ExROptionRowViewProps {
 	uniqueOptionId: UniqueOptionId;
 	depth?: number;
 	isLeaf?: boolean;
-	noHover?: boolean;
 }
 
 export function ExROptionRowView({
 	uniqueOptionId,
 	depth = 0,
 	isLeaf = false,
-	noHover = false,
 }: ExROptionRowViewProps) {
 	return isLeaf ? (
 		<ExROptionRowViewContent
 			uniqueOptionId={uniqueOptionId}
 			indentClassName={getIndentClass(depth, 2)}
-			noHover={noHover}
 		/>
 	) : (
 		<ExROptionRowViewContent
 			uniqueOptionId={uniqueOptionId}
 			indentClassName={getIndentClass(depth, 2)}
-			noHover={noHover}
 		/>
 	);
 }

--- a/src/feature/rightsidepanel/ExROptionRowView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowView.tsx
@@ -1,3 +1,4 @@
+import { getIndentClass } from "@/logics/indentUtils";
 import type { UniqueOptionId } from "@/type";
 import { ExROptionRowViewContent } from "./ExROptionRowViewContent";
 
@@ -5,15 +6,26 @@ interface ExROptionRowViewProps {
 	uniqueOptionId: UniqueOptionId;
 	depth?: number;
 	isLeaf?: boolean;
+	noHover?: boolean;
 }
 
 export function ExROptionRowView({
 	uniqueOptionId,
+	depth = 0,
 	isLeaf = false,
+	noHover = false,
 }: ExROptionRowViewProps) {
 	return isLeaf ? (
-		<ExROptionRowViewContent uniqueOptionId={uniqueOptionId} />
+		<ExROptionRowViewContent
+			uniqueOptionId={uniqueOptionId}
+			indentClassName={getIndentClass(depth, 2)}
+			noHover={noHover}
+		/>
 	) : (
-		<ExROptionRowViewContent uniqueOptionId={uniqueOptionId} />
+		<ExROptionRowViewContent
+			uniqueOptionId={uniqueOptionId}
+			indentClassName={getIndentClass(depth, 2)}
+			noHover={noHover}
+		/>
 	);
 }

--- a/src/feature/rightsidepanel/ExROptionRowViewContent.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowViewContent.tsx
@@ -7,6 +7,8 @@ import { ExRValueView } from "./ExRValueView";
 
 interface ExROptionRowViewContentProps {
 	uniqueOptionId: UniqueOptionId;
+	indentClassName?: string;
+	noHover?: boolean;
 }
 
 /**
@@ -14,6 +16,8 @@ interface ExROptionRowViewContentProps {
  */
 export function ExROptionRowViewContent({
 	uniqueOptionId,
+	indentClassName = "",
+	noHover = false,
 }: ExROptionRowViewContentProps) {
 	const optionData = exrOptionMetaData.options[uniqueOptionId]?.metaData;
 	const navigate = useExROptionNavigation(uniqueOptionId);
@@ -32,6 +36,8 @@ export function ExROptionRowViewContent({
 				/>
 			}
 			onDoubleClick={navigate}
+			indentClassName={indentClassName}
+			noHover={noHover}
 		/>
 	);
 }

--- a/src/feature/rightsidepanel/ExROptionRowViewContent.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowViewContent.tsx
@@ -8,7 +8,6 @@ import { ExRValueView } from "./ExRValueView";
 interface ExROptionRowViewContentProps {
 	uniqueOptionId: UniqueOptionId;
 	indentClassName?: string;
-	noHover?: boolean;
 }
 
 /**
@@ -17,7 +16,6 @@ interface ExROptionRowViewContentProps {
 export function ExROptionRowViewContent({
 	uniqueOptionId,
 	indentClassName = "",
-	noHover = false,
 }: ExROptionRowViewContentProps) {
 	const optionData = exrOptionMetaData.options[uniqueOptionId]?.metaData;
 	const navigate = useExROptionNavigation(uniqueOptionId);
@@ -37,7 +35,6 @@ export function ExROptionRowViewContent({
 			}
 			onDoubleClick={navigate}
 			indentClassName={indentClassName}
-			noHover={noHover}
 		/>
 	);
 }

--- a/src/logics/indentUtils.ts
+++ b/src/logics/indentUtils.ts
@@ -1,0 +1,29 @@
+/**
+ * ネストの深さに応じたパディングクラスを返します。
+ * Tailwindの動的クラス生成を避けるため、静的なマッピングを使用します。
+ *
+ * @param depth ネストの深さ (0-indexed)
+ * @param step 1段階あたりのパディング量 (4: 1rem, 2: 0.5rem)
+ * @returns Tailwindのパディングクラス
+ */
+export function getIndentClass(depth: number, step: 4 | 2 = 4): string {
+  if (depth <= 0) return "";
+
+  if (step === 4) {
+    switch (depth) {
+      case 1: return "pl-4";
+      case 2: return "pl-8";
+      case 3: return "pl-12";
+      case 4: return "pl-16";
+      default: return "pl-20";
+    }
+  } else {
+    switch (depth) {
+      case 1: return "pl-2";
+      case 2: return "pl-4";
+      case 3: return "pl-6";
+      case 4: return "pl-8";
+      default: return "pl-10";
+    }
+  }
+}

--- a/src/logics/indentUtils.ts
+++ b/src/logics/indentUtils.ts
@@ -7,23 +7,35 @@
  * @returns Tailwindのパディングクラス
  */
 export function getIndentClass(depth: number, step: 4 | 2 = 4): string {
-  if (depth <= 0) return "";
+	if (depth <= 0) {
+		return "";
+	}
 
-  if (step === 4) {
-    switch (depth) {
-      case 1: return "pl-4";
-      case 2: return "pl-8";
-      case 3: return "pl-12";
-      case 4: return "pl-16";
-      default: return "pl-20";
-    }
-  } else {
-    switch (depth) {
-      case 1: return "pl-2";
-      case 2: return "pl-4";
-      case 3: return "pl-6";
-      case 4: return "pl-8";
-      default: return "pl-10";
-    }
-  }
+	if (step === 4) {
+		switch (depth) {
+			case 1:
+				return "pl-4";
+			case 2:
+				return "pl-8";
+			case 3:
+				return "pl-12";
+			case 4:
+				return "pl-16";
+			default:
+				return "pl-20";
+		}
+	} else {
+		switch (depth) {
+			case 1:
+				return "pl-2";
+			case 2:
+				return "pl-4";
+			case 3:
+				return "pl-6";
+			case 4:
+				return "pl-8";
+			default:
+				return "pl-10";
+		}
+	}
 }

--- a/tests/ChildOptionViewAccordion.test.tsx
+++ b/tests/ChildOptionViewAccordion.test.tsx
@@ -77,6 +77,6 @@ describe("ChildOptionViewAccordion", () => {
 		render(<ChildOptionViewAccordion {...defaultProps} depth={5} />);
 		const button = screen.getByRole("button", { name: OPEN });
 		const row = button.closest("div[class*='hover:bg-']");
-		expect(row).toHaveClass("pl-2");
+		expect(row).toHaveClass("pl-10"); // getIndentClass(5, 2)
 	});
 });

--- a/tests/ChildOptionViewAccordion.test.tsx
+++ b/tests/ChildOptionViewAccordion.test.tsx
@@ -77,6 +77,6 @@ describe("ChildOptionViewAccordion", () => {
 		render(<ChildOptionViewAccordion {...defaultProps} depth={5} />);
 		const button = screen.getByRole("button", { name: OPEN });
 		const row = button.closest("div[class*='hover:bg-']");
-		expect(row).toHaveClass("pl-10"); // getIndentClass(5, 2)
+		expect(row).toHaveClass("pl-2");
 	});
 });

--- a/tests/ChildOptionViewAccordion.test.tsx
+++ b/tests/ChildOptionViewAccordion.test.tsx
@@ -59,22 +59,24 @@ describe("ChildOptionViewAccordion", () => {
 		expect(button).toHaveAttribute("aria-label", CLOSE);
 	});
 
-	it("should apply padding class when depth > 0", () => {
-		const { container: containerDepth0 } = render(
+	it("should apply padding class to the row container when depth > 0", () => {
+		const { rerender } = render(
 			<ChildOptionViewAccordion {...defaultProps} depth={0} />,
 		);
-		expect(containerDepth0.firstChild).not.toHaveClass("pl-2");
+		const button0 = screen.getByRole("button", { name: OPEN });
+		const row0 = button0.closest("div[class*='hover:bg-']");
+		expect(row0).not.toHaveClass("pl-2");
 
-		const { container: containerDepth1 } = render(
-			<ChildOptionViewAccordion {...defaultProps} depth={1} />,
-		);
-		expect(containerDepth1.firstChild).toHaveClass("pl-2");
+		rerender(<ChildOptionViewAccordion {...defaultProps} depth={1} />);
+		const button1 = screen.getByRole("button", { name: OPEN });
+		const row1 = button1.closest("div[class*='hover:bg-']");
+		expect(row1).toHaveClass("pl-2");
 	});
 
-	it("should apply padding class when depth is large", () => {
-		const { container } = render(
-			<ChildOptionViewAccordion {...defaultProps} depth={5} />,
-		);
-		expect(container.firstChild).toHaveClass("pl-2");
+	it("should apply padding class to the row container when depth is large", () => {
+		render(<ChildOptionViewAccordion {...defaultProps} depth={5} />);
+		const button = screen.getByRole("button", { name: OPEN });
+		const row = button.closest("div[class*='hover:bg-']");
+		expect(row).toHaveClass("pl-2");
 	});
 });


### PR DESCRIPTION
The hover background color for nested accordions was missing in the left indentation area because the padding was applied to a parent wrapper instead of the hoverable element. I refactored the components to move the depth-based indentation padding onto the row container itself.

Key changes:
- `OptionRowContainer`: Added `containerClassName` prop and adjusted internal layout.
- `ChildOptionViewAccordion` & `OptionEditableAccordion`: Moved `pl-{depth*4}` from the root wrapper to the header row.
- Updated prop drilling in `HighlightableAccordionRow`, `ExROptionRecursiveItem`, and `ExROptionRow`.
- Updated `tests/ChildOptionViewAccordion.test.tsx` to correctly target elements for padding assertions.

Verified with Playwright E2E tests and manual inspection of screenshots. All unit tests passed.

---
*PR created automatically by Jules for task [1976020176325204605](https://jules.google.com/task/1976020176325204605) started by @yukieiji*