### PR TITLE
PresetDropdownをshadcn/UIベースにリファクタリング

### DIFF
--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -33,7 +33,9 @@ test("Options interaction behavior", async ({ page }) => {
 	await presetInput.press("Enter");
 
 	// ドロップダウンを開いて名前が反映されているか確認
-	await page.getByRole("combobox", { name: "プリセットを選択" }).click({ force: true });
+	await page
+		.getByRole("combobox", { name: "プリセットを選択" })
+		.click({ force: true });
 	// ドロップダウン内の項目を特定するため、より具体的なロケータを使用（サイドバーにも同じテキストが表示されるため）
 	await expect(
 		page.getByRole("option", { name: "Test Preset" }).first(),

--- a/e2e/options_interaction.spec.ts
+++ b/e2e/options_interaction.spec.ts
@@ -33,12 +33,13 @@ test("Options interaction behavior", async ({ page }) => {
 	await presetInput.press("Enter");
 
 	// ドロップダウンを開いて名前が反映されているか確認
-	await page.getByRole("button", { name: "プリセットを選択" }).click();
+	await page.getByRole("combobox", { name: "プリセットを選択" }).click({ force: true });
 	// ドロップダウン内の項目を特定するため、より具体的なロケータを使用（サイドバーにも同じテキストが表示されるため）
 	await expect(
-		page.getByRole("button", { name: "Test Preset" }).first(),
+		page.getByRole("option", { name: "Test Preset" }).first(),
 	).toBeVisible();
 
+	await page.keyboard.press("Escape");
 	// 別のカテゴリの操作を確認
 	const shuffleCategory = page
 		.getByTestId("category-list")

--- a/e2e/preset_naming.spec.ts
+++ b/e2e/preset_naming.spec.ts
@@ -37,7 +37,7 @@ test("Preset naming and persistence behavior", async ({ page }) => {
 	const selectButton = page.getByRole("combobox", { name: "プリセットを選択" });
 	await expect(selectButton).toBeVisible();
 	await selectButton.click({ force: true });
-	await page.waitForSelector("[data-slot=\"select-content\"]");
+	await page.waitForSelector('[data-slot="select-content"]');
 
 	// プリセット 2 (index 1) に切り替える
 	const preset2Button = page.getByRole("option", { name: "10", exact: true });
@@ -80,7 +80,7 @@ test("Preset naming and persistence behavior", async ({ page }) => {
 	// ドロップダウンを開いて index 1 の名前が保持されていることを確認
 	await expect(selectButton).toBeVisible();
 	await selectButton.click({ force: true });
-	await page.waitForSelector("[data-slot=\"select-content\"]");
+	await page.waitForSelector('[data-slot="select-content"]');
 	const casualFunButton = page.getByRole("option", { name: "Casual Fun" });
 	await expect(casualFunButton).toBeVisible();
 

--- a/e2e/preset_naming.spec.ts
+++ b/e2e/preset_naming.spec.ts
@@ -34,12 +34,13 @@ test("Preset naming and persistence behavior", async ({ page }) => {
 	await presetInput.press("Enter");
 
 	// ドロップダウンを開く
-	const selectButton = page.getByRole("button", { name: "プリセットを選択" });
+	const selectButton = page.getByRole("combobox", { name: "プリセットを選択" });
 	await expect(selectButton).toBeVisible();
-	await selectButton.click();
+	await selectButton.click({ force: true });
+	await page.waitForSelector("[data-slot=\"select-content\"]");
 
 	// プリセット 2 (index 1) に切り替える
-	const preset2Button = page.getByRole("button", { name: "10", exact: true });
+	const preset2Button = page.getByRole("option", { name: "10", exact: true });
 	await expect(preset2Button).toBeVisible();
 	await preset2Button.click();
 
@@ -78,8 +79,9 @@ test("Preset naming and persistence behavior", async ({ page }) => {
 
 	// ドロップダウンを開いて index 1 の名前が保持されていることを確認
 	await expect(selectButton).toBeVisible();
-	await selectButton.click();
-	const casualFunButton = page.getByRole("button", { name: "Casual Fun" });
+	await selectButton.click({ force: true });
+	await page.waitForSelector("[data-slot=\"select-content\"]");
+	const casualFunButton = page.getByRole("option", { name: "Casual Fun" });
 	await expect(casualFunButton).toBeVisible();
 
 	// index 1 (Casual Fun) に切り替える

--- a/src/feature/exr/PresetDropdown.tsx
+++ b/src/feature/exr/PresetDropdown.tsx
@@ -1,62 +1,21 @@
-import { useBackendUpdate } from "@/hooks/useBackend";
-import { updateExrOption } from "@/logics/api";
-import { format, PRESET_SWITCH_MESSAGE, PRESET_SWITCH_TITLE } from "@/noTrans";
-import { useStore } from "@/useStore";
+import { SelectContent } from "@/components/ui/select";
 import { PresetDropdownItem } from "./PresetDropdownItem";
 
 interface PresetDropdownProps {
-	currentSelection: number;
 	presetValues: number[];
 }
 
 /**
  * プリセットの選択肢を表示するドロップダウンリストコンポーネント
  */
-export function PresetDropdown({
-	currentSelection,
-	presetValues,
-}: PresetDropdownProps) {
-	const currentPresetName = useStore((state) => {
-		return (
-			state.presetNames[currentSelection] ??
-			String(presetValues[currentSelection])
-		);
-	});
-	const setPresetDropdownOpen = useStore(
-		(state) => state.setPresetDropdownOpen,
-	);
-	const setBlockDialog = useStore((state) => state.openBlockDialog);
-
-	const backendUpdator = useBackendUpdate();
-
-	const handlePresetSelect = (index: number, newPreset: string) => {
-		setPresetDropdownOpen(false);
-
-		setBlockDialog({
-			type: "confirm",
-			title: PRESET_SWITCH_TITLE,
-			message: format(PRESET_SWITCH_MESSAGE, currentPresetName, newPreset),
-			onConfirm: () =>
-				backendUpdator(async () => {
-					await updateExrOption(0, 0, 0, index);
-				}),
-		});
-	};
-
+export function PresetDropdown({ presetValues }: PresetDropdownProps) {
 	return (
-		<div className="absolute top-full left-0 w-full bg-gray-800 border border-gray-700 rounded shadow-xl z-50 max-h-60 overflow-y-auto">
+		<SelectContent>
 			{presetValues.map((val, index) => {
-				const isSelected = index === currentSelection;
 				return (
-					<PresetDropdownItem
-						key={`preset-${val}`}
-						index={index}
-						value={val}
-						isSelected={isSelected}
-						onSelect={handlePresetSelect}
-					/>
+					<PresetDropdownItem key={`preset-${val}`} index={index} value={val} />
 				);
 			})}
-		</div>
+		</SelectContent>
 	);
 }

--- a/src/feature/exr/PresetDropdownItem.tsx
+++ b/src/feature/exr/PresetDropdownItem.tsx
@@ -1,43 +1,28 @@
+import { SelectItem } from "@/components/ui/select";
 import { useStore } from "@/useStore";
 
 interface PresetDropdownItemProps {
 	index: number;
 	value: number;
-	isSelected: boolean;
-	onSelect: (index: number, name: string) => void;
 }
 
 /**
  * ドロップダウン内の各プリセット項目を表示するコンポーネント。
  * 特定のインデックスの名前のみを購読することでパフォーマンスを最適化しています。
  */
-export function PresetDropdownItem({
-	index,
-	value,
-	isSelected,
-	onSelect,
-}: PresetDropdownItemProps) {
+export function PresetDropdownItem({ index, value }: PresetDropdownItemProps) {
 	const name = useStore((state) => {
 		return state.presetNames[index] ?? String(value);
 	});
 
 	return (
-		<button
-			type="button"
-			onClick={() => {
-				onSelect(index, name);
-			}}
-			className={`
-        w-full text-left px-3 py-2 text-sm transition-colors
-        ${isSelected ? "bg-blue-600 text-white" : "text-gray-300 hover:bg-gray-700"}
-      `}
-		>
-			<div className="flex justify-between items-center">
+		<SelectItem value={String(index)}>
+			<div className="flex justify-between items-center w-full">
 				<span>{name}</span>
 				{name !== String(value) && (
 					<span className="text-xs opacity-50 ml-2">({value})</span>
 				)}
 			</div>
-		</button>
+		</SelectItem>
 	);
 }

--- a/src/feature/exr/PresetInput.tsx
+++ b/src/feature/exr/PresetInput.tsx
@@ -1,5 +1,5 @@
-import { SelectTrigger } from "@/components/ui/select";
 import { useRef } from "react";
+import { SelectTrigger } from "@/components/ui/select";
 import { PRESET_INPUT_PLACEHOLDER, PRESET_SELECT_ARIA } from "@/noTrans";
 import { useStore } from "@/useStore";
 

--- a/src/feature/exr/PresetInput.tsx
+++ b/src/feature/exr/PresetInput.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from "lucide-react";
+import { SelectTrigger } from "@/components/ui/select";
 import { useRef } from "react";
 import { PRESET_INPUT_PLACEHOLDER, PRESET_SELECT_ARIA } from "@/noTrans";
 import { useStore } from "@/useStore";
@@ -18,11 +18,7 @@ export function PresetInput({
 	const currentPresetName = useStore((state) => {
 		return state.presetNames[currentSelection] ?? String(currentPresetValue);
 	});
-	const isDropdownOpen = useStore((state) => state.isPresetDropdownOpen);
 	const updatePresetName = useStore((state) => state.updatePresetName);
-	const setPresetDropdownOpen = useStore(
-		(state) => state.setPresetDropdownOpen,
-	);
 
 	const inputRef = useRef<HTMLInputElement>(null);
 
@@ -58,10 +54,6 @@ export function PresetInput({
 		}
 	};
 
-	const toggleDropdown = () => {
-		setPresetDropdownOpen(!isDropdownOpen);
-	};
-
 	return (
 		<div className="relative flex items-center bg-gray-800 border border-gray-700 rounded overflow-hidden focus-within:bg-gray-600">
 			<input
@@ -74,18 +66,10 @@ export function PresetInput({
 				className="px-3 py-1.5 text-sm bg-transparent text-gray-200 outline-none w-48"
 				placeholder={PRESET_INPUT_PLACEHOLDER}
 			/>
-			<button
-				type="button"
-				onClick={toggleDropdown}
-				className="px-2 py-1.5 bg-gray-700 hover:bg-gray-600 border-l border-gray-600 transition-colors"
+			<SelectTrigger
+				className="px-2 py-1.5 h-auto bg-gray-700 hover:bg-gray-600 border-l border-gray-600 rounded-none transition-colors border-y-0 border-r-0"
 				aria-label={PRESET_SELECT_ARIA}
-			>
-				<ChevronDown
-					size={16}
-					className={`text-gray-400 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
-					aria-hidden="true"
-				/>
-			</button>
+			/>
 		</div>
 	);
 }

--- a/src/feature/exr/PresetSelector.tsx
+++ b/src/feature/exr/PresetSelector.tsx
@@ -45,11 +45,7 @@ export function PresetSelector() {
 		setBlockDialog({
 			type: "confirm",
 			title: PRESET_SWITCH_TITLE,
-			message: format(
-				PRESET_SWITCH_MESSAGE,
-				currentPresetName,
-				newPresetName,
-			),
+			message: format(PRESET_SWITCH_MESSAGE, currentPresetName, newPresetName),
 			onConfirm: () =>
 				backendUpdator(async () => {
 					await updateExrOption(0, 0, 0, index);

--- a/src/feature/exr/PresetSelector.tsx
+++ b/src/feature/exr/PresetSelector.tsx
@@ -22,7 +22,6 @@ export function PresetSelector() {
 		return state.highlightedExROptionId === PRESET_OPTION_UNIQUE_ID;
 	});
 
-	const presetNames = useStore((state) => state.presetNames);
 	const setBlockDialog = useStore((state) => state.openBlockDialog);
 
 	const backendUpdator = useBackendUpdate();
@@ -38,6 +37,7 @@ export function PresetSelector() {
 	const handlePresetSelect = (value: string) => {
 		const index = Number(value);
 		const val = presetValues[index];
+		const presetNames = useStore.getState().presetNames;
 		const currentPresetName =
 			presetNames[currentSelection] ?? String(currentPresetValue);
 		const newPresetName = presetNames[index] ?? String(val);

--- a/src/feature/exr/PresetSelector.tsx
+++ b/src/feature/exr/PresetSelector.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useRef } from "react";
 import { HighlightWrapper } from "@/components/parts/HighlightWrapper";
+import { Select } from "@/components/ui/select";
+import { useBackendUpdate } from "@/hooks/useBackend";
 import { useOptionData } from "@/hooks/useExROptionData";
 import { createExRNavigateId } from "@/hooks/useOptionNavigation";
+import { updateExrOption } from "@/logics/api";
 import { PRESET_OPTION_UNIQUE_ID } from "@/logics/optionUtils";
+import { format, PRESET_SWITCH_MESSAGE, PRESET_SWITCH_TITLE } from "@/noTrans";
 import { useStore } from "@/useStore";
 import { PresetDropdown } from "./PresetDropdown";
 import { PresetInput } from "./PresetInput";
@@ -10,39 +13,19 @@ import { PresetInput } from "./PresetInput";
 /**
  * プリセットを選択・編集するためのコンポーネント。
  * CategoryId: 0, OptionId: 0 の設定を操作します。
- * AGENT.md のガイドラインに従い、useState を使用せず、グローバルストアで状態を管理します。
  */
 
 export function PresetSelector() {
 	const presetOption = useOptionData(PRESET_OPTION_UNIQUE_ID);
 
-	const isDropdownOpen = useStore((state) => {
-		return state.isPresetDropdownOpen;
-	});
-	const setPresetDropdownOpen = useStore((state) => {
-		return state.setPresetDropdownOpen;
-	});
 	const isHighlighted = useStore((state) => {
 		return state.highlightedExROptionId === PRESET_OPTION_UNIQUE_ID;
 	});
 
-	const dropdownRef = useRef<HTMLDivElement>(null);
+	const presetNames = useStore((state) => state.presetNames);
+	const setBlockDialog = useStore((state) => state.openBlockDialog);
 
-	// 外部クリックでドロップダウンを閉じる
-	useEffect(() => {
-		const handleClickOutside = (event: MouseEvent) => {
-			if (
-				dropdownRef.current &&
-				!dropdownRef.current.contains(event.target as Node)
-			) {
-				setPresetDropdownOpen(false);
-			}
-		};
-		document.addEventListener("mousedown", handleClickOutside);
-		return () => {
-			document.removeEventListener("mousedown", handleClickOutside);
-		};
-	}, [setPresetDropdownOpen]);
+	const backendUpdator = useBackendUpdate();
 
 	if (!presetOption) {
 		return null;
@@ -52,6 +35,28 @@ export function PresetSelector() {
 	const presetValues = presetOption.values as number[];
 	const currentPresetValue = presetValues[currentSelection];
 
+	const handlePresetSelect = (value: string) => {
+		const index = Number(value);
+		const val = presetValues[index];
+		const currentPresetName =
+			presetNames[currentSelection] ?? String(currentPresetValue);
+		const newPresetName = presetNames[index] ?? String(val);
+
+		setBlockDialog({
+			type: "confirm",
+			title: PRESET_SWITCH_TITLE,
+			message: format(
+				PRESET_SWITCH_MESSAGE,
+				currentPresetName,
+				newPresetName,
+			),
+			onConfirm: () =>
+				backendUpdator(async () => {
+					await updateExrOption(0, 0, 0, index);
+				}),
+		});
+	};
+
 	const navigateId = createExRNavigateId(PRESET_OPTION_UNIQUE_ID);
 
 	return (
@@ -60,19 +65,19 @@ export function PresetSelector() {
 			isHighlighted={isHighlighted}
 			isInset={false}
 		>
-			<div className="relative flex items-center gap-2" ref={dropdownRef}>
-				<PresetInput
-					currentSelection={currentSelection}
-					currentPresetValue={currentPresetValue}
-				/>
-
-				{isDropdownOpen && (
-					<PresetDropdown
+			<Select
+				value={String(currentSelection)}
+				onValueChange={handlePresetSelect}
+			>
+				<div className="relative flex items-center gap-2">
+					<PresetInput
 						currentSelection={currentSelection}
-						presetValues={presetValues}
+						currentPresetValue={currentPresetValue}
 					/>
-				)}
-			</div>
+
+					<PresetDropdown presetValues={presetValues} />
+				</div>
+			</Select>
 		</HighlightWrapper>
 	);
 }

--- a/src/feature/rightsidepanel/summary/PresetSummaryRow.tsx
+++ b/src/feature/rightsidepanel/summary/PresetSummaryRow.tsx
@@ -8,15 +8,14 @@ import { useStore } from "@/useStore";
 
 export function PresetSummaryRow() {
 	const navigateExR = useExROptionNavigationInline();
-
-	const selection = useStore(
-		(state) => state.exrValue[PRESET_OPTION_UNIQUE_ID]?.selection ?? 0,
-	);
-	const presetValue = useStore(
-		(state) => state.exrValue[PRESET_OPTION_UNIQUE_ID]?.values[selection] ?? "",
-	);
 	const presetName = useStore(
-		(state) => state.presetNames[selection] ?? String(presetValue),
+		useShallow((state) => {
+			const option = state.exrValue[PRESET_OPTION_UNIQUE_ID];
+			const selection = option?.selection ?? 0;
+			return (
+				state.presetNames[selection] ?? String(option?.values[selection] ?? "")
+			);
+		}),
 	);
 
 	const presetTitle =

--- a/src/feature/rightsidepanel/summary/PresetSummaryRow.tsx
+++ b/src/feature/rightsidepanel/summary/PresetSummaryRow.tsx
@@ -8,14 +8,15 @@ import { useStore } from "@/useStore";
 
 export function PresetSummaryRow() {
 	const navigateExR = useExROptionNavigationInline();
+
+	const selection = useStore(
+		(state) => state.exrValue[PRESET_OPTION_UNIQUE_ID]?.selection ?? 0,
+	);
+	const presetValue = useStore(
+		(state) => state.exrValue[PRESET_OPTION_UNIQUE_ID]?.values[selection] ?? "",
+	);
 	const presetName = useStore(
-		useShallow((state) => {
-			const option = state.exrValue[PRESET_OPTION_UNIQUE_ID];
-			const selection = option?.selection ?? 0;
-			return (
-				state.presetNames[selection] ?? String(option?.values[selection] ?? "")
-			);
-		}),
+		(state) => state.presetNames[selection] ?? String(presetValue),
 	);
 
 	const presetTitle =

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -21,7 +21,6 @@ export interface ExROptionViewerSlice {
 	openedExRCategoryIds: Record<number, boolean>;
 	openedExROptionIds: Record<number, boolean>;
 	presetNames: Record<number, string>;
-	isPresetDropdownOpen: boolean;
 	exrValue: Record<UniqueOptionId, ExROptionValueData>;
 	isExROptionActive: Record<UniqueOptionId, boolean>;
 	highlightedExROptionId: UniqueOptionId | null;
@@ -32,7 +31,6 @@ export interface ExROptionViewerSlice {
 	openExROptions: (uniqueOptionIds: UniqueOptionId[]) => void;
 	updateExROption: (updateOptions: (UpdatedOptions | null)[]) => void;
 	updatePresetName: (presetIndex: number, name: string) => void;
-	setPresetDropdownOpen: (isOpen: boolean) => void;
 	setHighlightedExROptionId: (id: UniqueOptionId | null) => void;
 	resetViewer: () => void;
 	setExROptions: (
@@ -57,7 +55,6 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		isExROptionActive: {},
 		highlightedExROptionId: null,
 		presetNames: loadPresetNamesFromLocalStorage(),
-		isPresetDropdownOpen: false,
 		setSelectedExRTabId: (id: ExRTabId) => {
 			console.log(
 				JSON.stringify({
@@ -77,7 +74,6 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 				isExRTabPending: false,
 				openedExRCategoryIds: {},
 				openedExROptionIds: {},
-				isPresetDropdownOpen: false,
 			});
 		},
 		toggleExRCategory: (categoryId: number) => {
@@ -167,9 +163,6 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 					presetNames: newPresetNames,
 				};
 			});
-		},
-		setPresetDropdownOpen: (isOpen: boolean) => {
-			set({ isPresetDropdownOpen: isOpen });
 		},
 		setHighlightedExROptionId: (id) => {
 			set({ highlightedExROptionId: id });

--- a/tests/PresetSelector.test.tsx
+++ b/tests/PresetSelector.test.tsx
@@ -37,10 +37,7 @@ vi.mock("@/components/ui/select", () => ({
 		className,
 		children,
 		...props
-	}: {
-		className?: string;
-		children?: ReactNode;
-	}) => (
+	}: { className?: string; children?: ReactNode }) => (
 		<span className={className} {...props}>
 			{children}
 		</span>
@@ -64,14 +61,15 @@ describe("PresetSelector", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.mocked(useStore).mockImplementation((selector) =>
-			selector({
-				presetNames: { 0: "Preset 1", 1: "Preset 2" },
-				updatePresetName: mockUpdatePresetName,
-				openBlockDialog: mockOpenBlockDialog,
-				highlightedExROptionId: null,
-			}),
-		);
+		const state = {
+			presetNames: { 0: "Preset 1", 1: "Preset 2" },
+			updatePresetName: mockUpdatePresetName,
+			openBlockDialog: mockOpenBlockDialog,
+			highlightedExROptionId: null,
+		};
+		vi.mocked(useStore).mockImplementation((selector) => selector(state));
+		// @ts-ignore
+		useStore.getState = () => state;
 	});
 
 	it("renders preset name in input", () => {
@@ -179,14 +177,15 @@ describe("PresetSelector", () => {
 			values: [10, 20],
 		});
 		// No custom names in store
-		vi.mocked(useStore).mockImplementation((selector) =>
-			selector({
-				presetNames: {},
-				updatePresetName: mockUpdatePresetName,
-				openBlockDialog: mockOpenBlockDialog,
-				highlightedExROptionId: null,
-			}),
-		);
+		const state = {
+			presetNames: {},
+			updatePresetName: mockUpdatePresetName,
+			openBlockDialog: mockOpenBlockDialog,
+			highlightedExROptionId: null,
+		};
+		vi.mocked(useStore).mockImplementation((selector) => selector(state));
+		// @ts-ignore
+		useStore.getState = () => state;
 
 		render(<PresetSelector />);
 

--- a/tests/PresetSelector.test.tsx
+++ b/tests/PresetSelector.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { PresetSelector } from "@/feature/exr/PresetSelector";
 import { useOptionData } from "@/hooks/useExROptionData";
@@ -14,29 +15,47 @@ vi.mock("@/hooks/useBackend", () => ({
 
 // Mock Select component to avoid JSDOM issues with portals/Radix
 vi.mock("@/components/ui/select", () => ({
-	Select: ({ children, onValueChange, value }: any) => (
-		<div
+	Select: ({
+		children,
+		onValueChange,
+		value,
+	}: {
+		children: ReactNode;
+		onValueChange: (v: string) => void;
+		value: string;
+	}) => (
+		<button
+			type="button"
 			data-testid="mock-select"
 			data-value={value}
 			onClick={() => onValueChange("1")}
 		>
 			{children}
-		</div>
-	),
-	SelectTrigger: ({ className, children, ...props }: any) => (
-		<button className={className} {...props}>
-			{children}
 		</button>
 	),
-	SelectContent: ({ children }: any) => (
+	SelectTrigger: ({
+		className,
+		children,
+		...props
+	}: {
+		className?: string;
+		children?: ReactNode;
+	}) => (
+		<span className={className} {...props}>
+			{children}
+		</span>
+	),
+	SelectContent: ({ children }: { children: ReactNode }) => (
 		<div data-testid="select-content">{children}</div>
 	),
-	SelectItem: ({ children, value }: any) => (
+	SelectItem: ({ children, value }: { children: ReactNode; value: string }) => (
 		<div data-testid={`select-item-${value}`} data-value={value}>
 			{children}
 		</div>
 	),
-	SelectValue: ({ children }: any) => <div>{children}</div>,
+	SelectValue: ({ children }: { children?: ReactNode }) => (
+		<span>{children}</span>
+	),
 }));
 
 describe("PresetSelector", () => {
@@ -141,7 +160,7 @@ describe("PresetSelector", () => {
 
 		render(<PresetSelector />);
 
-		// Trigger selection via mock Select
+		// Trigger selection via mock Select (which is a button)
 		const mockSelect = screen.getByTestId("mock-select");
 		fireEvent.click(mockSelect);
 
@@ -176,6 +195,7 @@ describe("PresetSelector", () => {
 
 		expect(mockOpenBlockDialog).toHaveBeenCalled();
 		const dialogConfig = mockOpenBlockDialog.mock.calls[0][0];
+		// Message should contain default names "10" and "20"
 		expect(dialogConfig.message).toContain("10");
 		expect(dialogConfig.message).toContain("20");
 	});
@@ -195,7 +215,9 @@ describe("PresetSelector", () => {
 		);
 
 		render(<PresetSelector />);
-		// Both items should show their original values in parentheses
+		// Current input value
+		expect(screen.getByRole("textbox")).toHaveValue("Custom 1");
+		// Check dropdown items (rendered by mock)
 		expect(screen.getByText("(123)")).toBeInTheDocument();
 		expect(screen.getByText("(456)")).toBeInTheDocument();
 	});

--- a/tests/PresetSelector.test.tsx
+++ b/tests/PresetSelector.test.tsx
@@ -13,7 +13,6 @@ vi.mock("@/hooks/useBackend", () => ({
 }));
 
 describe("PresetSelector", () => {
-	const mockSetPresetDropdownOpen = vi.fn();
 	const mockUpdatePresetName = vi.fn();
 	const mockOpenBlockDialog = vi.fn();
 
@@ -22,8 +21,6 @@ describe("PresetSelector", () => {
 		vi.mocked(useStore).mockImplementation((selector) =>
 			selector({
 				presetNames: ["Preset 1", "Preset 2"],
-				isPresetDropdownOpen: false,
-				setPresetDropdownOpen: mockSetPresetDropdownOpen,
 				updatePresetName: mockUpdatePresetName,
 				openBlockDialog: mockOpenBlockDialog,
 				highlightedExROptionId: null,
@@ -41,42 +38,6 @@ describe("PresetSelector", () => {
 
 		const input = screen.getByRole("textbox");
 		expect(input).toHaveValue("Preset 1");
-	});
-
-	it("toggles dropdown when button clicked", () => {
-		vi.mocked(useOptionData).mockReturnValue({
-			selection: 0,
-			values: [0, 1],
-		});
-
-		render(<PresetSelector />);
-
-		const button = screen.getByRole("button", { name: /プリセットを選択/i });
-		fireEvent.click(button);
-
-		expect(mockSetPresetDropdownOpen).toHaveBeenCalled();
-	});
-
-	it("shows dropdown items when open", () => {
-		vi.mocked(useOptionData).mockReturnValue({
-			selection: 0,
-			values: [0, 1],
-		});
-		vi.mocked(useStore).mockImplementation((selector) =>
-			selector({
-				presetNames: ["Preset 1", "Preset 2"],
-				isPresetDropdownOpen: true,
-				setPresetDropdownOpen: mockSetPresetDropdownOpen,
-				updatePresetName: mockUpdatePresetName,
-				openBlockDialog: mockOpenBlockDialog,
-				highlightedExROptionId: null,
-			}),
-		);
-
-		render(<PresetSelector />);
-
-		expect(screen.getByText("Preset 1")).toBeInTheDocument();
-		expect(screen.getByText("Preset 2")).toBeInTheDocument();
 	});
 
 	it("calls updatePresetName on blur", () => {
@@ -139,70 +100,9 @@ describe("PresetSelector", () => {
 		expect(mockUpdatePresetName).not.toHaveBeenCalled();
 	});
 
-	it("handles preset selection from dropdown and confirm dialog", async () => {
-		vi.mocked(useOptionData).mockReturnValue({
-			selection: 0,
-			values: [10, 20],
-		});
-		vi.mocked(useStore).mockImplementation((selector) =>
-			selector({
-				presetNames: ["P1", "P2"],
-				isPresetDropdownOpen: true,
-				setPresetDropdownOpen: mockSetPresetDropdownOpen,
-				updatePresetName: mockUpdatePresetName,
-				openBlockDialog: mockOpenBlockDialog,
-				highlightedExROptionId: null,
-			}),
-		);
-
-		render(<PresetSelector />);
-
-		const optionButton = screen.getByText("P2");
-		fireEvent.click(optionButton);
-
-		expect(mockSetPresetDropdownOpen).toHaveBeenCalledWith(false);
-		expect(mockOpenBlockDialog).toHaveBeenCalled();
-
-		const { onConfirm } = mockOpenBlockDialog.mock.calls[0][0];
-		await onConfirm();
-		expect(updateExrOption).toHaveBeenCalledWith(0, 0, 0, 1);
-	});
-
-	it("closes dropdown on outside click", () => {
-		vi.mocked(useOptionData).mockReturnValue({
-			selection: 0,
-			values: [0, 1],
-		});
-
-		render(<PresetSelector />);
-
-		fireEvent.mouseDown(document.body);
-		expect(mockSetPresetDropdownOpen).toHaveBeenCalledWith(false);
-	});
-
 	it("renders nothing if presetOption is missing", () => {
 		vi.mocked(useOptionData).mockReturnValue(null as never);
 		const { container } = render(<PresetSelector />);
 		expect(container.firstChild).toBeNull();
-	});
-
-	it("shows original values in dropdown if names are custom", () => {
-		vi.mocked(useOptionData).mockReturnValue({
-			selection: 0,
-			values: [123, 456],
-		});
-		vi.mocked(useStore).mockImplementation((selector) =>
-			selector({
-				presetNames: ["Custom Name", "Preset 2"],
-				isPresetDropdownOpen: true,
-				setPresetDropdownOpen: mockSetPresetDropdownOpen,
-				updatePresetName: mockUpdatePresetName,
-				openBlockDialog: mockOpenBlockDialog,
-				highlightedExROptionId: null,
-			}),
-		);
-
-		render(<PresetSelector />);
-		expect(screen.getByText("(123)")).toBeInTheDocument();
 	});
 });

--- a/tests/PresetSelector.test.tsx
+++ b/tests/PresetSelector.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { PresetSelector } from "@/feature/exr/PresetSelector";
 import { useOptionData } from "@/hooks/useExROptionData";
-import { updateExrOption } from "@/logics/api";
 import { useStore } from "@/useStore";
 
 vi.mock("@/hooks/useExROptionData");

--- a/tests/PresetSelector.test.tsx
+++ b/tests/PresetSelector.test.tsx
@@ -37,7 +37,10 @@ vi.mock("@/components/ui/select", () => ({
 		className,
 		children,
 		...props
-	}: { className?: string; children?: ReactNode }) => (
+	}: {
+		className?: string;
+		children?: ReactNode;
+	}) => (
 		<span className={className} {...props}>
 			{children}
 		</span>
@@ -68,7 +71,7 @@ describe("PresetSelector", () => {
 			highlightedExROptionId: null,
 		};
 		vi.mocked(useStore).mockImplementation((selector) => selector(state));
-		// @ts-ignore
+		// @ts-expect-error
 		useStore.getState = () => state;
 	});
 
@@ -184,7 +187,7 @@ describe("PresetSelector", () => {
 			highlightedExROptionId: null,
 		};
 		vi.mocked(useStore).mockImplementation((selector) => selector(state));
-		// @ts-ignore
+		// @ts-expect-error
 		useStore.getState = () => state;
 
 		render(<PresetSelector />);

--- a/tests/PresetSelector.test.tsx
+++ b/tests/PresetSelector.test.tsx
@@ -24,14 +24,29 @@ vi.mock("@/components/ui/select", () => ({
 		onValueChange: (v: string) => void;
 		value: string;
 	}) => (
-		<button
-			type="button"
+		<div
 			data-testid="mock-select"
 			data-value={value}
-			onClick={() => onValueChange("1")}
+			onClick={(e) => {
+				const target = e.target as HTMLElement;
+				const item = target.closest("[data-value]");
+				if (item) {
+					const val = item.getAttribute("data-value");
+					if (val) {
+						onValueChange(val);
+					}
+				}
+			}}
+			onKeyDown={(e) => {
+				if (e.key === "Enter") {
+					onValueChange("1");
+				}
+			}}
+			role="listbox"
+			tabIndex={0}
 		>
 			{children}
-		</button>
+		</div>
 	),
 	SelectTrigger: ({
 		className,
@@ -41,17 +56,23 @@ vi.mock("@/components/ui/select", () => ({
 		className?: string;
 		children?: ReactNode;
 	}) => (
-		<span className={className} {...props}>
+		<button type="button" className={className} {...props}>
 			{children}
-		</span>
+		</button>
 	),
 	SelectContent: ({ children }: { children: ReactNode }) => (
 		<div data-testid="select-content">{children}</div>
 	),
 	SelectItem: ({ children, value }: { children: ReactNode; value: string }) => (
-		<div data-testid={`select-item-${value}`} data-value={value}>
+		<button
+			type="button"
+			data-testid={`select-item-${value}`}
+			data-value={value}
+			role="option"
+			aria-selected={false}
+		>
 			{children}
-		</div>
+		</button>
 	),
 	SelectValue: ({ children }: { children?: ReactNode }) => (
 		<span>{children}</span>
@@ -161,9 +182,9 @@ describe("PresetSelector", () => {
 
 		render(<PresetSelector />);
 
-		// Trigger selection via mock Select (which is a button)
-		const mockSelect = screen.getByTestId("mock-select");
-		fireEvent.click(mockSelect);
+		// Trigger selection by clicking a mock SelectItem
+		const option2 = screen.getByTestId("select-item-1");
+		fireEvent.click(option2);
 
 		expect(mockOpenBlockDialog).toHaveBeenCalled();
 		const dialogConfig = mockOpenBlockDialog.mock.calls[0][0];
@@ -192,8 +213,8 @@ describe("PresetSelector", () => {
 
 		render(<PresetSelector />);
 
-		const mockSelect = screen.getByTestId("mock-select");
-		fireEvent.click(mockSelect);
+		const option2 = screen.getByTestId("select-item-1");
+		fireEvent.click(option2);
 
 		expect(mockOpenBlockDialog).toHaveBeenCalled();
 		const dialogConfig = mockOpenBlockDialog.mock.calls[0][0];

--- a/tests/PresetSelector.test.tsx
+++ b/tests/PresetSelector.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { PresetSelector } from "@/feature/exr/PresetSelector";
 import { useOptionData } from "@/hooks/useExROptionData";
+import { updateExrOption } from "@/logics/api";
 import { useStore } from "@/useStore";
 
 vi.mock("@/hooks/useExROptionData");
@@ -9,6 +10,33 @@ vi.mock("@/useStore");
 vi.mock("@/logics/api");
 vi.mock("@/hooks/useBackend", () => ({
 	useBackendUpdate: () => vi.fn((callback: () => Promise<void>) => callback()),
+}));
+
+// Mock Select component to avoid JSDOM issues with portals/Radix
+vi.mock("@/components/ui/select", () => ({
+	Select: ({ children, onValueChange, value }: any) => (
+		<div
+			data-testid="mock-select"
+			data-value={value}
+			onClick={() => onValueChange("1")}
+		>
+			{children}
+		</div>
+	),
+	SelectTrigger: ({ className, children, ...props }: any) => (
+		<button className={className} {...props}>
+			{children}
+		</button>
+	),
+	SelectContent: ({ children }: any) => (
+		<div data-testid="select-content">{children}</div>
+	),
+	SelectItem: ({ children, value }: any) => (
+		<div data-testid={`select-item-${value}`} data-value={value}>
+			{children}
+		</div>
+	),
+	SelectValue: ({ children }: any) => <div>{children}</div>,
 }));
 
 describe("PresetSelector", () => {
@@ -19,7 +47,7 @@ describe("PresetSelector", () => {
 		vi.clearAllMocks();
 		vi.mocked(useStore).mockImplementation((selector) =>
 			selector({
-				presetNames: ["Preset 1", "Preset 2"],
+				presetNames: { 0: "Preset 1", 1: "Preset 2" },
 				updatePresetName: mockUpdatePresetName,
 				openBlockDialog: mockOpenBlockDialog,
 				highlightedExROptionId: null,
@@ -39,7 +67,7 @@ describe("PresetSelector", () => {
 		expect(input).toHaveValue("Preset 1");
 	});
 
-	it("calls updatePresetName on blur", () => {
+	it("calls updatePresetName on blur with new name", () => {
 		vi.mocked(useOptionData).mockReturnValue({
 			selection: 0,
 			values: [0, 1],
@@ -52,6 +80,20 @@ describe("PresetSelector", () => {
 		fireEvent.blur(input);
 
 		expect(mockUpdatePresetName).toHaveBeenCalledWith(0, "New Name");
+	});
+
+	it("skips update if name is unchanged on blur", () => {
+		vi.mocked(useOptionData).mockReturnValue({
+			selection: 0,
+			values: [0, 1],
+		});
+
+		render(<PresetSelector />);
+
+		const input = screen.getByRole("textbox");
+		fireEvent.blur(input);
+
+		expect(mockUpdatePresetName).not.toHaveBeenCalled();
 	});
 
 	it("handles Enter key in input", () => {
@@ -85,23 +127,94 @@ describe("PresetSelector", () => {
 		expect(input).toHaveValue("100");
 	});
 
-	it("skips update if name is unchanged on blur", () => {
-		vi.mocked(useOptionData).mockReturnValue({
-			selection: 0,
-			values: [0, 1],
-		});
-
-		render(<PresetSelector />);
-
-		const input = screen.getByRole("textbox");
-		fireEvent.blur(input);
-
-		expect(mockUpdatePresetName).not.toHaveBeenCalled();
-	});
-
 	it("renders nothing if presetOption is missing", () => {
 		vi.mocked(useOptionData).mockReturnValue(null as never);
 		const { container } = render(<PresetSelector />);
 		expect(container.firstChild).toBeNull();
+	});
+
+	it("handles preset selection and confirm dialog", async () => {
+		vi.mocked(useOptionData).mockReturnValue({
+			selection: 0,
+			values: [10, 20],
+		});
+
+		render(<PresetSelector />);
+
+		// Trigger selection via mock Select
+		const mockSelect = screen.getByTestId("mock-select");
+		fireEvent.click(mockSelect);
+
+		expect(mockOpenBlockDialog).toHaveBeenCalled();
+		const dialogConfig = mockOpenBlockDialog.mock.calls[0][0];
+		expect(dialogConfig.type).toBe("confirm");
+
+		// Test onConfirm
+		await dialogConfig.onConfirm();
+		expect(updateExrOption).toHaveBeenCalledWith(0, 0, 0, 1);
+	});
+
+	it("covers default name branch in handlePresetSelect", async () => {
+		vi.mocked(useOptionData).mockReturnValue({
+			selection: 0,
+			values: [10, 20],
+		});
+		// No custom names in store
+		vi.mocked(useStore).mockImplementation((selector) =>
+			selector({
+				presetNames: {},
+				updatePresetName: mockUpdatePresetName,
+				openBlockDialog: mockOpenBlockDialog,
+				highlightedExROptionId: null,
+			}),
+		);
+
+		render(<PresetSelector />);
+
+		const mockSelect = screen.getByTestId("mock-select");
+		fireEvent.click(mockSelect);
+
+		expect(mockOpenBlockDialog).toHaveBeenCalled();
+		const dialogConfig = mockOpenBlockDialog.mock.calls[0][0];
+		expect(dialogConfig.message).toContain("10");
+		expect(dialogConfig.message).toContain("20");
+	});
+
+	it("renders additional info in dropdown items when name is custom", () => {
+		vi.mocked(useOptionData).mockReturnValue({
+			selection: 0,
+			values: [123, 456],
+		});
+		vi.mocked(useStore).mockImplementation((selector) =>
+			selector({
+				presetNames: { 0: "Custom 1", 1: "Custom 2" },
+				updatePresetName: mockUpdatePresetName,
+				openBlockDialog: mockOpenBlockDialog,
+				highlightedExROptionId: null,
+			}),
+		);
+
+		render(<PresetSelector />);
+		// Both items should show their original values in parentheses
+		expect(screen.getByText("(123)")).toBeInTheDocument();
+		expect(screen.getByText("(456)")).toBeInTheDocument();
+	});
+
+	it("does not render parentheses when name matches value", () => {
+		vi.mocked(useOptionData).mockReturnValue({
+			selection: 0,
+			values: [123],
+		});
+		vi.mocked(useStore).mockImplementation((selector) =>
+			selector({
+				presetNames: { 0: "123" },
+				updatePresetName: mockUpdatePresetName,
+				openBlockDialog: mockOpenBlockDialog,
+				highlightedExROptionId: null,
+			}),
+		);
+
+		render(<PresetSelector />);
+		expect(screen.queryByText("(123)")).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
PresetDropdownとその周辺コンポーネントをshadcn/UIのSelectベースに書き換えました。
主な変更点：
- PresetSelectorをSelectのルートコンポーネントとし、onValueChangeで確認ダイアログとバックエンド更新を制御するようにしました。
- PresetInput内のトグルボタンをSelectTriggerに置き換え、ストアでの開閉状態管理を削除しました。
- PresetDropdownItemをSelectItemを使用するように変更しました。
- ストア(exrOptionViewerSlice)から不要になったisPresetDropdownOpen状態を削除しました。
- 既存のテストを新しいコンポーネント構造に合わせて修正・整理しました。

---
*PR created automatically by Jules for task [238461307071634514](https://jules.google.com/task/238461307071634514) started by @yukieiji*