### PR TITLE
オプションを検索する検索バーの追加

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	// モックサーバーの状態をリセット
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	// すべてのテストで API の遅延を設定可能にする
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 100;
+	});
+
+	await page.goto("/");
+	// ローディング画面が消えるのを待つ
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+
+	// サイドバーが表示されるまで待機（アプリケーションがインタラクティブになったことの確認）
+	await expect(page.getByLabel("オプションサイドバー")).toBeVisible({
+		timeout: 30000,
+	});
+});
+
+test("Option search bar navigates to option", async ({ page }) => {
+	const searchBar = page.getByPlaceholder("オプションを検索...");
+	await expect(searchBar).toBeVisible();
+
+	// Search for an option (using a known option from mocks)
+	await searchBar.fill("map");
+
+	// Wait a bit for results to populate in the store
+	await page.waitForTimeout(1000);
+
+	const selectTrigger = page.locator(
+		'button[role="combobox"]:has-text("検索結果から選択")',
+	);
+	await expect(selectTrigger).toBeVisible({ timeout: 10000 });
+	await selectTrigger.click();
+
+	// Wait for the popup and select an item
+	const popup = page.locator('[data-slot="select-content"]');
+	await expect(popup).toBeVisible();
+
+	const optionItem = popup.getByRole("option", { name: "map" }).first();
+	await expect(optionItem).toBeVisible();
+	await optionItem.click();
+
+	// Verify navigation (check if correct tab is selected)
+	await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible();
+});
+
+test("Option search bar navigates to ExR option", async ({ page }) => {
+	const searchBar = page.getByPlaceholder("オプションを検索...");
+	await searchBar.fill("プリセット");
+
+	await page.waitForTimeout(1000);
+
+	const selectTrigger = page.locator(
+		'button[role="combobox"]:has-text("検索結果から選択")',
+	);
+	await expect(selectTrigger).toBeVisible({ timeout: 10000 });
+	await selectTrigger.click();
+
+	const popup = page.locator('[data-slot="select-content"]');
+	await expect(popup).toBeVisible();
+
+	const optionItem = popup.getByRole("option", { name: /プリセット/ }).first();
+	await expect(optionItem).toBeVisible();
+	await optionItem.click();
+
+	// Verify navigation to ExR tab
+	await expect(
+		page.getByRole("heading", { name: "ExR Options" }),
+	).toBeVisible();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,8 +96,8 @@ function MainContent() {
 			data-testid="main-content-section"
 			className="flex flex-col gap-4 transition-opacity duration-200 h-full overflow-hidden"
 		>
-			<div className="flex items-center gap-4">
-				<div className="flex items-center gap-5 flex-1 p-4">
+			<div className="flex items-center gap-4 p-4 border-b border-gray-700/50">
+				<div className="flex items-center gap-5 flex-1 min-w-0">
 					<h2 className="text-2xl font-bold whitespace-nowrap">
 						{titleMap[selectedTab]}
 					</h2>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { BlockableLoading } from "./feature/BlockableLoading";
 import { ExROptionEditor } from "./feature/exr/ExROptionEditor";
 import { PresetSelector } from "./feature/exr/PresetSelector";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
+import { OptionSearchBar } from "./feature/OptionSearchBar";
 import { RightSidePanel } from "./feature/rightsidepanel/RightSidePanel";
 import { RoleFilterViewer } from "./feature/rolefilter/RoleFilterViewer";
 import {
@@ -100,6 +101,7 @@ function MainContent() {
 					<h2 className="text-2xl font-bold whitespace-nowrap">
 						{titleMap[selectedTab]}
 					</h2>
+					<OptionSearchBar />
 					{selectedTab === "ExR" && (
 						<Suspense
 							fallback={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,25 +96,27 @@ function MainContent() {
 			data-testid="main-content-section"
 			className="flex flex-col gap-4 transition-opacity duration-200 h-full overflow-hidden"
 		>
-			<div className="flex items-center gap-4 p-4 border-b border-gray-700/50">
-				<div className="flex items-center gap-5 flex-1 min-w-0">
-					<h2 className="text-2xl font-bold whitespace-nowrap">
-						{titleMap[selectedTab]}
-					</h2>
-					<OptionSearchBar />
-					{selectedTab === "ExR" && (
-						<Suspense
-							fallback={
-								<div className="w-48 h-8 bg-gray-700 animate-pulse rounded" />
-							}
-						>
-							<PresetSelectorContainer />
-						</Suspense>
-					)}
-					{isSidebarPending && (
-						<div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
-					)}
-				</div>
+			<div className="flex items-center gap-4 p-4 border-b border-gray-700/50 min-w-0">
+				<h2 className="text-2xl font-bold shrink-0">{titleMap[selectedTab]}</h2>
+
+				{selectedTab === "ExR" && (
+					<Suspense
+						fallback={
+							<div className="w-48 h-8 bg-gray-700 animate-pulse rounded shrink-0" />
+						}
+					>
+						<PresetSelectorContainer />
+					</Suspense>
+				)}
+
+				<OptionSearchBar />
+
+				{isSidebarPending && (
+					<div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin shrink-0"></div>
+				)}
+
+				<div className="flex-1" />
+
 				<ImportButton onImport={handleImport} />
 				<ExportButton onClick={exporter} />
 				<SyncButton onClick={syncer} />

--- a/src/feature/OptionSearchBar.tsx
+++ b/src/feature/OptionSearchBar.tsx
@@ -15,7 +15,7 @@ export function OptionSearchBar() {
 	const setQuery = useStore((state) => state.setOptionSearchQuery);
 
 	return (
-		<div className="flex items-center gap-2 w-64 shrink-0">
+		<div className="flex items-center gap-2 w-72 shrink-0">
 			<InputGroup className="flex-1">
 				<InputGroupAddon align="inline-start">
 					<Search className="size-4" />

--- a/src/feature/OptionSearchBar.tsx
+++ b/src/feature/OptionSearchBar.tsx
@@ -1,0 +1,35 @@
+import { Search } from "lucide-react";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "@/components/ui/input-group";
+import { useStore } from "@/useStore";
+import { OptionSearchSuggestion } from "./OptionSearchSuggestion";
+
+/**
+ * オプションを検索する検索バーコンポーネント
+ */
+export function OptionSearchBar() {
+	const query = useStore((state) => state.optionSearchQuery);
+	const setQuery = useStore((state) => state.setOptionSearchQuery);
+
+	return (
+		<div className="flex items-center gap-2 flex-1 max-w-md mx-4">
+			<InputGroup className="flex-1">
+				<InputGroupAddon align="inline-start">
+					<Search className="size-4" />
+				</InputGroupAddon>
+				<InputGroupInput
+					placeholder="オプションを検索..."
+					value={query}
+					onChange={(e) => {
+						setQuery(e.target.value);
+					}}
+				/>
+			</InputGroup>
+
+			<OptionSearchSuggestion />
+		</div>
+	);
+}

--- a/src/feature/OptionSearchBar.tsx
+++ b/src/feature/OptionSearchBar.tsx
@@ -15,7 +15,7 @@ export function OptionSearchBar() {
 	const setQuery = useStore((state) => state.setOptionSearchQuery);
 
 	return (
-		<div className="flex items-center gap-2 flex-1 max-w-md mx-4">
+		<div className="flex items-center gap-2 w-64 shrink-0">
 			<InputGroup className="flex-1">
 				<InputGroupAddon align="inline-start">
 					<Search className="size-4" />

--- a/src/feature/OptionSearchSuggestion.tsx
+++ b/src/feature/OptionSearchSuggestion.tsx
@@ -1,0 +1,89 @@
+import {
+	Select,
+	SelectContent,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	useAuCategoryNavigationInline,
+	useAuOptionNavigationInline,
+	useExRCategoryNavigationInline,
+	useExROptionNavigationInline,
+} from "@/hooks/useOptionNavigation";
+import { useStore } from "@/useStore";
+import { OptionSearchSuggestionItem } from "./OptionSearchSuggestionItem";
+
+/**
+ * 検索クエリに基づいてフィルタリングされたアイテムを表示し、
+ * 選択時のナビゲーションを管理するコンポーネント
+ */
+export function OptionSearchSuggestion() {
+	const searchItems = useStore((state) => state.globalSearchItems);
+	const query = useStore((state) => state.optionSearchQuery);
+	const setQuery = useStore((state) => state.setOptionSearchQuery);
+	const isExROptionActive = useStore((state) => state.isExROptionActive);
+
+	const navigateToAuOption = useAuOptionNavigationInline();
+	const navigateToAuCategory = useAuCategoryNavigationInline();
+	const navigateToExROption = useExROptionNavigationInline();
+	const navigateToExRCategory = useExRCategoryNavigationInline();
+
+	// 検索クエリに基づいてフィルタリングされたアイテム
+	const lowerQuery = query.toLowerCase();
+	const filteredItems = query
+		? searchItems.filter((item) => {
+				const nameMatch = item.term.toLowerCase().includes(lowerQuery);
+				if (!nameMatch) {
+					return false;
+				}
+
+				// ExRのオプションの場合は、有効なもののみ表示
+				if (item.info.mode === "exr-opt") {
+					return isExROptionActive[item.info.uniqueOptionId] ?? false;
+				}
+				return true;
+			})
+		: [];
+
+	if (filteredItems.length === 0) {
+		return null;
+	}
+
+	const onSelect = (value: string | null) => {
+		if (!value) {
+			return;
+		}
+		const item = searchItems.find((i) => {
+			return i.id === value;
+		});
+		if (!item) {
+			return;
+		}
+
+		const info = item.info;
+		if (info.mode === "au-opt") {
+			navigateToAuOption(info.tabId, info.categoryId, info.auOptionId);
+		} else if (info.mode === "au-cat") {
+			navigateToAuCategory(info.tabId, info.categoryId);
+		} else if (info.mode === "exr-opt") {
+			navigateToExROption(info.uniqueOptionId);
+		} else if (info.mode === "exr-cat") {
+			navigateToExRCategory(info.tabId, info.categoryId);
+		}
+		// 選択後はクエリをクリア
+		setQuery("");
+	};
+
+	return (
+		<Select onValueChange={onSelect}>
+			<SelectTrigger className="w-[180px]">
+				<SelectValue placeholder="検索結果から選択" />
+			</SelectTrigger>
+			<SelectContent>
+				{filteredItems.slice(0, 20).map((item) => {
+					return <OptionSearchSuggestionItem key={item.id} item={item} />;
+				})}
+			</SelectContent>
+		</Select>
+	);
+}

--- a/src/feature/OptionSearchSuggestion.tsx
+++ b/src/feature/OptionSearchSuggestion.tsx
@@ -76,8 +76,8 @@ export function OptionSearchSuggestion() {
 
 	return (
 		<Select onValueChange={onSelect}>
-			<SelectTrigger className="w-[180px]">
-				<SelectValue placeholder="検索結果から選択" />
+			<SelectTrigger className="w-32">
+				<SelectValue placeholder="結果" />
 			</SelectTrigger>
 			<SelectContent>
 				{filteredItems.slice(0, 20).map((item) => {

--- a/src/feature/OptionSearchSuggestionItem.tsx
+++ b/src/feature/OptionSearchSuggestionItem.tsx
@@ -1,0 +1,30 @@
+import { SelectItem } from "@/components/ui/select";
+import type { SearchItem } from "@/type";
+
+interface OptionSearchSuggestionItemProps {
+	item: SearchItem;
+}
+
+/**
+ * 検索サジェストの各項目の内容を表示するコンポーネント
+ */
+export function OptionSearchSuggestionItem({
+	item,
+}: OptionSearchSuggestionItemProps) {
+	const isAu = item.info.mode === "au-opt" || item.info.mode === "au-cat";
+	const isOption = item.info.mode === "au-opt" || item.info.mode === "exr-opt";
+
+	return (
+		<SelectItem value={item.id}>
+			<div className="flex flex-col text-left">
+				<span className="font-medium text-sm">{item.term}</span>
+				<span className="text-[10px] text-muted-foreground leading-tight">
+					{isAu ? "Among Us" : "Extreme Roles"}
+					{" - "}
+					{isOption ? "オプション" : "カテゴリ"}
+					{item.context && ` (${item.context})`}
+				</span>
+			</div>
+		</SelectItem>
+	);
+}

--- a/src/hooks/useOptionNavigation.ts
+++ b/src/hooks/useOptionNavigation.ts
@@ -12,7 +12,7 @@ export function createAuNavigateId(auOptionId: AuOptionId) {
 }
 
 function useNavigate() {
-	return (navId: string, timeoutFunc: () => void) => {
+	return (navId: string, timeoutFunc?: () => void) => {
 		setTimeout(() => {
 			if (typeof document !== "undefined") {
 				const element = document.getElementById(navId);
@@ -20,7 +20,9 @@ function useNavigate() {
 					element.scrollIntoView({ behavior: "smooth", block: "center" });
 				}
 			}
-			setTimeout(timeoutFunc, 2000);
+			if (timeoutFunc) {
+				setTimeout(timeoutFunc, 2000);
+			}
 		}, 100);
 	};
 }
@@ -83,6 +85,44 @@ export function useAuOptionNavigation(
 	};
 
 	return navigateToOption;
+}
+
+export function useAuCategoryNavigationInline() {
+	const setSelectedTab = useStore((state) => state.setSelectedTab);
+	const setSelectedAuTabId = useStore((state) => state.setSelectedAuTabId);
+	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
+	const setRightPanelOpen = useStore((state) => state.setRightPanelOpen);
+	const nav = useNavigate();
+
+	return (tabId: number, categoryId: number) => {
+		const { openedAuCategoryIds } = useStore.getState();
+		setRightPanelOpen(false);
+		setSelectedTab("Au");
+		setSelectedAuTabId(tabId);
+		if (!openedAuCategoryIds[categoryId]) {
+			toggleAuCategory(categoryId);
+		}
+		nav(`au-category-${categoryId}`);
+	};
+}
+
+export function useExRCategoryNavigationInline() {
+	const setSelectedTab = useStore((state) => state.setSelectedTab);
+	const setSelectedExRTabId = useStore((state) => state.setSelectedExRTabId);
+	const toggleExRCategory = useStore((state) => state.toggleExRCategory);
+	const setRightPanelOpen = useStore((state) => state.setRightPanelOpen);
+	const nav = useNavigate();
+
+	return (tabId: ExRTabId, categoryId: number) => {
+		const { openedExRCategoryIds } = useStore.getState();
+		setRightPanelOpen(false);
+		setSelectedTab("ExR");
+		setSelectedExRTabId(tabId);
+		if (!openedExRCategoryIds[categoryId]) {
+			toggleExRCategory(categoryId);
+		}
+		nav(`exr-category-${categoryId}`);
+	};
 }
 
 export function useAuOptionNavigationInline() {

--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -12,6 +12,7 @@ import {
 	createExROptionMetaData,
 	fetchRoleFilterData,
 	fetchTranslationMetaData,
+	globalSearchItems,
 	updateAuOption,
 	updateExrOption,
 } from "./api";
@@ -192,6 +193,7 @@ export async function refetchAll(): Promise<void> {
 		createAuOptionMetaDataWithStore(),
 		fetchRoleFilterDataWithStore(),
 	]);
+	useStore.getState().setGlobalSearchItems([...globalSearchItems]);
 }
 
 export function getAllOptions(): Promise<void> {

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -69,6 +69,20 @@ export const roleFilterMetaData: RoleFilterMetaData = {
 export const globalSearchItems: SearchItem[] = [];
 
 /**
+ * 検索アイテムをリセットする
+ */
+function resetGlobalSearchItems(mode: "Au" | "ExR") {
+	const items = globalSearchItems.filter((item) => {
+		if (mode === "Au") {
+			return item.info.mode !== "au-opt" && item.info.mode !== "au-cat";
+		}
+		return item.info.mode !== "exr-opt" && item.info.mode !== "exr-cat";
+	});
+	globalSearchItems.length = 0;
+	globalSearchItems.push(...items);
+}
+
+/**
  * ExRオプションのメタデータをリセットする（テスト用）
  */
 export function resetExrOptionMetaData() {
@@ -76,6 +90,7 @@ export function resetExrOptionMetaData() {
 	exrOptionMetaData.categories = {};
 	exrOptionMetaData.options = {};
 	exrOptionMetaData.globalCategoryIdTopLevelMap = {};
+	resetGlobalSearchItems("ExR");
 }
 
 /**
@@ -86,6 +101,7 @@ export function resetAuOptionMetaData() {
 	auOptionMetaData.tabCategoryMap = {};
 	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};
+	resetGlobalSearchItems("Au");
 }
 
 /**
@@ -177,6 +193,7 @@ export async function fetchTranslationMetaData(): Promise<void> {
 }
 
 export async function createExROptionMetaData(): Promise<ExRinitializeData> {
+	resetGlobalSearchItems("ExR");
 	console.log(
 		JSON.stringify({ type: "request", method: "GET", url: EXR_OPTION_URL }),
 	);
@@ -222,6 +239,25 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 					exrOptionMetaData.options[uniqueId]?.childOptionIds ?? [],
 				parentOptionIds: ancestorIds,
 			};
+
+			const contextParts = [exrOptionMetaData.categories[categoryId]?.name];
+			for (const ancestorId of ancestorIds) {
+				const ancestorName =
+					exrOptionMetaData.options[ancestorId]?.metaData.translatedName;
+				if (ancestorName) {
+					contextParts.push(ancestorName);
+				}
+			}
+
+			globalSearchItems.push({
+				id: `exr-opt-${uniqueId}`,
+				term: opt.TranslatedName,
+				context: contextParts.filter(Boolean).join(" > "),
+				info: {
+					mode: "exr-opt",
+					uniqueOptionId: uniqueId,
+				},
+			});
 
 			valueData[uniqueId] = {
 				selection: opt.Selection,
@@ -271,6 +307,15 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 				name: category.Name,
 				tabId: tab.Id,
 			};
+			globalSearchItems.push({
+				id: `exr-cat-${category.Id}`,
+				term: category.Name,
+				info: {
+					mode: "exr-cat",
+					tabId: tab.Id,
+					categoryId: category.Id,
+				},
+			});
 			if (tab.Id === ExRTabId.GeneralTab) {
 				// 一般タブのカテゴリは、トップレベルオプションIDを直接カテゴリIDに紐づける
 				exrOptionMetaData.globalCategoryIdTopLevelMap[category.Id] =
@@ -287,6 +332,7 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 export async function createAuOptionMetaData(): Promise<
 	Record<AuOptionId, number>
 > {
+	resetGlobalSearchItems("Au");
 	console.log(
 		JSON.stringify({ type: "request", method: "GET", url: AU_OPTION_URL }),
 	);
@@ -336,6 +382,17 @@ export async function createAuOptionMetaData(): Promise<
 			options: [],
 		};
 
+		globalSearchItems.push({
+			id: `au-cat-${categoryId}`,
+			term: category.TranslatedTitle,
+			context: `Tab ${currentTab}`,
+			info: {
+				mode: "au-cat",
+				tabId: currentTab,
+				categoryId: categoryId,
+			},
+		});
+
 		for (const opt of category.Options) {
 			const valueType = opt.Info.ValueType;
 			const optionName = opt.Info.OptionName;
@@ -353,6 +410,18 @@ export async function createAuOptionMetaData(): Promise<
 				};
 				initialValueData[chanceId] = Math.floor(roleValue.Chance / 10);
 
+				globalSearchItems.push({
+					id: `au-opt-${chanceId}`,
+					term: `${opt.TranslatedTitle} (Chance)`,
+					context: category.TranslatedTitle,
+					info: {
+						mode: "au-opt",
+						tabId: currentTab,
+						categoryId: categoryId,
+						auOptionId: chanceId,
+					},
+				});
+
 				// MaxCount
 				const maxCountId = getAuOptionId(
 					optionName,
@@ -366,6 +435,18 @@ export async function createAuOptionMetaData(): Promise<
 					range: Array.from({ length: 16 }, (_, i) => i), // 0～15を1刻みで用意するため
 				};
 				initialValueData[maxCountId] = roleValue.MaxCount;
+
+				globalSearchItems.push({
+					id: `au-opt-${maxCountId}`,
+					term: `${opt.TranslatedTitle} (MaxCount)`,
+					context: category.TranslatedTitle,
+					info: {
+						mode: "au-opt",
+						tabId: currentTab,
+						categoryId: categoryId,
+						auOptionId: maxCountId,
+					},
+				});
 			} else {
 				const auOptionId = getAuOptionId(optionName, valueType);
 				auOptionMetaData.categoryMetaData[categoryId].options.push(auOptionId);
@@ -391,6 +472,18 @@ export async function createAuOptionMetaData(): Promise<
 					range,
 				};
 				initialValueData[auOptionId] = index;
+
+				globalSearchItems.push({
+					id: `au-opt-${auOptionId}`,
+					term: opt.TranslatedTitle,
+					context: category.TranslatedTitle,
+					info: {
+						mode: "au-opt",
+						tabId: currentTab,
+						categoryId: categoryId,
+						auOptionId: auOptionId,
+					},
+				});
 			}
 		}
 	}

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -73,6 +73,8 @@ export const ROLE_FILTER_SHORT_LABEL = "R";
 export const ON = "ON";
 export const OFF = "OFF";
 
+export const SEARCH_PLACEHOLDER = "オプションを検索...";
+
 export const ERROR_TITLE = "エラーが発生しました";
 export const ERROR_RETRY_BUTTON = "再試行";
 export const ERROR_DETAIL_LABEL = "エラー詳細:";

--- a/src/slices/optionSearchSlice.ts
+++ b/src/slices/optionSearchSlice.ts
@@ -1,0 +1,25 @@
+import type { StateCreator } from "zustand";
+import type { SearchItem } from "../type";
+
+export interface OptionSearchSlice {
+	optionSearchQuery: string;
+	setOptionSearchQuery: (query: string) => void;
+	filteredOptionSearchItems: SearchItem[];
+	setFilteredOptionSearchItems: (items: SearchItem[]) => void;
+	globalSearchItems: SearchItem[];
+	setGlobalSearchItems: (items: SearchItem[]) => void;
+}
+
+export const createOptionSearchSlice: StateCreator<OptionSearchSlice> = (
+	set,
+) => {
+	return {
+		optionSearchQuery: "",
+		setOptionSearchQuery: (query) => set({ optionSearchQuery: query }),
+		filteredOptionSearchItems: [],
+		setFilteredOptionSearchItems: (items) =>
+			set({ filteredOptionSearchItems: items }),
+		globalSearchItems: [],
+		setGlobalSearchItems: (items) => set({ globalSearchItems: items }),
+	};
+};

--- a/src/type.ts
+++ b/src/type.ts
@@ -518,7 +518,8 @@ export interface AuCategorySearchTargetInfo {
 
 export interface SearchItem {
 	id: string;
-	tearm: string;
+	term: string;
+	context?: string;
 	info:
 		| AuCategorySearchTargetInfo
 		| AuOptionSearchTargetInfo

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -7,6 +7,8 @@ import type { GlobalUiSlice } from "./slices/globalUiSlice";
 import { createGlobalUiSlice } from "./slices/globalUiSlice";
 import type { OptionGroupToggleSidebarSlice } from "./slices/optionGroupToggleSidebarSlice";
 import { createOptionGroupToggleSidebarSlice } from "./slices/optionGroupToggleSidebarSlice";
+import type { OptionSearchSlice } from "./slices/optionSearchSlice";
+import { createOptionSearchSlice } from "./slices/optionSearchSlice";
 import type { RightSidePanelSlice } from "./slices/rightSidePanelSlice";
 import { createRightSidePanelSlice } from "./slices/rightSidePanelSlice";
 import type { RoleFilterSlice } from "./slices/roleFilterSlice";
@@ -18,6 +20,7 @@ import { createRoleFilterSlice } from "./slices/roleFilterSlice";
 export const useStore = create<
 	GlobalUiSlice &
 		OptionGroupToggleSidebarSlice &
+		OptionSearchSlice &
 		RightSidePanelSlice &
 		AuOptionViewerSlice &
 		ExROptionViewerSlice &
@@ -26,6 +29,7 @@ export const useStore = create<
 	return {
 		...createGlobalUiSlice(...a),
 		...createOptionGroupToggleSidebarSlice(...a),
+		...createOptionSearchSlice(...a),
 		...createRightSidePanelSlice(...a),
 		...createAuOptionViewerSlice(...a),
 		...createExROptionViewerSlice(...a),

--- a/tests/OptionSearchBar.test.ts
+++ b/tests/OptionSearchBar.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createAuOptionMetaData,
+	createExROptionMetaData,
+	globalSearchItems,
+	resetAuOptionMetaData,
+	resetExrOptionMetaData,
+} from "@/logics/api";
+import { ExRTabId, OptionValueType } from "@/type";
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe("OptionSearchBar logic (globalSearchItems)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetAuOptionMetaData();
+		resetExrOptionMetaData();
+	});
+
+	it("should populate globalSearchItems with Au metadata and context", async () => {
+		const mockAuData = [
+			{
+				TranslatedTitle: "AuCategory",
+				Options: [
+					{
+						TranslatedTitle: "AuOption",
+						TranslatedFormat: "Format",
+						Value: 10,
+						Info: { ValueType: OptionValueType.Int, OptionName: 1 },
+						Range: [0, 10, 20],
+					},
+				],
+			},
+		];
+
+		vi.mocked(fetch).mockResolvedValue({
+			ok: true,
+			json: async () => mockAuData,
+		} as Response);
+
+		await createAuOptionMetaData();
+
+		const categorySearch = globalSearchItems.find(
+			(i) => i.term === "AuCategory",
+		);
+		const optionSearch = globalSearchItems.find((i) => i.term === "AuOption");
+
+		expect(categorySearch).toBeDefined();
+		expect(categorySearch?.info.mode).toBe("au-cat");
+		expect(categorySearch?.context).toBe("Tab 0");
+		expect(optionSearch).toBeDefined();
+		expect(optionSearch?.info.mode).toBe("au-opt");
+		expect(optionSearch?.context).toBe("AuCategory");
+	});
+
+	it("should populate globalSearchItems with ExR metadata and context", async () => {
+		const mockExRData = [
+			{
+				Id: ExRTabId.GeneralTab,
+				Name: "General",
+				Categories: [
+					{
+						Id: 1,
+						Name: "ExRCategory",
+						Options: [
+							{
+								Id: 10,
+								IsActive: true,
+								TranslatedName: "ExROption",
+								Selection: 0,
+								Format: "format",
+								RangeMeta: { Type: "Int32", Values: [0, 1, 2] },
+								Childs: [
+									{
+										Id: 11,
+										IsActive: true,
+										TranslatedName: "ChildOption",
+										Selection: 0,
+										Format: "format",
+										RangeMeta: { Type: "Int32", Values: [0, 1] },
+										Childs: [],
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		];
+
+		vi.mocked(fetch).mockResolvedValue({
+			ok: true,
+			json: async () => mockExRData,
+		} as Response);
+
+		await createExROptionMetaData();
+
+		const categorySearch = globalSearchItems.find(
+			(i) => i.term === "ExRCategory",
+		);
+		const optionSearch = globalSearchItems.find((i) => i.term === "ExROption");
+		const childSearch = globalSearchItems.find((i) => i.term === "ChildOption");
+
+		expect(categorySearch).toBeDefined();
+		expect(categorySearch?.info.mode).toBe("exr-cat");
+		expect(optionSearch).toBeDefined();
+		expect(optionSearch?.info.mode).toBe("exr-opt");
+		expect(optionSearch?.context).toBe("ExRCategory");
+
+		expect(childSearch).toBeDefined();
+		expect(childSearch?.context).toBe("ExRCategory > ExROption");
+	});
+
+	it("should clear old items when re-populating", async () => {
+		const mockAuData = [
+			{
+				TranslatedTitle: "AuCategory",
+				Options: [
+					{
+						TranslatedTitle: "AuOption",
+						TranslatedFormat: "Format",
+						Value: 10,
+						Info: { ValueType: OptionValueType.Int, OptionName: 1 },
+						Range: [0, 10, 20],
+					},
+				],
+			},
+		];
+
+		vi.mocked(fetch).mockResolvedValue({
+			ok: true,
+			json: async () => mockAuData,
+		} as Response);
+
+		await createAuOptionMetaData();
+		const initialCount = globalSearchItems.length;
+
+		await createAuOptionMetaData();
+		expect(globalSearchItems.length).toBe(initialCount);
+	});
+});


### PR DESCRIPTION
### 概要
オプションおよびカテゴリを検索できる検索バーを追加しました。

### 変更内容
- **UIコンポーネントの実装**:
  - `src/feature/OptionSearchBar.tsx`: 検索入力とサジェスト表示の親コンポーネント。
  - `src/feature/OptionSearchSuggestion.tsx`: 検索結果のフィルタリングと `Select` ドロップダウンの表示を担当。
  - `src/feature/OptionSearchSuggestionItem.tsx`: 各検索結果の `SelectItem` 表示を担当。
- **データ管理**:
  - `src/slices/optionSearchSlice.ts`: 検索クエリとインデックスを管理する Zustand スライス。
  - `src/logics/api.ts`: メタデータ取得時に検索インデックス（`SearchItem`）を構築するロジックの追加。タイポ `tearm` を `term` に修正。
  - `src/logics/api.store.ts`: データ取得完了後にインデックスを Zustand ストアに同期する処理の追加。
- **ナビゲーション**:
  - `src/hooks/useOptionNavigation.ts`: カテゴリへのナビゲーションをサポートするフックを追加。
- **テスト**:
  - `tests/OptionSearchBar.test.ts`: 検索インデックス構築ロジックのユニットテスト。

### 動作確認
- `pnpm run check`: パス（Biomeによる検証）
- `pnpm test`: パス（vitestによるユニットテスト）
- 検索バーに文字列を入力し、関連するオプションやカテゴリが表示されること、選択時に該当箇所へ遷移することを確認。

---
*PR created automatically by Jules for task [16757122028465207502](https://jules.google.com/task/16757122028465207502) started by @yukieiji*