### PR TITLE
Refactor OptionSlider logic into a shared hook

### DIFF
--- a/src/components/blocks/OptionSingleSlider.tsx
+++ b/src/components/blocks/OptionSingleSlider.tsx
@@ -1,5 +1,5 @@
-import { useId, useRef } from "react";
-import { findClosestIndex } from "@/logics/optionUtils";
+import { useId } from "react";
+import { useOptionSlider } from "@/hooks/useOptionSlider";
 import { OptionFormat } from "../parts/OptionFormat";
 import { Field, FieldLabel, FieldSet } from "../ui/field";
 import { Input } from "../ui/input";
@@ -22,37 +22,8 @@ export function OptionSingleSlider({
 	onChange,
 }: OptionSingleSliderProps) {
 	const id = useId();
-	const currentValue = values[selection] ?? values[0] ?? 0;
-	const inputRef = useRef<HTMLInputElement>(null);
-
-	const handleSliderChange = (val: number | readonly number[]) => {
-		onChange(Array.isArray(val) ? val[0] : val);
-	};
-
-	const commitValue = () => {
-		if (!inputRef.current) {
-			return;
-		}
-		const val = parseFloat(inputRef.current.value);
-		if (Number.isNaN(val)) {
-			inputRef.current.value = currentValue.toString();
-			return;
-		}
-
-		const closestIdx = findClosestIndex(values, val);
-		inputRef.current.value = (values[closestIdx] ?? values[0] ?? 0).toString();
-		onChange(closestIdx);
-	};
-
-	const handleBlur = () => {
-		commitValue();
-	};
-
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-		if (e.key === "Enter") {
-			e.currentTarget.blur();
-		}
-	};
+	const { currentValue, inputRef, handleSliderChange, handleBlur, handleKeyDown } =
+		useOptionSlider({ selection, values, onChange });
 
 	return (
 		<FieldSet>

--- a/src/components/blocks/OptionSingleSlider.tsx
+++ b/src/components/blocks/OptionSingleSlider.tsx
@@ -38,7 +38,6 @@ export function OptionSingleSlider({
 					id={id}
 					ref={inputRef}
 					type="text"
-					key={selection}
 					defaultValue={currentValue.toString()}
 					onBlur={handleBlur}
 					onKeyDown={handleKeyDown}

--- a/src/components/blocks/OptionSingleSlider.tsx
+++ b/src/components/blocks/OptionSingleSlider.tsx
@@ -22,8 +22,13 @@ export function OptionSingleSlider({
 	onChange,
 }: OptionSingleSliderProps) {
 	const id = useId();
-	const { currentValue, inputRef, handleSliderChange, handleBlur, handleKeyDown } =
-		useOptionSlider({ selection, values, onChange });
+	const {
+		currentValue,
+		inputRef,
+		handleSliderChange,
+		handleBlur,
+		handleKeyDown,
+	} = useOptionSlider({ selection, values, onChange });
 
 	return (
 		<FieldSet>

--- a/src/components/blocks/OptionSliderControl.tsx
+++ b/src/components/blocks/OptionSliderControl.tsx
@@ -1,7 +1,7 @@
 import { useId } from "react";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
-import { findClosestIndex } from "@/logics/optionUtils";
+import { useOptionSlider } from "@/hooks/useOptionSlider";
 import { OptionFormat } from "../parts/OptionFormat";
 import { Field, FieldSet } from "../ui/field";
 import { Label } from "../ui/label";
@@ -23,21 +23,8 @@ export function OptionSliderControl({
 	onChange,
 }: OptionSliderControlProps) {
 	const id = useId();
-
-	const currentValue = values[selection] ?? values[0] ?? 0;
-
-	const handleSliderChange = (val: number | readonly number[]) => {
-		onChange(Array.isArray(val) ? val[0] : val);
-	};
-
-	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const val = parseFloat(e.target.value);
-		if (Number.isNaN(val)) {
-			return;
-		}
-
-		onChange(findClosestIndex(values, val));
-	};
+	const { currentValue, inputRef, handleSliderChange, handleBlur, handleKeyDown } =
+		useOptionSlider({ selection, values, onChange });
 
 	return (
 		<FieldSet>
@@ -52,9 +39,12 @@ export function OptionSliderControl({
 			<Field orientation="horizontal">
 				<Input
 					id={id}
+					ref={inputRef}
 					type="text"
-					value={currentValue}
-					onChange={handleInputChange}
+					key={selection}
+					defaultValue={currentValue.toString()}
+					onBlur={handleBlur}
+					onKeyDown={handleKeyDown}
 				/>
 				<Label htmlFor={id}>
 					<OptionFormat format={format} />

--- a/src/components/blocks/OptionSliderControl.tsx
+++ b/src/components/blocks/OptionSliderControl.tsx
@@ -46,7 +46,6 @@ export function OptionSliderControl({
 					id={id}
 					ref={inputRef}
 					type="text"
-					key={selection}
 					defaultValue={currentValue.toString()}
 					onBlur={handleBlur}
 					onKeyDown={handleKeyDown}

--- a/src/components/blocks/OptionSliderControl.tsx
+++ b/src/components/blocks/OptionSliderControl.tsx
@@ -23,8 +23,13 @@ export function OptionSliderControl({
 	onChange,
 }: OptionSliderControlProps) {
 	const id = useId();
-	const { currentValue, inputRef, handleSliderChange, handleBlur, handleKeyDown } =
-		useOptionSlider({ selection, values, onChange });
+	const {
+		currentValue,
+		inputRef,
+		handleSliderChange,
+		handleBlur,
+		handleKeyDown,
+	} = useOptionSlider({ selection, values, onChange });
 
 	return (
 		<FieldSet>

--- a/src/hooks/useOptionSlider.ts
+++ b/src/hooks/useOptionSlider.ts
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
 import type { KeyboardEvent } from "react";
+import { useEffect, useRef } from "react";
 import { findClosestIndex } from "@/logics/optionUtils";
 
 interface UseOptionSliderProps {

--- a/src/hooks/useOptionSlider.ts
+++ b/src/hooks/useOptionSlider.ts
@@ -1,0 +1,55 @@
+import { useRef } from "react";
+import { findClosestIndex } from "@/logics/optionUtils";
+
+interface UseOptionSliderProps {
+	selection: number;
+	values: number[];
+	onChange: (selection: number) => void;
+}
+
+export function useOptionSlider({
+	selection,
+	values,
+	onChange,
+}: UseOptionSliderProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const currentValue = values[selection] ?? values[0] ?? 0;
+
+	const handleSliderChange = (val: number | readonly number[]) => {
+		const newIndex = Array.isArray(val) ? val[0] : val;
+		onChange(newIndex);
+	};
+
+	const commitValue = () => {
+		if (!inputRef.current) {
+			return;
+		}
+		const val = parseFloat(inputRef.current.value);
+		if (Number.isNaN(val)) {
+			inputRef.current.value = currentValue.toString();
+			return;
+		}
+
+		const closestIdx = findClosestIndex(values, val);
+		inputRef.current.value = (values[closestIdx] ?? values[0] ?? 0).toString();
+		onChange(closestIdx);
+	};
+
+	const handleBlur = () => {
+		commitValue();
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			e.currentTarget.blur();
+		}
+	};
+
+	return {
+		currentValue,
+		inputRef,
+		handleSliderChange,
+		handleBlur,
+		handleKeyDown,
+	};
+}

--- a/src/hooks/useOptionSlider.ts
+++ b/src/hooks/useOptionSlider.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { findClosestIndex } from "@/logics/optionUtils";
 
 interface UseOptionSliderProps {
@@ -14,6 +14,12 @@ export function useOptionSlider({
 }: UseOptionSliderProps) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const currentValue = values[selection] ?? values[0] ?? 0;
+
+	useEffect(() => {
+		if (inputRef.current) {
+			inputRef.current.value = currentValue.toString();
+		}
+	}, [currentValue]);
 
 	const handleSliderChange = (val: number | readonly number[]) => {
 		const newIndex = Array.isArray(val) ? val[0] : val;

--- a/src/hooks/useOptionSlider.ts
+++ b/src/hooks/useOptionSlider.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import type { KeyboardEvent } from "react";
 import { findClosestIndex } from "@/logics/optionUtils";
 
 interface UseOptionSliderProps {
@@ -45,7 +46,7 @@ export function useOptionSlider({
 		commitValue();
 	};
 
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Enter") {
 			e.currentTarget.blur();
 		}

--- a/tests/AuOptionControl.test.tsx
+++ b/tests/AuOptionControl.test.tsx
@@ -91,6 +91,7 @@ describe("AuOptionControl", () => {
 		// Test handleInputChange (text input)
 		const input = screen.getByRole("textbox");
 		fireEvent.change(input, { target: { value: "4" } });
+		fireEvent.blur(input);
 		expect(onSelectionChangeMock).toHaveBeenCalledWith(4);
 	});
 

--- a/tests/OptionSliderControl.test.tsx
+++ b/tests/OptionSliderControl.test.tsx
@@ -51,7 +51,7 @@ describe("OptionSliderControl", () => {
 		expect(onChange).toHaveBeenCalledWith(3);
 	});
 
-	it("calls onChange with closest value when input changes", async () => {
+	it("calls onChange with closest value when input changes and blurred", async () => {
 		const onChange = vi.fn();
 		await act(async () => {
 			render(
@@ -70,17 +70,25 @@ describe("OptionSliderControl", () => {
 		await act(async () => {
 			fireEvent.change(input, { target: { value: "24" } });
 		});
+		// Should not be called yet (unified behavior: blur/enter)
+		expect(onChange).not.toHaveBeenCalled();
+
+		await act(async () => {
+			fireEvent.blur(input);
+		});
 		expect(onChange).toHaveBeenCalledWith(1);
 
 		// 26 is closer to 30 (index 2)
 		await act(async () => {
 			fireEvent.change(input, { target: { value: "26" } });
+			fireEvent.blur(input);
 		});
 		expect(onChange).toHaveBeenCalledWith(2);
 
 		// 100 is closer to 50 (index 4)
 		await act(async () => {
 			fireEvent.change(input, { target: { value: "100" } });
+			fireEvent.blur(input);
 		});
 		expect(onChange).toHaveBeenCalledWith(4);
 	});


### PR DESCRIPTION
This PR refactors `OptionSingleSlider` and `OptionSliderControl` to eliminate duplicated logic.

Key changes:
1. **New `useOptionSlider` hook**: Centralizes state management and event handlers for components combining a slider and a numeric text input.
2. **Unified behavior**: `OptionSliderControl` was previously updating on every keystroke, while `OptionSingleSlider` updated on blur/enter. They are now unified to the blur/enter behavior, which provides a more consistent user experience for numeric inputs that snap to discrete values.
3. **Cleaned up components**: The components now focus only on their specific layout and UI elements (labels, field structure).
4. **Verified with tests**: Existing tests for `OptionSingleSlider` still pass, and `OptionSliderControl` tests have been updated to match the new unified behavior.

---
*PR created automatically by Jules for task [9028902991973694429](https://jules.google.com/task/9028902991973694429) started by @yukieiji*