### PR TITLE
CompactSliderのリファクタリング（useOptionSliderの導入）

### DIFF
--- a/src/components/blocks/RoleSpawnControls.tsx
+++ b/src/components/blocks/RoleSpawnControls.tsx
@@ -5,7 +5,6 @@ interface ControlProps {
 	values: number[];
 	currentSelection: number;
 	onSelectionChange: (selection: number) => void;
-	onInputChange: (value: number) => void;
 }
 
 interface RoleSpawnControlsProps {
@@ -21,7 +20,6 @@ export function RoleSpawnControls({ rate, num }: RoleSpawnControlsProps) {
 				values={rate.values}
 				currentSelection={rate.currentSelection}
 				onSelectionChange={rate.onSelectionChange}
-				onInputChange={rate.onInputChange}
 				testId="spawn-rate-control"
 			/>
 			<CompactSlider
@@ -29,7 +27,6 @@ export function RoleSpawnControls({ rate, num }: RoleSpawnControlsProps) {
 				values={num.values}
 				currentSelection={num.currentSelection}
 				onSelectionChange={num.onSelectionChange}
-				onInputChange={num.onInputChange}
 				testId="spawn-count-control"
 			/>
 		</div>

--- a/src/components/parts/CompactSlider.tsx
+++ b/src/components/parts/CompactSlider.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
-import { useId } from "react";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
+import { useOptionSlider } from "@/hooks/useOptionSlider";
 import { Field, FieldLabel, FieldSet } from "../ui/field";
 
 interface CompactSliderProps {
@@ -9,7 +9,6 @@ interface CompactSliderProps {
 	values: number[];
 	currentSelection: number;
 	onSelectionChange: (selection: number) => void;
-	onInputChange: (value: number) => void;
 	testId?: string;
 }
 
@@ -22,23 +21,16 @@ export function CompactSlider({
 	values,
 	currentSelection,
 	onSelectionChange,
-	onInputChange,
 	testId,
 }: CompactSliderProps) {
-	const id = useId();
-	const currentValue = values[currentSelection] ?? values[0] ?? 0;
-
-	const handleSliderChange = (val: number | readonly number[]) => {
-		onSelectionChange(Array.isArray(val) ? val[0] : val);
-	};
-
-	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		e.stopPropagation();
-		const val = parseFloat(e.target.value);
-		if (!Number.isNaN(val)) {
-			onInputChange(val);
-		}
-	};
+	const {
+		id,
+		currentValue,
+		inputRef,
+		handleSliderChange,
+		handleBlur,
+		handleKeyDown,
+	} = useOptionSlider(currentSelection, values, onSelectionChange);
 
 	const stopPropagation = (e: React.MouseEvent | React.KeyboardEvent) => {
 		e.stopPropagation();
@@ -57,9 +49,11 @@ export function CompactSlider({
 				</FieldLabel>
 				<Input
 					id={id}
+					ref={inputRef}
 					type="text"
-					value={currentValue}
-					onChange={handleInputChange}
+					defaultValue={currentValue.toString()}
+					onBlur={handleBlur}
+					onKeyDown={handleKeyDown}
 				/>
 			</Field>
 			<Slider

--- a/src/feature/amongus/AuRoleSpawnControls.tsx
+++ b/src/feature/amongus/AuRoleSpawnControls.tsx
@@ -76,10 +76,6 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 		}
 	};
 
-	const handleChanceInputChange = (val: number) => {
-		handleChanceChange(findClosestIndex(chanceValues, val));
-	};
-
 	const handleMaxCountChange = (newSelection: number) => {
 		const newMaxCountValue = maxCountValues[newSelection] ?? 0;
 		const isBecomingEnabled = isChanceZero && newMaxCountValue > 0;
@@ -125,23 +121,17 @@ export function AuRoleSpawnControls({ categoryId }: AuRoleSpawnControlsProps) {
 		}
 	};
 
-	const handleMaxCountInputChange = (val: number) => {
-		handleMaxCountChange(findClosestIndex(maxCountValues, val));
-	};
-
 	return (
 		<RoleSpawnControls
 			rate={{
 				values: chanceValues,
 				currentSelection: chanceSelection,
 				onSelectionChange: handleChanceChange,
-				onInputChange: handleChanceInputChange,
 			}}
 			num={{
 				values: maxCountValues,
 				currentSelection: maxCountSelection,
 				onSelectionChange: handleMaxCountChange,
-				onInputChange: handleMaxCountInputChange,
 			}}
 		/>
 	);

--- a/src/feature/exr/ExRHeaderOptionControl.tsx
+++ b/src/feature/exr/ExRHeaderOptionControl.tsx
@@ -1,6 +1,6 @@
 import { CompactSlider } from "@/components/parts/CompactSlider";
 import { useUpdateExROptionSelection } from "@/logics/api.store";
-import { findClosestIndex, getUniqueOptionId } from "@/logics/optionUtils";
+import { getUniqueOptionId } from "@/logics/optionUtils";
 import type { ExROptionDto } from "@/type";
 import { useStore } from "@/useStore";
 
@@ -35,20 +35,12 @@ export function ExRHeaderOptionControl({
 		});
 	};
 
-	const handleInputChange = async (val: number) => {
-		await updateExRSelection({
-			uniqueOptionId: uniqueId,
-			selection: findClosestIndex(values, val),
-		});
-	};
-
 	return (
 		<CompactSlider
 			label={label}
 			values={values}
 			currentSelection={currentSelection}
 			onSelectionChange={handleSelectionChange}
-			onInputChange={handleInputChange}
 		/>
 	);
 }

--- a/src/feature/exr/ExRRoleSpawnControls.tsx
+++ b/src/feature/exr/ExRRoleSpawnControls.tsx
@@ -72,10 +72,6 @@ export function ExRRoleSpawnControls({
 		}
 	};
 
-	const handleRateInputChange = async (val: number) => {
-		await handleRateChange(findClosestIndex(rateValues, val));
-	};
-
 	const handleCountUIChange = async (newUISelection: number) => {
 		const isBecomingEnabled = isSpawnRateZero && newUISelection > 0;
 
@@ -115,23 +111,17 @@ export function ExRRoleSpawnControls({
 		}
 	};
 
-	const handleCountUIInputChange = async (val: number) => {
-		await handleCountUIChange(findClosestIndex(virtualCountValues, val));
-	};
-
 	return (
 		<RoleSpawnControls
 			rate={{
 				values: rateValues,
 				currentSelection: spawnRateSelection,
 				onSelectionChange: handleRateChange,
-				onInputChange: handleRateInputChange,
 			}}
 			num={{
 				values: virtualCountValues,
 				currentSelection: currentCountUISelection,
 				onSelectionChange: handleCountUIChange,
-				onInputChange: handleCountUIInputChange,
 			}}
 		/>
 	);

--- a/tests/CompactSlider.test.tsx
+++ b/tests/CompactSlider.test.tsx
@@ -8,7 +8,6 @@ describe("CompactSlider", () => {
 		currentSelection: 1,
 		values: [0, 10, 20, 30],
 		onSelectionChange: vi.fn(),
-		onInputChange: vi.fn(),
 	};
 
 	it("renders label and current value correctly", async () => {
@@ -47,18 +46,25 @@ describe("CompactSlider", () => {
 		expect(onSelectionChange).toHaveBeenCalledWith(2);
 	});
 
-	it("calls onInputChange when input value changes", async () => {
-		const onInputChange = vi.fn();
+	it("calls onSelectionChange with closest index when input is blurred", async () => {
+		const onSelectionChange = vi.fn();
 		await act(async () => {
-			render(<CompactSlider {...defaultProps} onInputChange={onInputChange} />);
+			render(
+				<CompactSlider
+					{...defaultProps}
+					onSelectionChange={onSelectionChange}
+				/>,
+			);
 		});
 
 		const input = screen.getByRole("textbox");
 		await act(async () => {
-			fireEvent.change(input, { target: { value: "25" } });
+			fireEvent.change(input, { target: { value: "26" } });
+			fireEvent.blur(input);
 		});
 
-		expect(onInputChange).toHaveBeenCalledWith(25);
+		// 26 is closest to values[3] (30)
+		expect(onSelectionChange).toHaveBeenCalledWith(3);
 	});
 
 	it("stops propagation when slider is changed", async () => {
@@ -86,23 +92,27 @@ describe("CompactSlider", () => {
 	});
 
 	it("stops propagation when input is changed", async () => {
-		const onInputChange = vi.fn();
+		const onSelectionChange = vi.fn();
 		const onParentClick = vi.fn();
 		await act(async () => {
 			render(
 				// biome-ignore lint/a11y/noStaticElementInteractions: test
 				<div onClick={onParentClick} onKeyDown={onParentClick}>
-					<CompactSlider {...defaultProps} onInputChange={onInputChange} />
+					<CompactSlider
+						{...defaultProps}
+						onSelectionChange={onSelectionChange}
+					/>
 				</div>,
 			);
 		});
 
 		const input = screen.getByRole("textbox");
 		await act(async () => {
-			fireEvent.change(input, { target: { value: "25" } });
+			fireEvent.change(input, { target: { value: "26" } });
+			fireEvent.blur(input);
 		});
 
-		expect(onInputChange).toHaveBeenCalled();
+		expect(onSelectionChange).toHaveBeenCalled();
 		expect(onParentClick).not.toHaveBeenCalled();
 	});
 

--- a/tests/ExRHeaderOptionControl.test.tsx
+++ b/tests/ExRHeaderOptionControl.test.tsx
@@ -94,7 +94,7 @@ describe("ExRHeaderOptionControl", () => {
 		).toBe(1);
 	});
 
-	it("updates selection when input is changed", async () => {
+	it("updates selection when input is changed and blurred", async () => {
 		setUpudateExROptionSelectionMock(mockOption.RangeMeta.Values);
 
 		await act(async () => {
@@ -110,6 +110,7 @@ describe("ExRHeaderOptionControl", () => {
 		const input = screen.getByRole("textbox");
 		await act(async () => {
 			fireEvent.change(input, { target: { value: "100" } });
+			fireEvent.blur(input);
 		});
 
 		const state = useStore.getState();


### PR DESCRIPTION
CompactSliderコンポーネントをリファクタリングし、既存のuseOptionSliderフックを再利用するようにしました。これにより、数値入力の確定ロジック（最も近いインデックスの算出など）が統一され、入力中の頻繁な更新から確定時の更新へと挙動が改善されました。また、不要なプロップの削除とそれに関連する各フィーチャー（Among Us, ExR）のクリーンアップも行っています。

---
*PR created automatically by Jules for task [7040885436088564233](https://jules.google.com/task/7040885436088564233) started by @yukieiji*