### PR TITLE
アコーディオンのインデント部分のホバー背景色の修正

### DIFF
--- a/src/components/blocks/ChildOptionViewAccordion.tsx
+++ b/src/components/blocks/ChildOptionViewAccordion.tsx
@@ -22,8 +22,10 @@ export function ChildOptionViewAccordion({
 	children,
 	depth,
 }: ChildOptionViewAccordionProps) {
+	const paddingLeft = depth > 0 ? `${depth * 0.5}rem` : "0";
+
 	return (
-		<div className={`flex flex-col ${depth > 0 ? "pl-2" : ""}`}>
+		<div className="flex flex-col">
 			<OptionRowContainer
 				leading={
 					<div className="flex items-center justify-center w-full h-full">
@@ -39,6 +41,7 @@ export function ChildOptionViewAccordion({
 					</div>
 				}
 				content={optionItem}
+				style={{ paddingLeft: `calc(0.375rem + ${paddingLeft})` }}
 			/>
 
 			{/* 子要素（ネストされたオプション） */}

--- a/src/components/blocks/ChildOptionViewAccordion.tsx
+++ b/src/components/blocks/ChildOptionViewAccordion.tsx
@@ -22,8 +22,6 @@ export function ChildOptionViewAccordion({
 	children,
 	depth,
 }: ChildOptionViewAccordionProps) {
-	const paddingLeft = depth > 0 ? `${depth * 0.5}rem` : "0";
-
 	return (
 		<div className="flex flex-col">
 			<OptionRowContainer
@@ -41,7 +39,8 @@ export function ChildOptionViewAccordion({
 					</div>
 				}
 				content={optionItem}
-				style={{ paddingLeft: `calc(0.375rem + ${paddingLeft})` }}
+				depth={depth}
+				indentMultiplier={0.5}
 			/>
 
 			{/* 子要素（ネストされたオプション） */}

--- a/src/components/blocks/HighlightableAccordionRow.tsx
+++ b/src/components/blocks/HighlightableAccordionRow.tsx
@@ -10,6 +10,7 @@ interface HighlightableAccordionRowProps {
 	children: ReactNode;
 	isOpen: boolean;
 	onToggle: () => void;
+	depth?: number;
 }
 
 export function HighlightableAccordionRow({
@@ -18,7 +19,10 @@ export function HighlightableAccordionRow({
 	isOpen,
 	onToggle,
 	children,
+	depth = 0,
 }: HighlightableAccordionRowProps) {
+	const paddingLeft = depth > 0 ? `${depth * 1}rem` : "0";
+
 	return (
 		<HighlightWrapper id={id} isHighlighted={isHighlight} isInset={true}>
 			<OptionRowContainer
@@ -36,6 +40,7 @@ export function HighlightableAccordionRow({
 					</div>
 				}
 				content={children}
+				style={{ paddingLeft: `calc(0.375rem + ${paddingLeft})` }}
 			/>
 		</HighlightWrapper>
 	);

--- a/src/components/blocks/HighlightableAccordionRow.tsx
+++ b/src/components/blocks/HighlightableAccordionRow.tsx
@@ -21,8 +21,6 @@ export function HighlightableAccordionRow({
 	children,
 	depth = 0,
 }: HighlightableAccordionRowProps) {
-	const paddingLeft = depth > 0 ? `${depth * 1}rem` : "0";
-
 	return (
 		<HighlightWrapper id={id} isHighlighted={isHighlight} isInset={true}>
 			<OptionRowContainer
@@ -40,7 +38,8 @@ export function HighlightableAccordionRow({
 					</div>
 				}
 				content={children}
-				style={{ paddingLeft: `calc(0.375rem + ${paddingLeft})` }}
+				depth={depth}
+				indentMultiplier={1}
 			/>
 		</HighlightWrapper>
 	);

--- a/src/components/blocks/OptionEditableAccordion.tsx
+++ b/src/components/blocks/OptionEditableAccordion.tsx
@@ -5,7 +5,6 @@ interface RowCustomizeAccordionProps {
 	row: ReactNode;
 	isOpen: boolean;
 	children: ReactNode;
-	depth: number;
 }
 
 /**

--- a/src/components/blocks/OptionEditableAccordion.tsx
+++ b/src/components/blocks/OptionEditableAccordion.tsx
@@ -15,10 +15,9 @@ export function RowCustomizeAccordion({
 	isOpen,
 	row,
 	children,
-	depth,
 }: RowCustomizeAccordionProps) {
 	return (
-		<div className={`flex flex-col ${depth > 0 ? "pl-4" : ""}`}>
+		<div className="flex flex-col">
 			{row}
 			{/* 子要素（ネストされたオプション） */}
 			<AccordionContentContainer isOpen={isOpen}>

--- a/src/components/blocks/OptionEditorCategoryOptionLayout.tsx
+++ b/src/components/blocks/OptionEditorCategoryOptionLayout.tsx
@@ -6,18 +6,20 @@ interface OptionEditorCategoryOptionLayoutProp<T> {
 	arr: T[];
 	children: (categoryId: T) => ReactNode;
 	ignoreIndex: number;
+	depth?: number;
 }
 
 export function OptionEditorCategoryOptionLayout<T>({
 	arr,
 	children,
 	ignoreIndex,
+	depth = 0,
 }: OptionEditorCategoryOptionLayoutProp<T>) {
 	return (
 		<OptionEditorOptionRowGroupLayout>
 			{arr.map((key, index) => (
 				<div key={String(key)}>
-					{index !== ignoreIndex && <BorderLine />}
+					{index !== ignoreIndex && <BorderLine depth={depth} />}
 					{children(key)}
 				</div>
 			))}

--- a/src/components/blocks/RightPanelContainer.tsx
+++ b/src/components/blocks/RightPanelContainer.tsx
@@ -7,18 +7,20 @@ interface RightPanelContainerProp<T> {
 	arr: T[];
 	children: (categoryId: T) => ReactNode;
 	ignoreIndex: number;
+	depth?: number;
 }
 
 export function RightPanelContainer<T>({
 	arr,
 	children,
 	ignoreIndex,
+	depth = 0,
 }: RightPanelContainerProp<T>) {
 	return (
 		<RightPanelItemColumnLayout>
 			{arr.map((key, index) => (
 				<div key={String(key)}>
-					{index !== ignoreIndex && <RightPanelBorderLine />}
+					{index !== ignoreIndex && <RightPanelBorderLine depth={depth} />}
 					{children(key)}
 				</div>
 			))}

--- a/src/components/parts/BorderLine.tsx
+++ b/src/components/parts/BorderLine.tsx
@@ -1,9 +1,13 @@
 interface BorderLineProps {
 	depth?: number;
+	indentMultiplier?: number;
 }
 
-export function BorderLine({ depth = 0 }: BorderLineProps) {
-	const paddingLeft = depth > 0 ? `${depth * 1}rem` : "0";
+export function BorderLine({
+	depth = 0,
+	indentMultiplier = 1,
+}: BorderLineProps) {
+	const paddingLeft = depth > 0 ? `${depth * indentMultiplier}rem` : "0";
 	return (
 		<div style={{ paddingLeft: paddingLeft }}>
 			<hr className="w-[95%] mx-auto border-t border-gray-700" />

--- a/src/components/parts/BorderLine.tsx
+++ b/src/components/parts/BorderLine.tsx
@@ -3,11 +3,13 @@ interface BorderLineProps {
 	indentMultiplier?: number;
 }
 
+import { calculateIndentation } from "@/logics/optionUtils";
+
 export function BorderLine({
 	depth = 0,
 	indentMultiplier = 1,
 }: BorderLineProps) {
-	const paddingLeft = depth > 0 ? `${depth * indentMultiplier}rem` : "0";
+	const paddingLeft = calculateIndentation(depth, indentMultiplier);
 	return (
 		<div style={{ paddingLeft: paddingLeft }}>
 			<hr className="w-[95%] mx-auto border-t border-gray-700" />

--- a/src/components/parts/BorderLine.tsx
+++ b/src/components/parts/BorderLine.tsx
@@ -1,3 +1,12 @@
-export function BorderLine() {
-	return <hr className="w-[95%] mx-auto border-t rounded-lg border-gray-700" />;
+interface BorderLineProps {
+	depth?: number;
+}
+
+export function BorderLine({ depth = 0 }: BorderLineProps) {
+	const paddingLeft = depth > 0 ? `${depth * 1}rem` : "0";
+	return (
+		<div style={{ paddingLeft: paddingLeft }}>
+			<hr className="w-[95%] mx-auto border-t border-gray-700" />
+		</div>
+	);
 }

--- a/src/components/parts/OptionRowContainer.tsx
+++ b/src/components/parts/OptionRowContainer.tsx
@@ -1,9 +1,10 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 interface OptionRowContainerProps {
 	leading: ReactNode;
 	content: ReactNode;
 	className?: string;
+	style?: CSSProperties;
 }
 
 /**
@@ -14,10 +15,11 @@ export function OptionRowContainer({
 	leading,
 	content,
 	className = "",
+	style,
 }: OptionRowContainerProps) {
 	return (
-		<div className="pl-1.5 py-0.5 hover:bg-gray-800/50 transition-colors">
-			<div className={`flex items-stretch ${className}`}>
+		<div className="py-0.5 hover:bg-gray-800/50 transition-colors">
+			<div className={`flex items-stretch ${className}`} style={style}>
 				{/* 左側領域（トグルボタンやスペーサー） */}
 				<div className="flex items-center justify-center w-10 shrink-0">
 					{leading}

--- a/src/components/parts/OptionRowContainer.tsx
+++ b/src/components/parts/OptionRowContainer.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { calculateIndentation } from "@/logics/optionUtils";
 
 interface OptionRowContainerProps {
 	leading: ReactNode;
@@ -19,7 +20,7 @@ export function OptionRowContainer({
 	depth = 0,
 	indentMultiplier = 1,
 }: OptionRowContainerProps) {
-	const paddingLeft = depth > 0 ? `${depth * indentMultiplier}rem` : "0";
+	const paddingLeft = calculateIndentation(depth, indentMultiplier);
 
 	return (
 		<div className="py-0.5 hover:bg-gray-800/50 transition-colors">

--- a/src/components/parts/OptionRowContainer.tsx
+++ b/src/components/parts/OptionRowContainer.tsx
@@ -1,10 +1,11 @@
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 interface OptionRowContainerProps {
 	leading: ReactNode;
 	content: ReactNode;
 	className?: string;
-	style?: CSSProperties;
+	depth?: number;
+	indentMultiplier?: number;
 }
 
 /**
@@ -15,11 +16,17 @@ export function OptionRowContainer({
 	leading,
 	content,
 	className = "",
-	style,
+	depth = 0,
+	indentMultiplier = 1,
 }: OptionRowContainerProps) {
+	const paddingLeft = depth > 0 ? `${depth * indentMultiplier}rem` : "0";
+
 	return (
 		<div className="py-0.5 hover:bg-gray-800/50 transition-colors">
-			<div className={`flex items-stretch ${className}`} style={style}>
+			<div
+				className={`flex items-stretch ${className}`}
+				style={{ paddingLeft: `calc(0.375rem + ${paddingLeft})` }}
+			>
 				{/* 左側領域（トグルボタンやスペーサー） */}
 				<div className="flex items-center justify-center w-10 shrink-0">
 					{leading}

--- a/src/components/parts/OptionRowContainer.tsx
+++ b/src/components/parts/OptionRowContainer.tsx
@@ -20,13 +20,13 @@ export function OptionRowContainer({
 	depth = 0,
 	indentMultiplier = 1,
 }: OptionRowContainerProps) {
-	const paddingLeft = calculateIndentation(depth, indentMultiplier);
+	const paddingLeft = calculateIndentation(depth, indentMultiplier, 0.375);
 
 	return (
 		<div className="py-0.5 hover:bg-gray-800/50 transition-colors">
 			<div
 				className={`flex items-stretch ${className}`}
-				style={{ paddingLeft: `calc(0.375rem + ${paddingLeft})` }}
+				style={{ paddingLeft }}
 			>
 				{/* 左側領域（トグルボタンやスペーサー） */}
 				<div className="flex items-center justify-center w-10 shrink-0">

--- a/src/components/parts/RightPanelBorderLine.tsx
+++ b/src/components/parts/RightPanelBorderLine.tsx
@@ -1,3 +1,12 @@
-export function RightPanelBorderLine() {
-	return <hr className="w-[95%] mx-auto border-t rounded-lg border-gray-400" />;
+interface RightPanelBorderLineProps {
+	depth?: number;
+}
+
+export function RightPanelBorderLine({ depth = 0 }: RightPanelBorderLineProps) {
+	const paddingLeft = depth > 0 ? `${depth * 0.5}rem` : "0";
+	return (
+		<div style={{ paddingLeft: paddingLeft }}>
+			<hr className="w-[95%] mx-auto border-t rounded-lg border-gray-400" />
+		</div>
+	);
 }

--- a/src/components/parts/RightPanelBorderLine.tsx
+++ b/src/components/parts/RightPanelBorderLine.tsx
@@ -1,9 +1,13 @@
 interface RightPanelBorderLineProps {
 	depth?: number;
+	indentMultiplier?: number;
 }
 
-export function RightPanelBorderLine({ depth = 0 }: RightPanelBorderLineProps) {
-	const paddingLeft = depth > 0 ? `${depth * 0.5}rem` : "0";
+export function RightPanelBorderLine({
+	depth = 0,
+	indentMultiplier = 0.5,
+}: RightPanelBorderLineProps) {
+	const paddingLeft = depth > 0 ? `${depth * indentMultiplier}rem` : "0";
 	return (
 		<div style={{ paddingLeft: paddingLeft }}>
 			<hr className="w-[95%] mx-auto border-t border-gray-400" />

--- a/src/components/parts/RightPanelBorderLine.tsx
+++ b/src/components/parts/RightPanelBorderLine.tsx
@@ -3,11 +3,13 @@ interface RightPanelBorderLineProps {
 	indentMultiplier?: number;
 }
 
+import { calculateIndentation } from "@/logics/optionUtils";
+
 export function RightPanelBorderLine({
 	depth = 0,
 	indentMultiplier = 0.5,
 }: RightPanelBorderLineProps) {
-	const paddingLeft = depth > 0 ? `${depth * indentMultiplier}rem` : "0";
+	const paddingLeft = calculateIndentation(depth, indentMultiplier);
 	return (
 		<div style={{ paddingLeft: paddingLeft }}>
 			<hr className="w-[95%] mx-auto border-t border-gray-400" />

--- a/src/components/parts/RightPanelBorderLine.tsx
+++ b/src/components/parts/RightPanelBorderLine.tsx
@@ -6,7 +6,7 @@ export function RightPanelBorderLine({ depth = 0 }: RightPanelBorderLineProps) {
 	const paddingLeft = depth > 0 ? `${depth * 0.5}rem` : "0";
 	return (
 		<div style={{ paddingLeft: paddingLeft }}>
-			<hr className="w-[95%] mx-auto border-t rounded-lg border-gray-400" />
+			<hr className="w-[95%] mx-auto border-t border-gray-400" />
 		</div>
 	);
 }

--- a/src/components/parts/ViewerOptionRow.tsx
+++ b/src/components/parts/ViewerOptionRow.tsx
@@ -5,6 +5,7 @@ interface ViewerOptionRowProps {
 	title: ReactNode;
 	value: ReactNode;
 	onDoubleClick: () => void;
+	depth?: number;
 }
 
 /**
@@ -14,12 +15,16 @@ export function ViewerOptionRow({
 	title,
 	value,
 	onDoubleClick,
+	depth = 0,
 }: ViewerOptionRowProps) {
+	const paddingLeft = depth > 0 ? `${depth * 0.5}rem` : "0";
+
 	return (
 		<button
 			type="button"
 			onDoubleClick={onDoubleClick}
-			className="w-full flex justify-between items-center py-1 px-2 hover:bg-gray-700/50 rounded cursor-pointer select-none gap-2 group"
+			className="w-full flex justify-between items-center py-1 pr-2 hover:bg-gray-700/50 rounded cursor-pointer select-none gap-2 group"
+			style={{ paddingLeft: `calc(0.5rem + ${paddingLeft})` }}
 			title={VIEWER_ROW_TITLE}
 		>
 			<span className="text-sm text-gray-300 flex-1 text-left group-hover:text-white transition-colors">

--- a/src/components/parts/ViewerOptionRow.tsx
+++ b/src/components/parts/ViewerOptionRow.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { calculateIndentation } from "@/logics/optionUtils";
 import { VIEWER_ROW_TITLE } from "@/noTrans";
 
 interface ViewerOptionRowProps {
@@ -19,7 +20,7 @@ export function ViewerOptionRow({
 	depth = 0,
 	indentMultiplier = 0.5,
 }: ViewerOptionRowProps) {
-	const paddingLeft = depth > 0 ? `${depth * indentMultiplier}rem` : "0";
+	const paddingLeft = calculateIndentation(depth, indentMultiplier);
 
 	return (
 		<button

--- a/src/components/parts/ViewerOptionRow.tsx
+++ b/src/components/parts/ViewerOptionRow.tsx
@@ -20,14 +20,14 @@ export function ViewerOptionRow({
 	depth = 0,
 	indentMultiplier = 0.5,
 }: ViewerOptionRowProps) {
-	const paddingLeft = calculateIndentation(depth, indentMultiplier);
+	const paddingLeft = calculateIndentation(depth, indentMultiplier, 0.5);
 
 	return (
 		<button
 			type="button"
 			onDoubleClick={onDoubleClick}
 			className="w-full flex justify-between items-center py-1 pr-2 hover:bg-gray-700/50 rounded cursor-pointer select-none gap-2 group"
-			style={{ paddingLeft: `calc(0.5rem + ${paddingLeft})` }}
+			style={{ paddingLeft }}
 			title={VIEWER_ROW_TITLE}
 		>
 			<span className="text-sm text-gray-300 flex-1 text-left group-hover:text-white transition-colors">

--- a/src/components/parts/ViewerOptionRow.tsx
+++ b/src/components/parts/ViewerOptionRow.tsx
@@ -6,6 +6,7 @@ interface ViewerOptionRowProps {
 	value: ReactNode;
 	onDoubleClick: () => void;
 	depth?: number;
+	indentMultiplier?: number;
 }
 
 /**
@@ -16,8 +17,9 @@ export function ViewerOptionRow({
 	value,
 	onDoubleClick,
 	depth = 0,
+	indentMultiplier = 0.5,
 }: ViewerOptionRowProps) {
-	const paddingLeft = depth > 0 ? `${depth * 0.5}rem` : "0";
+	const paddingLeft = depth > 0 ? `${depth * indentMultiplier}rem` : "0";
 
 	return (
 		<button

--- a/src/feature/amongus/AuOptionRow.tsx
+++ b/src/feature/amongus/AuOptionRow.tsx
@@ -40,7 +40,8 @@ export function AuOptionRow({ auOptionId }: AuOptionRowProps) {
 		>
 			<OptionRowContainer
 				leading={<LargePoint />}
-				style={{ paddingLeft: "0.375rem" }}
+				depth={0}
+				indentMultiplier={1}
 				content={
 					<OptionRowContent name={optionMeta.title}>
 						<AuOptionControl

--- a/src/feature/amongus/AuOptionRow.tsx
+++ b/src/feature/amongus/AuOptionRow.tsx
@@ -40,6 +40,7 @@ export function AuOptionRow({ auOptionId }: AuOptionRowProps) {
 		>
 			<OptionRowContainer
 				leading={<LargePoint />}
+				style={{ paddingLeft: "0.375rem" }}
 				content={
 					<OptionRowContent name={optionMeta.title}>
 						<AuOptionControl

--- a/src/feature/exr/ExRCategoryOptionList.tsx
+++ b/src/feature/exr/ExRCategoryOptionList.tsx
@@ -40,7 +40,8 @@ export function ExRCategoryOptionList({
 						) : (
 							<OptionRowContainer
 								leading={<LargePoint />}
-								style={{ paddingLeft: "0.375rem" }}
+								depth={0}
+								indentMultiplier={1}
 								content={
 									<ExRPairedOptionItem
 										baseName={item.baseName}

--- a/src/feature/exr/ExRCategoryOptionList.tsx
+++ b/src/feature/exr/ExRCategoryOptionList.tsx
@@ -40,6 +40,7 @@ export function ExRCategoryOptionList({
 						) : (
 							<OptionRowContainer
 								leading={<LargePoint />}
+								style={{ paddingLeft: "0.375rem" }}
 								content={
 									<ExRPairedOptionItem
 										baseName={item.baseName}

--- a/src/feature/exr/ExROptionRecursiveItem.tsx
+++ b/src/feature/exr/ExROptionRecursiveItem.tsx
@@ -57,7 +57,6 @@ export function ExROptionRecursiveItem({
 				</HighlightableAccordionRow>
 			}
 			isOpen={isOpen}
-			depth={depth}
 		>
 			<OptionEditorCategoryOptionLayout
 				arr={childs}

--- a/src/feature/exr/ExROptionRecursiveItem.tsx
+++ b/src/feature/exr/ExROptionRecursiveItem.tsx
@@ -57,6 +57,7 @@ export function ExROptionRecursiveItem({
 				</HighlightableAccordionRow>
 			}
 			isOpen={isOpen}
+			depth={depth}
 		>
 			<OptionEditorCategoryOptionLayout
 				arr={childs}

--- a/src/feature/exr/ExROptionRecursiveItem.tsx
+++ b/src/feature/exr/ExROptionRecursiveItem.tsx
@@ -47,6 +47,7 @@ export function ExROptionRecursiveItem({
 					onToggle={handleToggle}
 					isOpen={isOpen}
 					isHighlight={isHighlighted}
+					depth={depth}
 				>
 					<ExROptionRow
 						uniqueOptionId={uniqueOptionId}
@@ -56,9 +57,12 @@ export function ExROptionRecursiveItem({
 				</HighlightableAccordionRow>
 			}
 			isOpen={isOpen}
-			depth={depth}
 		>
-			<OptionEditorCategoryOptionLayout arr={childs} ignoreIndex={-1}>
+			<OptionEditorCategoryOptionLayout
+				arr={childs}
+				ignoreIndex={-1}
+				depth={depth + 1}
+			>
 				{(childId) => (
 					<ExROptionItem uniqueOptionId={childId} depth={depth + 1} />
 				)}

--- a/src/feature/exr/ExROptionRow.tsx
+++ b/src/feature/exr/ExROptionRow.tsx
@@ -26,6 +26,7 @@ function ExROptionRowInner({ uniqueOptionId, depth }: ExROptionRowInnerProps) {
 	});
 
 	const navigateId = createExRNavigateId(uniqueOptionId);
+	const paddingLeft = depth > 0 ? `${depth * 1}rem` : "0";
 
 	return (
 		<HighlightWrapper
@@ -36,7 +37,7 @@ function ExROptionRowInner({ uniqueOptionId, depth }: ExROptionRowInnerProps) {
 			<OptionRowContainer
 				leading={<LargePoint />}
 				content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
-				className={depth > 0 ? "pl-4" : ""}
+				style={{ paddingLeft: `calc(0.375rem + ${paddingLeft})` }}
 			/>
 		</HighlightWrapper>
 	);

--- a/src/feature/exr/ExROptionRow.tsx
+++ b/src/feature/exr/ExROptionRow.tsx
@@ -26,7 +26,6 @@ function ExROptionRowInner({ uniqueOptionId, depth }: ExROptionRowInnerProps) {
 	});
 
 	const navigateId = createExRNavigateId(uniqueOptionId);
-	const paddingLeft = depth > 0 ? `${depth * 1}rem` : "0";
 
 	return (
 		<HighlightWrapper
@@ -37,7 +36,8 @@ function ExROptionRowInner({ uniqueOptionId, depth }: ExROptionRowInnerProps) {
 			<OptionRowContainer
 				leading={<LargePoint />}
 				content={<ExROptionRowContent uniqueOptionId={uniqueOptionId} />}
-				style={{ paddingLeft: `calc(0.375rem + ${paddingLeft})` }}
+				depth={depth}
+				indentMultiplier={1}
 			/>
 		</HighlightWrapper>
 	);

--- a/src/feature/rightsidepanel/ExROptionRecursiveItemView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRecursiveItemView.tsx
@@ -45,8 +45,10 @@ export function ExROptionRecursiveItemView({
 			onToggle={handleToggle}
 			depth={depth}
 		>
-			<RightPanelContainer arr={childs} ignoreIndex={-1}>
-				{(optionid) => <ExROptionItemView uniqueOptionId={optionid} />}
+			<RightPanelContainer arr={childs} ignoreIndex={-1} depth={depth + 1}>
+				{(optionid) => (
+					<ExROptionItemView uniqueOptionId={optionid} depth={depth + 1} />
+				)}
 			</RightPanelContainer>
 		</ChildOptionViewAccordion>
 	);

--- a/src/feature/rightsidepanel/ExROptionRowView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowView.tsx
@@ -9,11 +9,12 @@ interface ExROptionRowViewProps {
 
 export function ExROptionRowView({
 	uniqueOptionId,
+	depth = 0,
 	isLeaf = false,
 }: ExROptionRowViewProps) {
 	return isLeaf ? (
-		<ExROptionRowViewContent uniqueOptionId={uniqueOptionId} />
+		<ExROptionRowViewContent uniqueOptionId={uniqueOptionId} depth={depth} />
 	) : (
-		<ExROptionRowViewContent uniqueOptionId={uniqueOptionId} />
+		<ExROptionRowViewContent uniqueOptionId={uniqueOptionId} depth={depth} />
 	);
 }

--- a/src/feature/rightsidepanel/ExROptionRowViewContent.tsx
+++ b/src/feature/rightsidepanel/ExROptionRowViewContent.tsx
@@ -7,6 +7,7 @@ import { ExRValueView } from "./ExRValueView";
 
 interface ExROptionRowViewContentProps {
 	uniqueOptionId: UniqueOptionId;
+	depth?: number;
 }
 
 /**
@@ -14,6 +15,7 @@ interface ExROptionRowViewContentProps {
  */
 export function ExROptionRowViewContent({
 	uniqueOptionId,
+	depth = 0,
 }: ExROptionRowViewContentProps) {
 	const optionData = exrOptionMetaData.options[uniqueOptionId]?.metaData;
 	const navigate = useExROptionNavigation(uniqueOptionId);
@@ -32,6 +34,7 @@ export function ExROptionRowViewContent({
 				/>
 			}
 			onDoubleClick={navigate}
+			depth={depth}
 		/>
 	);
 }

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -229,11 +229,13 @@ export function groupOptionPairs(
 }
 
 /**
- * 階層（depth）と倍率（multiplier）に基づいてインデント幅（rem）を計算します。
+ * 階層（depth）と倍率（multiplier）、およびベース値に基づいてインデント幅（rem）を計算します。
  */
 export function calculateIndentation(
 	depth: number,
 	multiplier: number,
+	base = 0,
 ): string {
-	return depth > 0 ? `${depth * multiplier}rem` : "0";
+	const total = base + (depth > 0 ? depth * multiplier : 0);
+	return total > 0 ? `${total}rem` : "0";
 }

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -227,3 +227,13 @@ export function groupOptionPairs(
 	}
 	return result;
 }
+
+/**
+ * 階層（depth）と倍率（multiplier）に基づいてインデント幅（rem）を計算します。
+ */
+export function calculateIndentation(
+	depth: number,
+	multiplier: number,
+): string {
+	return depth > 0 ? `${depth * multiplier}rem` : "0";
+}

--- a/tests/ChildOptionViewAccordion.test.tsx
+++ b/tests/ChildOptionViewAccordion.test.tsx
@@ -59,22 +59,25 @@ describe("ChildOptionViewAccordion", () => {
 		expect(button).toHaveAttribute("aria-label", CLOSE);
 	});
 
-	it("should apply padding class when depth > 0", () => {
-		const { container: containerDepth0 } = render(
-			<ChildOptionViewAccordion {...defaultProps} depth={0} />,
-		);
-		expect(containerDepth0.firstChild).not.toHaveClass("pl-2");
+	it("should apply indentation to the header when depth > 0", () => {
+		render(<ChildOptionViewAccordion {...defaultProps} depth={1} />);
 
-		const { container: containerDepth1 } = render(
-			<ChildOptionViewAccordion {...defaultProps} depth={1} />,
-		);
-		expect(containerDepth1.firstChild).toHaveClass("pl-2");
+		// OptionRowContainer now receives the padding through its inner flex div
+		const header = screen.getByText("Option Item");
+		// The parent of Option Item (content area) should have its grandparent as the flex container with style
+		const flexContainer = header.parentElement?.parentElement;
+		expect(flexContainer).toHaveStyle({
+			paddingLeft: "calc(0.875rem)",
+		});
 	});
 
-	it("should apply padding class when depth is large", () => {
-		const { container } = render(
-			<ChildOptionViewAccordion {...defaultProps} depth={5} />,
-		);
-		expect(container.firstChild).toHaveClass("pl-2");
+	it("should apply correct indentation for large depth", () => {
+		render(<ChildOptionViewAccordion {...defaultProps} depth={5} />);
+
+		const header = screen.getByText("Option Item");
+		const flexContainer = header.parentElement?.parentElement;
+		expect(flexContainer).toHaveStyle({
+			paddingLeft: "calc(2.875rem)",
+		});
 	});
 });

--- a/tests/ChildOptionViewAccordion.test.tsx
+++ b/tests/ChildOptionViewAccordion.test.tsx
@@ -67,7 +67,7 @@ describe("ChildOptionViewAccordion", () => {
 		// The parent of Option Item (content area) should have its grandparent as the flex container with style
 		const flexContainer = header.parentElement?.parentElement;
 		expect(flexContainer).toHaveStyle({
-			paddingLeft: "calc(0.875rem)",
+			paddingLeft: "0.875rem",
 		});
 	});
 
@@ -77,7 +77,7 @@ describe("ChildOptionViewAccordion", () => {
 		const header = screen.getByText("Option Item");
 		const flexContainer = header.parentElement?.parentElement;
 		expect(flexContainer).toHaveStyle({
-			paddingLeft: "calc(2.875rem)",
+			paddingLeft: "2.875rem",
 		});
 	});
 });

--- a/tests/RowCustomizeAccordion.test.tsx
+++ b/tests/RowCustomizeAccordion.test.tsx
@@ -30,10 +30,10 @@ describe("RowCustomizeAccordion", () => {
 		expect(contentContainer).toHaveClass("grid-rows-[1fr]");
 	});
 
-    it("should NOT have padding class on container (to support full-width hover background)", () => {
-        const { container } = render(<RowCustomizeAccordion {...defaultProps} />);
-        // The outer div should just be "flex flex-col" without "pl-4"
-        expect(container.firstChild).toHaveClass("flex flex-col");
-        expect(container.firstChild).not.toHaveClass("pl-4");
-    });
+	it("should NOT have padding class on container (to support full-width hover background)", () => {
+		const { container } = render(<RowCustomizeAccordion {...defaultProps} />);
+		// The outer div should just be "flex flex-col" without "pl-4"
+		expect(container.firstChild).toHaveClass("flex flex-col");
+		expect(container.firstChild).not.toHaveClass("pl-4");
+	});
 });

--- a/tests/RowCustomizeAccordion.test.tsx
+++ b/tests/RowCustomizeAccordion.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RowCustomizeAccordion } from "@/components/blocks/OptionEditableAccordion";
+
+describe("RowCustomizeAccordion", () => {
+	const defaultProps = {
+		row: <div>Header Row</div>,
+		isOpen: false,
+		children: <div>Child Content</div>,
+	};
+
+	it("should render row content", () => {
+		render(<RowCustomizeAccordion {...defaultProps} />);
+		expect(screen.getByText("Header Row")).toBeInTheDocument();
+	});
+
+	it("should not render children when isOpen is false", () => {
+		render(<RowCustomizeAccordion {...defaultProps} isOpen={false} />);
+		expect(screen.queryByText("Child Content")).not.toBeInTheDocument();
+
+		const contentContainer = screen.getByTestId("accordion-content");
+		expect(contentContainer).toHaveClass("grid-rows-[0fr]");
+	});
+
+	it("should render children when isOpen is true", () => {
+		render(<RowCustomizeAccordion {...defaultProps} isOpen={true} />);
+		expect(screen.getByText("Child Content")).toBeInTheDocument();
+
+		const contentContainer = screen.getByTestId("accordion-content");
+		expect(contentContainer).toHaveClass("grid-rows-[1fr]");
+	});
+
+    it("should NOT have padding class on container (to support full-width hover background)", () => {
+        const { container } = render(<RowCustomizeAccordion {...defaultProps} />);
+        // The outer div should just be "flex flex-col" without "pl-4"
+        expect(container.firstChild).toHaveClass("flex flex-col");
+        expect(container.firstChild).not.toHaveClass("pl-4");
+    });
+});


### PR DESCRIPTION
アコーディオンがネストされている場合に、インデントされた左側の余白部分でホバー時の背景色が変わらない不具合を修正しました。

主な変更点：
1. `OptionRowContainer` の `pl-1.5` を内部の flex コンテナに移動。
2. `ChildOptionViewAccordion` および `RowCustomizeAccordion` で外側の `div` に設定されていた `pl-2` / `pl-4` を削除。
3. `depth`（階層の深さ）プロップを各コンポーネントに伝播させ、`OptionRowContainer` の `style` プロップを通じて個別にインデントを適用するように変更。
4. 右サイドパネルの `ViewerOptionRow` および `RightPanelBorderLine` / `BorderLine` にも `depth` に基づくインデント処理を追加。
5. 影響を受けるテスト（`ChildOptionViewAccordion.test.tsx`）を、新しいスタイル適用方法に合わせて更新。

これにより、アコーディオンの行をホバーした際、左端から右端まで一貫して背景色が変わるようになります。

---
*PR created automatically by Jules for task [10605587155705085005](https://jules.google.com/task/10605587155705085005) started by @yukieiji*