### PR TITLE
ExR一般タブのアウトライン表示修正

### DIFF
--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -269,9 +269,13 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 			tab.Id === ExRTabId.GhostNeutralTab;
 
 		const extractedColors = extractColors(tab.Name);
-		const colors = isGhost
+		let colors = isGhost
 			? extractedColors.map((c) => darkenColor(c))
 			: extractedColors;
+
+		if (colors.length === 0 && tab.Id === ExRTabId.GeneralTab) {
+			colors = ["#FFFFFF"];
+		}
 
 		exrOptionMetaData.tabs[tab.Id] = {
 			name: stripColorTags(tab.Name),

--- a/tests/exrOptionMetaDataColors.test.ts
+++ b/tests/exrOptionMetaDataColors.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createExROptionMetaData,
+	exrOptionMetaData,
+	resetExrOptionMetaData,
+} from "@/logics/api";
+import { ExRTabId } from "@/type";
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe("exrOptionMetaData color assignment", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetExrOptionMetaData();
+	});
+
+	it("should assign default color #FFFFFF to GeneralTab if no color tags are present", async () => {
+		const mockData = [
+			{
+				Id: ExRTabId.GeneralTab,
+				Name: "General",
+				Categories: [
+					{
+						Id: 1,
+						Name: "Category 1",
+						Options: [],
+					},
+				],
+			},
+		];
+
+		vi.mocked(fetch).mockResolvedValue({
+			ok: true,
+			json: async () => mockData,
+		} as Response);
+
+		await createExROptionMetaData();
+
+		expect(exrOptionMetaData.tabs[ExRTabId.GeneralTab].colors).toEqual([
+			"#FFFFFF",
+		]);
+	});
+
+	it("should extract colors from GeneralTab if color tags are present", async () => {
+		const mockData = [
+			{
+				Id: ExRTabId.GeneralTab,
+				Name: "<color=#FF0000>General</color>",
+				Categories: [
+					{
+						Id: 1,
+						Name: "Category 1",
+						Options: [],
+					},
+				],
+			},
+		];
+
+		vi.mocked(fetch).mockResolvedValue({
+			ok: true,
+			json: async () => mockData,
+		} as Response);
+
+		await createExROptionMetaData();
+
+		expect(exrOptionMetaData.tabs[ExRTabId.GeneralTab].colors).toEqual([
+			"#FF0000",
+		]);
+	});
+
+	it("should NOT assign default color to other tabs if no color tags are present", async () => {
+		const mockData = [
+			{
+				Id: ExRTabId.CrewmateTab,
+				Name: "Crewmate",
+				Categories: [
+					{
+						Id: 2,
+						Name: "Category 2",
+						Options: [],
+					},
+				],
+			},
+		];
+
+		vi.mocked(fetch).mockResolvedValue({
+			ok: true,
+			json: async () => mockData,
+		} as Response);
+
+		await createExROptionMetaData();
+
+		expect(exrOptionMetaData.tabs[ExRTabId.CrewmateTab].colors).toEqual([]);
+	});
+});

--- a/tests/exrOptionMetaDataColors.test.ts
+++ b/tests/exrOptionMetaDataColors.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createExROptionMetaData,
 	exrOptionMetaData,
@@ -6,13 +6,17 @@ import {
 } from "@/logics/api";
 import { ExRTabId } from "@/type";
 
-// Mock global fetch
-global.fetch = vi.fn();
-
 describe("exrOptionMetaData color assignment", () => {
+	const mockFetch = vi.fn();
+
 	beforeEach(() => {
-		vi.clearAllMocks();
+		vi.stubGlobal("fetch", mockFetch);
 		resetExrOptionMetaData();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
 	});
 
 	it("should assign default color #FFFFFF to GeneralTab if no color tags are present", async () => {
@@ -30,7 +34,7 @@ describe("exrOptionMetaData color assignment", () => {
 			},
 		];
 
-		vi.mocked(fetch).mockResolvedValue({
+		mockFetch.mockResolvedValue({
 			ok: true,
 			json: async () => mockData,
 		} as Response);
@@ -57,7 +61,7 @@ describe("exrOptionMetaData color assignment", () => {
 			},
 		];
 
-		vi.mocked(fetch).mockResolvedValue({
+		mockFetch.mockResolvedValue({
 			ok: true,
 			json: async () => mockData,
 		} as Response);
@@ -84,7 +88,7 @@ describe("exrOptionMetaData color assignment", () => {
 			},
 		];
 
-		vi.mocked(fetch).mockResolvedValue({
+		mockFetch.mockResolvedValue({
 			ok: true,
 			json: async () => mockData,
 		} as Response);


### PR DESCRIPTION
ExRの一般タブ（グローバル設定）において、タブ名にカラータグが含まれていない場合に枠線（アウトライン）が表示されない問題を修正しました。

具体的には以下の変更を行いました：
1. `src/logics/api.ts` のメタデータ生成処理において、一般タブ（`ExRTabId.GeneralTab`）のカラーが抽出できなかった場合に、デフォルトとして `#FFFFFF`（白）を割り当てるようにしました。
2. 新しく `tests/exrOptionMetaDataColors.test.ts` を作成し、一般タブにカラーが割り当てられること、および他のタブに影響を与えないことを検証するテストを追加しました。

これにより、一般タブが選択された際にも他の役職タブと同様に枠線が表示されるようになります。

---
*PR created automatically by Jules for task [7073811197678905843](https://jules.google.com/task/7073811197678905843) started by @yukieiji*