### PR TITLE
Change tab names to plain text and use colors for category list border

### DIFF
--- a/src/components/blocks/CategoryContainer.tsx
+++ b/src/components/blocks/CategoryContainer.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
-import { LoadingCycle } from "../parts/LoadingCycle";
-
 import { getLinearGradient } from "@/logics/colorUtils";
+import { LoadingCycle } from "../parts/LoadingCycle";
 
 interface CategoryContainerProps {
 	isPending: boolean;

--- a/src/components/blocks/CategoryContainer.tsx
+++ b/src/components/blocks/CategoryContainer.tsx
@@ -14,6 +14,10 @@ export function CategoryContainer({
 	children,
 }: CategoryContainerProps) {
 	const containerStyle = (() => {
+		if (colors.length === 0) {
+			return {};
+		}
+
 		const gradient = getLinearGradient(colors);
 		if (gradient.startsWith("linear-gradient")) {
 			return {

--- a/src/components/blocks/CategoryContainer.tsx
+++ b/src/components/blocks/CategoryContainer.tsx
@@ -17,7 +17,9 @@ export function CategoryContainer({
 		const gradient = getLinearGradient(colors);
 		if (gradient.startsWith("linear-gradient")) {
 			return {
-				background: `linear-gradient(var(--background), var(--background)) padding-box, ${gradient} border-box`,
+				backgroundImage: `linear-gradient(var(--background), var(--background)), ${gradient}`,
+				backgroundOrigin: "border-box",
+				backgroundClip: "padding-box, border-box",
 				border: "2px solid transparent",
 			};
 		}

--- a/src/components/blocks/CategoryContainer.tsx
+++ b/src/components/blocks/CategoryContainer.tsx
@@ -13,8 +13,10 @@ export function CategoryContainer({
 	colors = [],
 	children,
 }: CategoryContainerProps) {
+	const hasColors = colors.length > 0;
+
 	const containerStyle = (() => {
-		if (colors.length === 0) {
+		if (!hasColors) {
 			return {};
 		}
 
@@ -37,7 +39,7 @@ export function CategoryContainer({
 	return (
 		<div
 			data-testid="category-list"
-			className={`pb-20 flex flex-col relative transition-opacity duration-200 flex-1 overflow-y-auto [scrollbar-gutter:stable] gap-2 *:shrink-0 rounded-lg ${isPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
+			className={`pb-20 flex flex-col relative transition-opacity duration-200 flex-1 overflow-y-auto [scrollbar-gutter:stable] gap-2 *:shrink-0 ${hasColors ? "rounded-lg" : ""} ${isPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
 			style={containerStyle}
 		>
 			{isPending && (

--- a/src/components/blocks/CategoryContainer.tsx
+++ b/src/components/blocks/CategoryContainer.tsx
@@ -1,19 +1,43 @@
 import type { ReactNode } from "react";
 import { LoadingCycle } from "../parts/LoadingCycle";
 
+import { getLinearGradient } from "@/logics/colorUtils";
+
 interface CategoryContainerProps {
 	isPending: boolean;
+	colors?: string[];
+	isGhost?: boolean;
 	children: ReactNode;
 }
 
 export function CategoryContainer({
 	isPending,
+	colors = [],
+	isGhost = false,
 	children,
 }: CategoryContainerProps) {
+	const borderStyle = (() => {
+		const gradient = getLinearGradient(colors, isGhost);
+		if (gradient.startsWith("linear-gradient")) {
+			return {
+				borderImageSource: gradient,
+				borderImageSlice: 1,
+				borderStyle: "solid",
+				borderWidth: "2px",
+			};
+		}
+		return {
+			borderColor: gradient,
+			borderStyle: "solid",
+			borderWidth: "2px",
+		};
+	})();
+
 	return (
 		<div
 			data-testid="category-list"
-			className={`pb-20 flex flex-col relative transition-opacity duration-200 flex-1 overflow-y-auto [scrollbar-gutter:stable] gap-2 *:shrink-0 ${isPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
+			className={`pb-20 flex flex-col relative transition-opacity duration-200 flex-1 overflow-y-auto [scrollbar-gutter:stable] gap-2 *:shrink-0 rounded-lg ${isPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
+			style={borderStyle}
 		>
 			{isPending && (
 				<div className="absolute inset-0 flex items-center justify-center z-10">

--- a/src/components/blocks/CategoryContainer.tsx
+++ b/src/components/blocks/CategoryContainer.tsx
@@ -5,18 +5,16 @@ import { LoadingCycle } from "../parts/LoadingCycle";
 interface CategoryContainerProps {
 	isPending: boolean;
 	colors?: string[];
-	isGhost?: boolean;
 	children: ReactNode;
 }
 
 export function CategoryContainer({
 	isPending,
 	colors = [],
-	isGhost = false,
 	children,
 }: CategoryContainerProps) {
 	const containerStyle = (() => {
-		const gradient = getLinearGradient(colors, isGhost);
+		const gradient = getLinearGradient(colors);
 		if (gradient.startsWith("linear-gradient")) {
 			return {
 				background: `linear-gradient(var(--background), var(--background)) padding-box, ${gradient} border-box`,

--- a/src/components/blocks/CategoryContainer.tsx
+++ b/src/components/blocks/CategoryContainer.tsx
@@ -15,14 +15,12 @@ export function CategoryContainer({
 	isGhost = false,
 	children,
 }: CategoryContainerProps) {
-	const borderStyle = (() => {
+	const containerStyle = (() => {
 		const gradient = getLinearGradient(colors, isGhost);
 		if (gradient.startsWith("linear-gradient")) {
 			return {
-				borderImageSource: gradient,
-				borderImageSlice: 1,
-				borderStyle: "solid",
-				borderWidth: "2px",
+				background: `linear-gradient(var(--background), var(--background)) padding-box, ${gradient} border-box`,
+				border: "2px solid transparent",
 			};
 		}
 		return {
@@ -36,7 +34,7 @@ export function CategoryContainer({
 		<div
 			data-testid="category-list"
 			className={`pb-20 flex flex-col relative transition-opacity duration-200 flex-1 overflow-y-auto [scrollbar-gutter:stable] gap-2 *:shrink-0 rounded-lg ${isPending ? "is-pending opacity-50 pointer-events-none" : "opacity-100"}`}
-			style={borderStyle}
+			style={containerStyle}
 		>
 			{isPending && (
 				<div className="absolute inset-0 flex items-center justify-center z-10">

--- a/src/feature/exr/ExRCategoryList.tsx
+++ b/src/feature/exr/ExRCategoryList.tsx
@@ -44,12 +44,21 @@ export function ExRCategoryList() {
 		return state.isExRTabPending;
 	});
 
-	const tabCategory =
-		exrOptionMetaData.tabs[selectedExRTabId]?.categoryIds || [];
+	const tabMeta = exrOptionMetaData.tabs[selectedExRTabId];
+	const tabCategory = tabMeta?.categoryIds || [];
 	const isRoleTab = selectedExRTabId !== ExRTabId.GeneralTab;
 
+	const isGhost =
+		selectedExRTabId === ExRTabId.GhostCrewmateTab ||
+		selectedExRTabId === ExRTabId.GhostImpostorTab ||
+		selectedExRTabId === ExRTabId.GhostNeutralTab;
+
 	return (
-		<CategoryContainer isPending={isTabPending}>
+		<CategoryContainer
+			isPending={isTabPending}
+			colors={tabMeta?.colors || []}
+			isGhost={isGhost}
+		>
 			{isRoleTab ? (
 				<ExRRoleCategoryList categoryIds={tabCategory} />
 			) : (

--- a/src/feature/exr/ExRCategoryList.tsx
+++ b/src/feature/exr/ExRCategoryList.tsx
@@ -48,17 +48,8 @@ export function ExRCategoryList() {
 	const tabCategory = tabMeta?.categoryIds || [];
 	const isRoleTab = selectedExRTabId !== ExRTabId.GeneralTab;
 
-	const isGhost =
-		selectedExRTabId === ExRTabId.GhostCrewmateTab ||
-		selectedExRTabId === ExRTabId.GhostImpostorTab ||
-		selectedExRTabId === ExRTabId.GhostNeutralTab;
-
 	return (
-		<CategoryContainer
-			isPending={isTabPending}
-			colors={tabMeta?.colors || []}
-			isGhost={isGhost}
-		>
+		<CategoryContainer isPending={isTabPending} colors={tabMeta?.colors || []}>
 			{isRoleTab ? (
 				<ExRRoleCategoryList categoryIds={tabCategory} />
 			) : (

--- a/src/feature/exr/ExRTabSelector.tsx
+++ b/src/feature/exr/ExRTabSelector.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useTransition } from "react";
-import { ColoredText } from "@/components/parts/ColoredText";
 import { TabButtonContainer } from "@/components/parts/TabButtonContainer";
 import { exrOptionMetaData } from "@/logics/api";
 import type { ExRTabId } from "@/type";
@@ -48,9 +47,7 @@ export function ExRTabSelector() {
 		>
 			{(t) => {
 				const castedTabId = Number(t) as ExRTabId;
-				return (
-					<ColoredText text={exrOptionMetaData.tabs[castedTabId]?.name ?? ""} />
-				);
+				return exrOptionMetaData.tabs[castedTabId]?.name ?? "";
 			}}
 		</TabButtonContainer>
 	);

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -28,6 +28,7 @@ import {
 	UpdatedOptionsSchema,
 } from "../type";
 
+import { extractColors, stripColorTags } from "./colorUtils";
 import { getAuOptionId, getUniqueOptionId } from "./optionUtils";
 
 /**
@@ -263,7 +264,8 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 
 	for (const tab of data) {
 		exrOptionMetaData.tabs[tab.Id] = {
-			name: tab.Name,
+			name: stripColorTags(tab.Name),
+			colors: extractColors(tab.Name),
 			categoryIds: tab.Categories.map((c) => c.Id),
 		};
 		for (const category of tab.Categories) {

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -28,7 +28,7 @@ import {
 	UpdatedOptionsSchema,
 } from "../type";
 
-import { extractColors, stripColorTags } from "./colorUtils";
+import { darkenColor, extractColors, stripColorTags } from "./colorUtils";
 import { getAuOptionId, getUniqueOptionId } from "./optionUtils";
 
 /**
@@ -263,9 +263,19 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 	};
 
 	for (const tab of data) {
+		const isGhost =
+			tab.Id === ExRTabId.GhostCrewmateTab ||
+			tab.Id === ExRTabId.GhostImpostorTab ||
+			tab.Id === ExRTabId.GhostNeutralTab;
+
+		const extractedColors = extractColors(tab.Name);
+		const colors = isGhost
+			? extractedColors.map((c) => darkenColor(c))
+			: extractedColors;
+
 		exrOptionMetaData.tabs[tab.Id] = {
 			name: stripColorTags(tab.Name),
-			colors: extractColors(tab.Name),
+			colors,
 			categoryIds: tab.Categories.map((c) => c.Id),
 		};
 		for (const category of tab.Categories) {

--- a/src/logics/colorUtils.ts
+++ b/src/logics/colorUtils.ts
@@ -53,11 +53,7 @@ export function darkenColor(hex: string, percent = 0.5): string {
 /**
  * グラデーション文字列を生成する
  */
-export function getLinearGradient(colors: string[] | undefined): string {
-	if (!colors || colors.length === 0) {
-		return "#4b5563"; // デフォルト色
-	}
-
+export function getLinearGradient(colors: string[]): string {
 	if (colors.length === 1) {
 		return colors[0];
 	}

--- a/src/logics/colorUtils.ts
+++ b/src/logics/colorUtils.ts
@@ -4,15 +4,8 @@
 export function extractColors(text: string): string[] {
 	const COLOR_TAG_HEX_REGEX =
 		/<color\s*=\s*["']?\s*(#[0-9A-F]{6,8})\s*["']?\s*>/gi;
-	const colors: string[] = [];
-	let match: RegExpExecArray | null;
-
-	// biome-ignore lint/suspicious/noAssignInExpressions: standard regex loop
-	while ((match = COLOR_TAG_HEX_REGEX.exec(text)) !== null) {
-		colors.push(match[1]);
-	}
-
-	return Array.from(new Set(colors));
+	const matches = Array.from(text.matchAll(COLOR_TAG_HEX_REGEX), (m) => m[1]);
+	return Array.from(new Set(matches));
 }
 
 /**

--- a/src/logics/colorUtils.ts
+++ b/src/logics/colorUtils.ts
@@ -2,9 +2,8 @@
  * <color=#RRGGBB>...</color> タグからカラーコードを抽出する
  */
 export function extractColors(text: string): string[] {
-	const COLOR_TAG_HEX_REGEX =
-		/<color\s*=\s*["']?\s*(#[0-9A-F]{6,8})\s*["']?\s*>/gi;
-	const matches = Array.from(text.matchAll(COLOR_TAG_HEX_REGEX), (m) => m[1]);
+	const TAG_COLOR_REGEX = /<color=(#[0-9A-F]{6,8})>/gi;
+	const matches = Array.from(text.matchAll(TAG_COLOR_REGEX), (m) => m[1]);
 	return Array.from(new Set(matches));
 }
 

--- a/src/logics/colorUtils.ts
+++ b/src/logics/colorUtils.ts
@@ -1,0 +1,66 @@
+/**
+ * <color=#RRGGBB>...</color> タグからカラーコードを抽出する
+ */
+export function extractColors(text: string): string[] {
+	const COLOR_HEX_REGEX = /#[0-9A-F]{6,8}/gi;
+	const matches = text.match(COLOR_HEX_REGEX);
+	return matches ? Array.from(new Set(matches)) : [];
+}
+
+/**
+ * カラータグを除去してプレーンテキストにする
+ */
+export function stripColorTags(text: string): string {
+	return text.replace(/<color=#[0-9A-F]{6,8}>|<\/color>/gi, "");
+}
+
+/**
+ * カラーコードを50%暗くする
+ * #RRGGBB または #RRGGBBAA 形式をサポート
+ */
+export function darkenColor(hex: string, percent = 0.5): string {
+	let color = hex.replace("#", "");
+
+	// 文字数が足りない場合はそのまま返す
+	if (color.length !== 6 && color.length !== 8) {
+		return hex;
+	}
+
+	const hasAlpha = color.length === 8;
+	let r = Number.parseInt(color.substring(0, 2), 16);
+	let g = Number.parseInt(color.substring(2, 4), 16);
+	let b = Number.parseInt(color.substring(4, 6), 16);
+	const a = hasAlpha ? color.substring(6, 8) : "";
+
+	r = Math.floor(r * (1 - percent));
+	g = Math.floor(g * (1 - percent));
+	b = Math.floor(b * (1 - percent));
+
+	const rs = r.toString(16).padStart(2, "0");
+	const gs = g.toString(16).padStart(2, "0");
+	const bs = b.toString(16).padStart(2, "0");
+
+	return `#${rs}${gs}${bs}${a}`;
+}
+
+/**
+ * グラデーション文字列を生成する
+ */
+export function getLinearGradient(
+	colors: string[] | undefined,
+	isGhost: boolean,
+): string {
+	if (!colors || colors.length === 0) {
+		return isGhost ? darkenColor("#4b5563") : "#4b5563"; // デフォルト色
+	}
+
+	const processedColors = isGhost
+		? colors.map((c) => darkenColor(c))
+		: colors;
+
+	if (processedColors.length === 1) {
+		return processedColors[0];
+	}
+
+	return `linear-gradient(to right, ${processedColors.join(", ")})`;
+}

--- a/src/logics/colorUtils.ts
+++ b/src/logics/colorUtils.ts
@@ -46,19 +46,14 @@ export function darkenColor(hex: string, percent = 0.5): string {
 /**
  * グラデーション文字列を生成する
  */
-export function getLinearGradient(
-	colors: string[] | undefined,
-	isGhost: boolean,
-): string {
+export function getLinearGradient(colors: string[] | undefined): string {
 	if (!colors || colors.length === 0) {
-		return isGhost ? darkenColor("#4b5563") : "#4b5563"; // デフォルト色
+		return "#4b5563"; // デフォルト色
 	}
 
-	const processedColors = isGhost ? colors.map((c) => darkenColor(c)) : colors;
-
-	if (processedColors.length === 1) {
-		return processedColors[0];
+	if (colors.length === 1) {
+		return colors[0];
 	}
 
-	return `linear-gradient(to right, ${processedColors.join(", ")})`;
+	return `linear-gradient(to right, ${colors.join(", ")})`;
 }

--- a/src/logics/colorUtils.ts
+++ b/src/logics/colorUtils.ts
@@ -2,9 +2,16 @@
  * <color=#RRGGBB>...</color> タグからカラーコードを抽出する
  */
 export function extractColors(text: string): string[] {
-	const COLOR_HEX_REGEX = /#[0-9A-F]{6,8}/gi;
-	const matches = text.match(COLOR_HEX_REGEX);
-	return matches ? Array.from(new Set(matches)) : [];
+	const COLOR_TAG_HEX_REGEX = /<color=(#[0-9A-F]{6,8})>/gi;
+	const colors: string[] = [];
+	let match: RegExpExecArray | null;
+
+	// biome-ignore lint/suspicious/noAssignInExpressions: standard regex loop
+	while ((match = COLOR_TAG_HEX_REGEX.exec(text)) !== null) {
+		colors.push(match[1]);
+	}
+
+	return Array.from(new Set(colors));
 }
 
 /**

--- a/src/logics/colorUtils.ts
+++ b/src/logics/colorUtils.ts
@@ -19,7 +19,7 @@ export function stripColorTags(text: string): string {
  * #RRGGBB または #RRGGBBAA 形式をサポート
  */
 export function darkenColor(hex: string, percent = 0.5): string {
-	let color = hex.replace("#", "");
+	const color = hex.replace("#", "");
 
 	// 文字数が足りない場合はそのまま返す
 	if (color.length !== 6 && color.length !== 8) {
@@ -54,9 +54,7 @@ export function getLinearGradient(
 		return isGhost ? darkenColor("#4b5563") : "#4b5563"; // デフォルト色
 	}
 
-	const processedColors = isGhost
-		? colors.map((c) => darkenColor(c))
-		: colors;
+	const processedColors = isGhost ? colors.map((c) => darkenColor(c)) : colors;
 
 	if (processedColors.length === 1) {
 		return processedColors[0];

--- a/src/logics/colorUtils.ts
+++ b/src/logics/colorUtils.ts
@@ -2,7 +2,8 @@
  * <color=#RRGGBB>...</color> タグからカラーコードを抽出する
  */
 export function extractColors(text: string): string[] {
-	const COLOR_TAG_HEX_REGEX = /<color=(#[0-9A-F]{6,8})>/gi;
+	const COLOR_TAG_HEX_REGEX =
+		/<color\s*=\s*["']?\s*(#[0-9A-F]{6,8})\s*["']?\s*>/gi;
 	const colors: string[] = [];
 	let match: RegExpExecArray | null;
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -30,6 +30,7 @@ export interface ExROptionValueData {
 export interface ExRTabMetaData {
 	name: string;
 	categoryIds: number[];
+	colors: string[];
 }
 
 export interface ExRCategoryMetaData {


### PR DESCRIPTION
This change modifies how tab colors are handled in the UI. Tab names are now displayed as normal text (color tags are stripped), and their associated colors are instead applied to the border of the CategoryList. 
For tabs with multiple colors, a linear gradient is used. For ghost-related tabs, the colors are darkened by 50%.

Key changes:
- `src/type.ts`: Added `colors` field to `ExRTabMetaData`.
- `src/logics/colorUtils.ts`: New utility functions for color extraction, stripping tags, darkening colors, and generating CSS gradients.
- `src/logics/api.ts`: Updated `createExROptionMetaData` to extract colors and strip tags from tab names.
- `src/feature/exr/ExRTabSelector.tsx`: Changed tab name display to plain text.
- `src/components/blocks/CategoryContainer.tsx`: Added support for dynamic border colors and gradients.
- `src/feature/exr/ExRCategoryList.tsx`: Correctly identify ghost tabs and pass colors to the container.

---
*PR created automatically by Jules for task [400165087686225756](https://jules.google.com/task/400165087686225756) started by @yukieiji*