### PR TITLE
ExROptionItem の isActive 判定の親コンポーネントへの移動

### DIFF
--- a/src/feature/exr/ExRCategoryOptionList.tsx
+++ b/src/feature/exr/ExRCategoryOptionList.tsx
@@ -1,9 +1,11 @@
+import { useShallow } from "zustand/react/shallow";
 import { BorderLine } from "@/components/parts/BorderLine";
 import { LargePoint } from "@/components/parts/LargePoint";
 import { OptionEditorOptionRowGroupLayout } from "@/components/parts/OptionEditorOptionRowLayout";
 import { OptionRowContainer } from "@/components/parts/OptionRowContainer";
 import { groupOptionPairs } from "@/logics/optionUtils";
 import type { UniqueOptionId } from "@/type";
+import { useStore } from "@/useStore";
 import { ExROptionItem } from "./ExROptionItem";
 import { ExRPairedOptionItem } from "./ExRPairedOptionItem";
 
@@ -21,10 +23,15 @@ export function ExRCategoryOptionList({
 	categoryId,
 	uniqueOptionIds,
 }: ExRCategoryOptionListProps) {
+	const activeUniqueOptionIds = useStore(
+		useShallow((state) =>
+			uniqueOptionIds.filter((id) => state.isExROptionActive[id]),
+		),
+	);
 	const shouldGroup = GROUPED_CATEGORY_IDS.includes(categoryId);
 	const groupedItems = shouldGroup
-		? groupOptionPairs(uniqueOptionIds)
-		: uniqueOptionIds;
+		? groupOptionPairs(activeUniqueOptionIds)
+		: activeUniqueOptionIds;
 
 	// gropedItemsはOptionIdの配列か、ペアオプションの情報を持つオブジェクトの配列になる
 	return (

--- a/src/feature/exr/ExROptionItem.tsx
+++ b/src/feature/exr/ExROptionItem.tsx
@@ -1,7 +1,4 @@
-import {
-	useHasActiveOptionChild,
-	useOptionActive,
-} from "@/hooks/useExROptionData";
+import { useHasActiveOptionChild } from "@/hooks/useExROptionData";
 import type { UniqueOptionId } from "@/type";
 import { ExROptionRecursiveItem } from "./ExROptionRecursiveItem";
 import { ExROptionRow } from "./ExROptionRow";
@@ -15,21 +12,14 @@ interface ExROptionItemProps {
 	depth?: number;
 }
 
-function ExROptionItemInner({ uniqueOptionId, depth = 0 }: ExROptionItemProps) {
+export function ExROptionItem({
+	uniqueOptionId,
+	depth = 0,
+}: ExROptionItemProps) {
 	const hasActiveChildren = useHasActiveOptionChild(uniqueOptionId);
 	return hasActiveChildren ? (
 		<ExROptionRecursiveItem uniqueOptionId={uniqueOptionId} depth={depth} />
 	) : (
 		<ExROptionRow uniqueOptionId={uniqueOptionId} depth={depth} isLeaf={true} />
 	);
-}
-
-export function ExROptionItem({
-	uniqueOptionId,
-	depth = 0,
-}: ExROptionItemProps) {
-	const isActive = useOptionActive(uniqueOptionId);
-	return isActive ? (
-		<ExROptionItemInner uniqueOptionId={uniqueOptionId} depth={depth} />
-	) : null;
 }

--- a/src/feature/exr/ExROptionRecursiveItem.tsx
+++ b/src/feature/exr/ExROptionRecursiveItem.tsx
@@ -1,8 +1,8 @@
 import { HighlightableAccordionRow } from "@/components/blocks/HighlightableAccordionRow";
 import { RowCustomizeAccordion } from "@/components/blocks/OptionEditableAccordion";
 import { OptionEditorCategoryOptionLayout } from "@/components/blocks/OptionEditorCategoryOptionLayout";
+import { useActiveChildOptions } from "@/hooks/useExROptionData";
 import { createExRNavigateId } from "@/hooks/useOptionNavigation";
-import { exrOptionMetaData } from "@/logics/api";
 import type { UniqueOptionId } from "@/type";
 import { useStore } from "@/useStore";
 import { ExROptionItem } from "./ExROptionItem";
@@ -34,8 +34,7 @@ export function ExROptionRecursiveItem({
 		return state.highlightedExROptionId === uniqueOptionId;
 	});
 
-	const childs =
-		exrOptionMetaData.options[uniqueOptionId]?.childOptionIds ?? [];
+	const activeChilds = useActiveChildOptions(uniqueOptionId);
 
 	const navigateId = createExRNavigateId(uniqueOptionId);
 
@@ -59,7 +58,7 @@ export function ExROptionRecursiveItem({
 			isOpen={isOpen}
 		>
 			<OptionEditorCategoryOptionLayout
-				arr={childs}
+				arr={activeChilds}
 				ignoreIndex={-1}
 				depth={depth + 1}
 			>

--- a/src/feature/rightsidepanel/ExRCategoryViewer.tsx
+++ b/src/feature/rightsidepanel/ExRCategoryViewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { RightPanelContainer } from "@/components/blocks/RightPanelContainer";
 import { ViewerGroupAccordion } from "@/components/blocks/ViewerGroupAccordion";
 import { ColoredText } from "@/components/parts/ColoredText";
@@ -21,16 +21,22 @@ export function ExRCategoryViewer({ categoryId }: ExRCategoryViewerProps) {
 
 	const uniqueOptions =
 		exrOptionMetaData.globalCategoryIdTopLevelMap[categoryId];
-	const filteredOptions = useMemo(() => {
-		if (!uniqueOptions) {
-			return [];
-		}
-		return uniqueOptions.filter((uniqueId) => {
-			return uniqueId !== PRESET_OPTION_UNIQUE_ID;
-		});
-	}, [uniqueOptions]);
 
-	if (filteredOptions.length === 0) {
+	const activeOptions = useStore(
+		useShallow((state) => {
+			if (!uniqueOptions) {
+				return [];
+			}
+			return uniqueOptions.filter((uniqueId) => {
+				return (
+					uniqueId !== PRESET_OPTION_UNIQUE_ID &&
+					state.isExROptionActive[uniqueId]
+				);
+			});
+		}),
+	);
+
+	if (activeOptions.length === 0) {
 		return null;
 	}
 
@@ -46,7 +52,7 @@ export function ExRCategoryViewer({ categoryId }: ExRCategoryViewerProps) {
 				toggleCategory(categoryId);
 			}}
 		>
-			<RightPanelContainer arr={filteredOptions} ignoreIndex={0}>
+			<RightPanelContainer arr={activeOptions} ignoreIndex={0}>
 				{(optionid) => <ExROptionItemView uniqueOptionId={optionid} />}
 			</RightPanelContainer>
 		</ViewerGroupAccordion>

--- a/src/feature/rightsidepanel/ExROptionItemView.tsx
+++ b/src/feature/rightsidepanel/ExROptionItemView.tsx
@@ -1,7 +1,4 @@
-import {
-	useHasActiveOptionChild,
-	useOptionActive,
-} from "@/hooks/useExROptionData";
+import { useHasActiveOptionChild } from "@/hooks/useExROptionData";
 import type { UniqueOptionId } from "@/type";
 import { ExROptionRecursiveItemView } from "./ExROptionRecursiveItemView";
 import { ExROptionRowView } from "./ExROptionRowView";
@@ -11,7 +8,7 @@ interface ExROptionItemViewProps {
 	depth?: number;
 }
 
-function ExROptionItemViewInner({
+export function ExROptionItemView({
 	uniqueOptionId,
 	depth = 0,
 }: ExROptionItemViewProps) {
@@ -25,14 +22,4 @@ function ExROptionItemViewInner({
 			isLeaf={true}
 		/>
 	);
-}
-
-export function ExROptionItemView({
-	uniqueOptionId,
-	depth = 0,
-}: ExROptionItemViewProps) {
-	const isActive = useOptionActive(uniqueOptionId);
-	return isActive ? (
-		<ExROptionItemViewInner uniqueOptionId={uniqueOptionId} depth={depth} />
-	) : null;
 }

--- a/src/feature/rightsidepanel/ExROptionRecursiveItemView.tsx
+++ b/src/feature/rightsidepanel/ExROptionRecursiveItemView.tsx
@@ -1,6 +1,6 @@
 import { ChildOptionViewAccordion } from "@/components/blocks/ChildOptionViewAccordion";
 import { RightPanelContainer } from "@/components/blocks/RightPanelContainer";
-import { exrOptionMetaData } from "@/logics/api";
+import { useActiveChildOptions } from "@/hooks/useExROptionData";
 import type { UniqueOptionId } from "@/type";
 import { useStore } from "@/useStore";
 import { ExROptionItemView } from "./ExROptionItemView";
@@ -29,8 +29,7 @@ export function ExROptionRecursiveItemView({
 		toggleExROption(uniqueOptionId);
 	};
 
-	const childs =
-		exrOptionMetaData.options[uniqueOptionId]?.childOptionIds ?? [];
+	const activeChilds = useActiveChildOptions(uniqueOptionId);
 
 	return (
 		<ChildOptionViewAccordion
@@ -45,7 +44,11 @@ export function ExROptionRecursiveItemView({
 			onToggle={handleToggle}
 			depth={depth}
 		>
-			<RightPanelContainer arr={childs} ignoreIndex={-1} depth={depth + 1}>
+			<RightPanelContainer
+				arr={activeChilds}
+				ignoreIndex={-1}
+				depth={depth + 1}
+			>
 				{(optionid) => (
 					<ExROptionItemView uniqueOptionId={optionid} depth={depth + 1} />
 				)}

--- a/src/hooks/useExROptionData.ts
+++ b/src/hooks/useExROptionData.ts
@@ -22,6 +22,18 @@ export function useOptionActive(uniqueOptionId: UniqueOptionId): boolean {
 	);
 }
 
+export function useActiveChildOptions(
+	uniqueOptionId: UniqueOptionId,
+): UniqueOptionId[] {
+	const childs =
+		exrOptionMetaData.options[uniqueOptionId]?.childOptionIds ?? [];
+	return useStore(
+		useShallow((state) =>
+			childs.filter((childId) => state.isExROptionActive[childId]),
+		),
+	);
+}
+
 export function useHasActiveOptionChild(
 	uniqueOptionId: UniqueOptionId,
 ): boolean {

--- a/tests/ExRCategoryViewer.test.tsx
+++ b/tests/ExRCategoryViewer.test.tsx
@@ -41,6 +41,16 @@ describe("ExRCategoryViewer", () => {
 			name: "Test Category",
 			tabId: 0,
 		};
+
+		// Default all options as active for tests unless specified otherwise
+		useStore.setState({
+			isExROptionActive: new Proxy(
+				{},
+				{
+					get: () => true,
+				},
+			),
+		});
 	});
 
 	it("renders null if there are no options in the category", () => {

--- a/tests/ExROptionItemView.test.tsx
+++ b/tests/ExROptionItemView.test.tsx
@@ -1,10 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExROptionItemView } from "@/feature/rightsidepanel/ExROptionItemView";
-import {
-	useHasActiveOptionChild,
-	useOptionActive,
-} from "@/hooks/useExROptionData";
+import { useHasActiveOptionChild } from "@/hooks/useExROptionData";
 import type { UniqueOptionId } from "@/type";
 
 vi.mock("@/hooks/useExROptionData");
@@ -43,18 +40,7 @@ describe("ExROptionItemView", () => {
 		vi.clearAllMocks();
 	});
 
-	it("renders nothing when the option is not active", () => {
-		vi.mocked(useOptionActive).mockReturnValue(false);
-
-		const { container } = render(
-			<ExROptionItemView uniqueOptionId={mockUniqueId} depth={mockDepth} />,
-		);
-
-		expect(container.firstChild).toBeNull();
-	});
-
-	it("renders ExROptionRowView when the option is active and has no active children", () => {
-		vi.mocked(useOptionActive).mockReturnValue(true);
+	it("renders ExROptionRowView when the option has no active children", () => {
 		vi.mocked(useHasActiveOptionChild).mockReturnValue(false);
 
 		render(
@@ -67,8 +53,7 @@ describe("ExROptionItemView", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders ExROptionRecursiveItemView when the option is active and has active children", () => {
-		vi.mocked(useOptionActive).mockReturnValue(true);
+	it("renders ExROptionRecursiveItemView when the option has active children", () => {
 		vi.mocked(useHasActiveOptionChild).mockReturnValue(true);
 
 		render(
@@ -84,7 +69,6 @@ describe("ExROptionItemView", () => {
 	});
 
 	it("uses default depth of 0 when depth prop is not provided", () => {
-		vi.mocked(useOptionActive).mockReturnValue(true);
 		vi.mocked(useHasActiveOptionChild).mockReturnValue(false);
 
 		render(<ExROptionItemView uniqueOptionId={mockUniqueId} />);

--- a/tests/ExROptionRecursiveItemView.test.tsx
+++ b/tests/ExROptionRecursiveItemView.test.tsx
@@ -46,6 +46,11 @@ describe("ExROptionRecursiveItemView", () => {
 		// Manually reset relevant store state
 		useStore.setState({
 			openedExROptionRightSidePanel: {},
+			isExROptionActive: {
+				[parentId]: true,
+				[childId1]: true,
+				[childId2]: true,
+			},
 		});
 
 		// Setup metadata


### PR DESCRIPTION
ExROptionItem および ExROptionItemView から isActive による自己判定を削除し、親コンポーネント（ExROptionRecursiveItem, ExRCategoryOptionList, ExRCategoryViewer）側で表示対象をフィルタリングするように変更しました。

これにより、非表示の項目の前後に BorderLine が重複して表示されるなどのレイアウト上の不具合が解消されます。また、共通のフィルタリングロジックを `useActiveChildOptions` フックとして抽出し、再利用性と保守性を向上させました。

---
*PR created automatically by Jules for task [11636656532188570927](https://jules.google.com/task/11636656532188570927) started by @yukieiji*