### PR TITLE
OptionSingleSliderのInput入力不具合の修正

### DIFF
--- a/src/components/blocks/OptionSingleSlider.tsx
+++ b/src/components/blocks/OptionSingleSlider.tsx
@@ -50,7 +50,6 @@ export function OptionSingleSlider({
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Enter") {
-			commitValue();
 			e.currentTarget.blur();
 		}
 	};

--- a/src/components/blocks/OptionSingleSlider.tsx
+++ b/src/components/blocks/OptionSingleSlider.tsx
@@ -39,7 +39,9 @@ export function OptionSingleSlider({
 			return;
 		}
 
-		onChange(findClosestIndex(values, val));
+		const closestIdx = findClosestIndex(values, val);
+		inputRef.current.value = (values[closestIdx] ?? values[0] ?? 0).toString();
+		onChange(closestIdx);
 	};
 
 	const handleBlur = () => {

--- a/src/components/blocks/OptionSingleSlider.tsx
+++ b/src/components/blocks/OptionSingleSlider.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useId, useRef } from "react";
 import { findClosestIndex } from "@/logics/optionUtils";
 import { OptionFormat } from "../parts/OptionFormat";
 import { Field, FieldLabel, FieldSet } from "../ui/field";
@@ -23,18 +23,34 @@ export function OptionSingleSlider({
 }: OptionSingleSliderProps) {
 	const id = useId();
 	const currentValue = values[selection] ?? values[0] ?? 0;
+	const inputRef = useRef<HTMLInputElement>(null);
 
 	const handleSliderChange = (val: number | readonly number[]) => {
 		onChange(Array.isArray(val) ? val[0] : val);
 	};
 
-	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const val = parseFloat(e.target.value);
+	const commitValue = () => {
+		if (!inputRef.current) {
+			return;
+		}
+		const val = parseFloat(inputRef.current.value);
 		if (Number.isNaN(val)) {
+			inputRef.current.value = currentValue.toString();
 			return;
 		}
 
 		onChange(findClosestIndex(values, val));
+	};
+
+	const handleBlur = () => {
+		commitValue();
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			commitValue();
+			e.currentTarget.blur();
+		}
 	};
 
 	return (
@@ -43,9 +59,12 @@ export function OptionSingleSlider({
 				<FieldLabel htmlFor={id}>{label}</FieldLabel>
 				<Input
 					id={id}
+					ref={inputRef}
 					type="text"
-					value={currentValue}
-					onChange={handleInputChange}
+					key={selection}
+					defaultValue={currentValue.toString()}
+					onBlur={handleBlur}
+					onKeyDown={handleKeyDown}
 				/>
 				<Label htmlFor={id}>
 					<OptionFormat format={format} />

--- a/tests/OptionSingleSlider.test.tsx
+++ b/tests/OptionSingleSlider.test.tsx
@@ -54,7 +54,7 @@ describe("OptionSingleSlider", () => {
 		expect(onChange).toHaveBeenCalledWith(3);
 	});
 
-	it("calls onChange with closest value when input changes", async () => {
+	it("calls onChange with closest value when input changes and blurred", async () => {
 		const onChange = vi.fn();
 		await act(async () => {
 			render(
@@ -74,12 +74,51 @@ describe("OptionSingleSlider", () => {
 		await act(async () => {
 			fireEvent.change(input, { target: { value: "24" } });
 		});
+		// Should not be called yet
+		expect(onChange).not.toHaveBeenCalled();
+
+		await act(async () => {
+			fireEvent.blur(input);
+		});
 		expect(onChange).toHaveBeenCalledWith(1);
 
 		// 26 is closer to 30 (index 2)
 		await act(async () => {
 			fireEvent.change(input, { target: { value: "26" } });
+			fireEvent.keyDown(input, { key: "Enter" });
 		});
+		expect(onChange).toHaveBeenCalledWith(2);
+	});
+
+	it("allows clearing input and then entering a value", async () => {
+		const onChange = vi.fn();
+		await act(async () => {
+			render(
+				<OptionSingleSlider
+					label={mockLabel}
+					selection={1}
+					values={mockValues}
+					format={mockFormat}
+					onChange={onChange}
+				/>,
+			);
+		});
+
+		const input = screen.getByRole("textbox");
+
+		await act(async () => {
+			fireEvent.change(input, { target: { value: "" } });
+		});
+		expect(input).toHaveValue("");
+		expect(onChange).not.toHaveBeenCalled();
+
+		await act(async () => {
+			fireEvent.change(input, { target: { value: "35" } });
+			fireEvent.blur(input);
+		});
+		// 35 is between 30 (index 2) and 40 (index 3).
+		// findClosestIndex: 30 - 35 = 5, 40 - 35 = 5. Ties usually take the first one or last one.
+		// values = [10, 20, 30, 40, 50]
 		expect(onChange).toHaveBeenCalledWith(2);
 	});
 });

--- a/tests/OptionSingleSlider.test.tsx
+++ b/tests/OptionSingleSlider.test.tsx
@@ -121,4 +121,31 @@ describe("OptionSingleSlider", () => {
 		// values = [10, 20, 30, 40, 50]
 		expect(onChange).toHaveBeenCalledWith(2);
 	});
+
+	it("snaps input value back even if selection index doesn't change", async () => {
+		const onChange = vi.fn();
+		await act(async () => {
+			render(
+				<OptionSingleSlider
+					label={mockLabel}
+					selection={1} // Value is 20
+					values={mockValues}
+					format={mockFormat}
+					onChange={onChange}
+				/>,
+			);
+		});
+
+		const input = screen.getByRole("textbox");
+
+		// 21 is closest to 20 (index 1)
+		await act(async () => {
+			fireEvent.change(input, { target: { value: "21" } });
+			fireEvent.blur(input);
+		});
+
+		// Selection index 1 didn't change, but input should snap back to "20"
+		expect(onChange).toHaveBeenCalledWith(1);
+		expect(input).toHaveValue("20");
+	});
 });

--- a/tests/OptionSingleSlider.test.tsx
+++ b/tests/OptionSingleSlider.test.tsx
@@ -86,6 +86,7 @@ describe("OptionSingleSlider", () => {
 		await act(async () => {
 			fireEvent.change(input, { target: { value: "26" } });
 			fireEvent.keyDown(input, { key: "Enter" });
+			fireEvent.blur(input);
 		});
 		expect(onChange).toHaveBeenCalledWith(2);
 	});


### PR DESCRIPTION
OptionSingleSliderのInputにおいて、既存の数値を削除してから新しい数値を入力できない問題を修正しました。
以前はonChangeが入力ごとに走り、不完全な数値（空文字など）の場合にNaNとなり更新が無視される、あるいはスナップ機能によって元の値に戻される動作になっていました。
今回の変更では、Inputを非制御コンポーネントとし、フォーカスが外れたタイミング（onBlur）またはEnterキーが押されたタイミングで値を確定させるようにしました。これにより、入力中の一時的な空の状態を維持できるようになり、スムーズな再入力が可能になりました。
また、プロジェクトの規約（AGENTS.md）を遵守し、useStateを使わずにuseRefとdefaultValue(keyによるリセット)を用いた実装としています。

---
*PR created automatically by Jules for task [7314333051687735788](https://jules.google.com/task/7314333051687735788) started by @yukieiji*