### PR TITLE
Add option search bar UI

### DIFF
--- a/e2e/option_search_bar.spec.ts
+++ b/e2e/option_search_bar.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Option Search Bar", () => {
+	test.beforeEach(async ({ page }) => {
+		// Mock API responses to avoid dependency on actual backend
+		await page.route("**/api/all-options", (route) => {
+			route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({
+					au: { categories: [] },
+					exr: { categories: [] },
+				}),
+			});
+		});
+		await page.goto("/");
+		await page.waitForSelector('[data-testid="main-content-section"]');
+	});
+
+	test("should be visible in Au Options tab", async ({ page }) => {
+		await page.getByRole("button", { name: "Au Options" }).click();
+		await expect(page.getByPlaceholder("オプションを検索...")).toBeVisible();
+	});
+
+	test("should be visible in ExR Options tab", async ({ page }) => {
+		await page.getByRole("button", { name: "ExR Options" }).click();
+		await expect(page.getByPlaceholder("オプションを検索...")).toBeVisible();
+	});
+
+	test("should not be visible in Role Filter tab", async ({ page }) => {
+		await page.getByRole("button", { name: "Role Filter" }).click();
+		await expect(
+			page.getByPlaceholder("オプションを検索..."),
+		).not.toBeVisible();
+	});
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { BlockableLoading } from "./feature/BlockableLoading";
 import { ExROptionEditor } from "./feature/exr/ExROptionEditor";
 import { PresetSelector } from "./feature/exr/PresetSelector";
 import { OptionGroupToggleSidebar } from "./feature/OptionGroupToggleSidebar";
+import { OptionSearchBar } from "./feature/OptionSearchBar";
 import { RightSidePanel } from "./feature/rightsidepanel/RightSidePanel";
 import { RoleFilterViewer } from "./feature/rolefilter/RoleFilterViewer";
 import {
@@ -108,6 +109,9 @@ function MainContent() {
 						>
 							<PresetSelectorContainer />
 						</Suspense>
+					)}
+					{(selectedTab === "ExR" || selectedTab === "Au") && (
+						<OptionSearchBar />
 					)}
 					{isSidebarPending && (
 						<div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>

--- a/src/feature/OptionSearchBar.tsx
+++ b/src/feature/OptionSearchBar.tsx
@@ -1,0 +1,26 @@
+import { Search } from "lucide-react";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "@/components/ui/input-group";
+import { OPTION_SEARCH_PLACEHOLDER } from "@/noTrans";
+
+/**
+ * オプションを検索するための検索バーコンポーネント。
+ * UIのみを提供し、メインのロジックはまだ実装されていません。
+ */
+export function OptionSearchBar() {
+	return (
+		<InputGroup className="w-64">
+			<InputGroupAddon align="inline-start">
+				<Search className="size-4 text-muted-foreground" />
+			</InputGroupAddon>
+			<InputGroupInput
+				placeholder={OPTION_SEARCH_PLACEHOLDER}
+				type="search"
+				className="flex-1"
+			/>
+		</InputGroup>
+	);
+}

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -58,6 +58,7 @@ export const ROLE_FILTER_ROLE_DELETE_CONFIRM_MESSAGE =
 export const ROLE_FILTER_NO_ROLES = "No roles selected";
 export const ROLE_FILTER_DELETE_ARIA = "Delete filter";
 export const ROLE_SELECT_SEARCH_PLACEHOLDER = "役職を検索...";
+export const OPTION_SEARCH_PLACEHOLDER = "オプションを検索...";
 export const ROLE_SELECT_DEFAULT_TITLE = "役職の選択";
 export const CSV_FILE_DESCRIPTION = "CSV File";
 

--- a/tests/OptionSearchBar.test.tsx
+++ b/tests/OptionSearchBar.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { OptionSearchBar } from "@/feature/OptionSearchBar";
+import { OPTION_SEARCH_PLACEHOLDER } from "@/noTrans";
+
+describe("OptionSearchBar", () => {
+	it("renders correctly with search icon and placeholder", () => {
+		render(<OptionSearchBar />);
+
+		const input = screen.getByPlaceholderText(OPTION_SEARCH_PLACEHOLDER);
+		expect(input).toBeInTheDocument();
+		expect(input).toHaveAttribute("type", "search");
+
+		const icon = document.querySelector("svg");
+		expect(icon).toBeInTheDocument();
+		expect(icon).toHaveClass("lucide-search");
+	});
+});


### PR DESCRIPTION
Added a search bar UI next to the preset selector as requested. The search bar is visible in both "Au Options" and "ExR Options" tabs. The implementation is UI-only and uses shadcn/ui components with a search icon from lucide-react.

---
*PR created automatically by Jules for task [13696341486919698178](https://jules.google.com/task/13696341486919698178) started by @yukieiji*