### PR TITLE
AmongUsタブへのアウトラインカラーの追加

### DIFF
--- a/e2e/au-tab-colors.spec.ts
+++ b/e2e/au-tab-colors.spec.ts
@@ -22,13 +22,19 @@ test.describe("Au Tab Outline Colors", () => {
 	test("Tab 0 (General) should have white outline", async ({ page }) => {
 		await page.getByRole("tab", { name: "0", exact: true }).click();
 		const categoryList = page.getByTestId("category-list");
-		await expect(categoryList).toHaveCSS("border-top-color", "rgb(255, 255, 255)");
+		await expect(categoryList).toHaveCSS(
+			"border-top-color",
+			"rgb(255, 255, 255)",
+		);
 	});
 
 	test("Tab 1 (Crewmate) should have lime green outline", async ({ page }) => {
 		await page.getByRole("tab", { name: "1", exact: true }).click();
 		const categoryList = page.getByTestId("category-list");
-		await expect(categoryList).toHaveCSS("border-top-color", "rgb(140, 255, 0)");
+		await expect(categoryList).toHaveCSS(
+			"border-top-color",
+			"rgb(140, 255, 0)",
+		);
 	});
 
 	test("Tab 2 (Impostor) should have red outline", async ({ page }) => {

--- a/e2e/au-tab-colors.spec.ts
+++ b/e2e/au-tab-colors.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 0;
+	});
+	await page.goto("/");
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+
+	// Au Options タブに切り替え
+	await page.getByRole("button", { name: "Au Options" }).click();
+	await expect(page.getByTestId("category-list")).toBeVisible({
+		timeout: 10000,
+	});
+});
+
+test.describe("Au Tab Outline Colors", () => {
+	test("Tab 0 (General) should have white outline", async ({ page }) => {
+		await page.getByRole("tab", { name: "0", exact: true }).click();
+		const categoryList = page.getByTestId("category-list");
+		await expect(categoryList).toHaveCSS("border-top-color", "rgb(255, 255, 255)");
+	});
+
+	test("Tab 1 (Crewmate) should have lime green outline", async ({ page }) => {
+		await page.getByRole("tab", { name: "1", exact: true }).click();
+		const categoryList = page.getByTestId("category-list");
+		await expect(categoryList).toHaveCSS("border-top-color", "rgb(140, 255, 0)");
+	});
+
+	test("Tab 2 (Impostor) should have red outline", async ({ page }) => {
+		await page.getByRole("tab", { name: "2", exact: true }).click();
+		const categoryList = page.getByTestId("category-list");
+		await expect(categoryList).toHaveCSS("border-top-color", "rgb(255, 0, 0)");
+	});
+});

