### PR TITLE
GitHub ActionsでのPlaywrightブラウザキャッシュの追加

### DIFF
--- a/.gemini/knowledge/github-actions-cache/playwright.md
+++ b/.gemini/knowledge/github-actions-cache/playwright.md
@@ -1,0 +1,45 @@
+# GitHub Actions での Playwright ブラウザキャッシュ
+
+GitHub Actions で Playwright の E2E テストを実行する際、ブラウザのダウンロード時間を短縮するためにキャッシュを利用する方法についての知識。
+
+## キャッシュの対象
+
+Playwright のブラウザバイナリは、デフォルトで以下のディレクトリに保存される。
+- Linux: `~/.cache/ms-playwright`
+- macOS: `~/Library/Caches/ms-playwright`
+- Windows: `%USERPROFILE%\AppData\Local\ms-playwright`
+
+GitHub Actions の Ubuntu runner では `~/.cache/ms-playwright` をキャッシュ対象とする。
+
+## キャッシュキーの設計
+
+キャッシュの整合性を保つために、以下の要素をキャッシュキーに含めるのが望ましい。
+- OS 名 (`runner.os`)
+- Playwright のバージョン
+- 対象のブラウザ (matrix で実行している場合など)
+
+Playwright のバージョンは `pnpm exec playwright --version` コマンドから取得できる。
+
+## ワークフローの実装例
+
+```yaml
+    - name: Get Playwright version
+      id: playwright-version
+      run: echo "version=$(pnpm exec playwright --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+
+    - name: Cache Playwright Browsers
+      id: cache-playwright
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ matrix.browser }}
+
+    - name: Install Playwright Browsers
+      if: steps.cache-playwright.outputs.cache-hit != 'true'
+      run: pnpm run setup:browser ${{ matrix.browser }}
+```
+
+## 注意点
+
+- `playwright install --with-deps` を使用する場合、`--with-deps` によってインストールされるシステムレベルの依存関係（OS パッケージなど）はキャッシュされない。バイナリ（ブラウザ本体）のみがキャッシュされる。
+- キャッシュヒット時でも、Playwright が正しく動作するために必要なシステム依存関係が不足している場合は、別途インストールが必要になる場合があるが、標準的な Ubuntu runner では多くの場合バイナリのキャッシュだけで十分高速化される。

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,19 @@ jobs:
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm exec playwright --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright Browsers
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ matrix.browser }}
+
       - name: Install Playwright Browsers
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
         run: pnpm run setup:browser ${{ matrix.browser }}
 
       - name: Run E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,19 @@ jobs:
     - name: Install dependencies
       run: pnpm i --frozen-lockfile
 
+    - name: Get Playwright version
+      id: playwright-version
+      run: echo "version=$(pnpm exec playwright --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+
+    - name: Cache Playwright Browsers
+      id: cache-playwright
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ matrix.browser }}
+
     - name: Install Playwright Browsers
+      if: steps.cache-playwright.outputs.cache-hit != 'true'
       run: pnpm run setup:browser ${{ matrix.browser }}
 
     - name: Run Playwright tests

--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ export default defineConfig([
 
 ## 追加知識
 - [showSaveFilePicker の使用とテスト](.gemini/knowledge/showSaveFilePicker/README.md)
+- [GitHub Actions での Playwright ブラウザキャッシュ](.gemini/knowledge/github-actions-cache/playwright.md)


### PR DESCRIPTION
GitHub ActionsのCI/CDワークフロー（ci.yml, cd.yml）において、Playwrightのブラウザ（~/.cache/ms-playwright）をキャッシュするようにしました。

主な変更点:
- Playwrightのバージョンを動的に取得するステップを追加
- actions/cache@v4 を使用してブラウザバイナリをキャッシュ
- キャッシュキーにOS、Playwrightバージョン、およびブラウザ名（matrix）を含めるように設定
- キャッシュヒット時はブラウザのインストールをスキップする条件付きステップに変更
- 関連する知識を .gemini/knowledge/ に記録し、README.md を更新

---
*PR created automatically by Jules for task [12067020096553310354](https://jules.google.com/task/12067020096553310354) started by @yukieiji*