--- a/src/feature/amongus/AuCategoryList.tsx
+++ b/src/feature/amongus/AuCategoryList.tsx
@@ -14,10 +14,13 @@ export function AuCategoryList() {
 
 	const tabCategoryIds = auOptionMetaData.tabCategoryMap[selectedAuTabId] || [];
 	const isRoleTab = selectedAuTabId === 1 || selectedAuTabId === 2;
-	const tabColors = auOptionMetaData.tabColors[selectedAuTabId] || [];
+	const tabColor = auOptionMetaData.tabColors[selectedAuTabId];
 
 	return (
-		<CategoryContainer isPending={isTabPending} colors={tabColors}>
+		<CategoryContainer
+			isPending={isTabPending}
+			colors={tabColor ? [tabColor] : []}
+		>
 			{tabCategoryIds.map((categoryId, index) => {
 				if (isRoleTab) {
 					return (

--- a/src/feature/amongus/AuCategoryList.tsx
+++ b/src/feature/amongus/AuCategoryList.tsx
@@ -14,9 +14,10 @@ export function AuCategoryList() {
 
 	const tabCategoryIds = auOptionMetaData.tabCategoryMap[selectedAuTabId] || [];
 	const isRoleTab = selectedAuTabId === 1 || selectedAuTabId === 2;
+	const tabColors = auOptionMetaData.tabColors[selectedAuTabId] || [];
 
 	return (
-		<CategoryContainer isPending={isTabPending}>
+		<CategoryContainer isPending={isTabPending} colors={tabColors}>
 			{tabCategoryIds.map((categoryId, index) => {
 				if (isRoleTab) {
 					return (

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -18,6 +18,7 @@ import type {
 } from "../type";
 import {
 	AU_PREFIX,
+	AU_TAB_COLORS,
 	AuOptionCategoryDtoArraySchema,
 	ExRTabDtoArraySchema,
 	ExRTabId,
@@ -328,7 +329,7 @@ export async function createAuOptionMetaData(): Promise<
 
 	const initialValueData: Record<number, number> = {};
 	auOptionMetaData.tabNames = ["0", "1", "2"];
-	auOptionMetaData.tabColors = ["#FFFFFF", "#8CFF00", "#FF0000"];
+	auOptionMetaData.tabColors = [...AU_TAB_COLORS];
 	auOptionMetaData.tabCategoryMap = { 0: [], 1: [], 2: [] };
 	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -328,7 +328,7 @@ export async function createAuOptionMetaData(): Promise<
 
 	const initialValueData: Record<number, number> = {};
 	auOptionMetaData.tabNames = ["0", "1", "2"];
-	auOptionMetaData.tabColors = [["#FFFFFF"], ["#8CFF00"], ["#FF0000"]];
+	auOptionMetaData.tabColors = ["#FFFFFF", "#8CFF00", "#FF0000"];
 	auOptionMetaData.tabCategoryMap = { 0: [], 1: [], 2: [] };
 	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -55,6 +55,7 @@ export const exrOptionMetaData: ExROptionMetaDataRecords = {
 
 export const auOptionMetaData: AuOptionMetaDataRecords = {
 	tabNames: [],
+	tabColors: [],
 	tabCategoryMap: {},
 	categoryMetaData: {},
 	options: {},
@@ -84,6 +85,7 @@ export function resetExrOptionMetaData() {
  */
 export function resetAuOptionMetaData() {
 	auOptionMetaData.tabNames = [];
+	auOptionMetaData.tabColors = [];
 	auOptionMetaData.tabCategoryMap = {};
 	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};
@@ -326,6 +328,7 @@ export async function createAuOptionMetaData(): Promise<
 
 	const initialValueData: Record<number, number> = {};
 	auOptionMetaData.tabNames = ["0", "1", "2"];
+	auOptionMetaData.tabColors = [["#FFFFFF"], ["#8CFF00"], ["#FF0000"]];
 	auOptionMetaData.tabCategoryMap = { 0: [], 1: [], 2: [] };
 	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};

--- a/src/type.ts
+++ b/src/type.ts
@@ -181,7 +181,7 @@ export interface AuOptionCategoryMetaData {
 
 export interface AuOptionMetaDataRecords {
 	tabNames: string[]; // タブの名前
-	tabColors: string[][]; // タブのカラー
+	tabColors: string[]; // タブのカラー
 	tabCategoryMap: Record<number, number[]>; // タブIDとそのタブに属するカテゴリIDの対応
 	categoryMetaData: Record<number, AuOptionCategoryMetaData>; // カテゴリIDとカテゴリメタデータの対応
 	options: Record<AuOptionId, AuOptionMeta>; // 全オプションのメタデータ

--- a/src/type.ts
+++ b/src/type.ts
@@ -181,6 +181,7 @@ export interface AuOptionCategoryMetaData {
 
 export interface AuOptionMetaDataRecords {
 	tabNames: string[]; // タブの名前
+	tabColors: string[][]; // タブのカラー
 	tabCategoryMap: Record<number, number[]>; // タブIDとそのタブに属するカテゴリIDの対応
 	categoryMetaData: Record<number, AuOptionCategoryMetaData>; // カテゴリIDとカテゴリメタデータの対応
 	options: Record<AuOptionId, AuOptionMeta>; // 全オプションのメタデータ

--- a/src/type.ts
+++ b/src/type.ts
@@ -156,6 +156,8 @@ export const AU_PREFIX = {
 	CHANCE: 2,
 } as const;
 
+export const AU_TAB_COLORS = ["#FFFFFF", "#8CFF00", "#FF0000"];
+
 // 全ての値（1 | 2）を型として抽出
 export type AuOptionPrefix = (typeof AU_PREFIX)[keyof typeof AU_PREFIX];
 

--- a/tests/auOptionMetaData.test.ts
+++ b/tests/auOptionMetaData.test.ts
@@ -65,6 +65,11 @@ describe("createAuOptionMetaData", () => {
 		expect(auOptionMetaData.tabCategoryMap[1]).toContain(1);
 		expect(auOptionMetaData.tabCategoryMap[2]).toContain(2);
 
+		// Check colors
+		expect(auOptionMetaData.tabColors[0]).toBe("#FFFFFF");
+		expect(auOptionMetaData.tabColors[1]).toBe("#8CFF00");
+		expect(auOptionMetaData.tabColors[2]).toBe("#FF0000");
+
 		// Check category info
 		expect(auOptionMetaData.categoryMetaData[0].name).toBe("Tab0Category");
 


### PR DESCRIPTION
AmongUsの各タブ（全般、クルー、インポスター）に対して、ExRタブと同様のアウトラインカラー（枠線の色）が表示されるように変更しました。

### 変更内容：
1. `src/type.ts`: `AuOptionMetaDataRecords` インターフェースに `tabColors` を追加。
2. `src/logics/api.ts`: 
   - `auOptionMetaData` の初期化とリセット処理に `tabColors` を追加。
   - `createAuOptionMetaData` 関数内で、各タブのデフォルトカラーを設定（0: 白, 1: 黄緑, 2: 赤）。
3. `src/feature/amongus/AuCategoryList.tsx`: 選択されたタブに応じた色を `CategoryContainer` に渡すように修正。

これにより、タブを切り替えた際にコンテンツエリアを囲む枠線の色が、タブの種類（全般・クルー・インポスター）に応じて変化するようになりました。

---
*PR created automatically by Jules for task [13967946283495074466](https://jules.google.com/task/13967946283495074466) started by @yukieiji*