### PR TITLE
SearchBarへのオプション検索機能の追加

### DIFF
--- a/src/feature/SearchBar.tsx
+++ b/src/feature/SearchBar.tsx
@@ -1,5 +1,5 @@
 import { Search } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import {
 	InputGroup,
 	InputGroupAddon,
@@ -18,37 +18,35 @@ import { useStore } from "@/useStore";
  * オプションやカテゴリをを検索するための検索バーコンポーネント。
  */
 export function SearchBar() {
-	const [query, setQuery] = useState("");
-	const [isOpen, setIsOpen] = useState(false);
-	const [results, setResults] = useState<SearchItem[]>([]);
 	const containerRef = useRef<HTMLDivElement>(null);
 
 	const isExROptionActive = useStore((state) => state.isExROptionActive);
+	const query = useStore((state) => state.optionSearchQuery);
+	const setQuery = useStore((state) => state.setOptionSearchQuery);
+	const isOpen = useStore((state) => state.isOptionSearchOpen);
+	const setIsOpen = useStore((state) => state.setIsOptionSearchOpen);
+
 	const navigateToExR = useExROptionNavigationInline();
 	const navigateToAu = useAuOptionNavigationInline();
 
-	useEffect(() => {
-		if (query.trim() === "") {
-			setResults([]);
-			return;
-		}
+	const lowerQuery = query.toLowerCase();
+	const results =
+		query.trim() === ""
+			? []
+			: globalSearchItems
+					.filter((item) => {
+						if (!item.term.toLowerCase().includes(lowerQuery)) {
+							return false;
+						}
 
-		const lowerQuery = query.toLowerCase();
-		const filtered = globalSearchItems.filter((item) => {
-			if (!item.term.toLowerCase().includes(lowerQuery)) {
-				return false;
-			}
+						// ExRオプションの場合はアクティブチェックを行う
+						if (item.info.mode === "exr-opt") {
+							return isExROptionActive[item.info.uniqueOptionId] ?? false;
+						}
 
-			// ExRオプションの場合はアクティブチェックを行う
-			if (item.info.mode === "exr-opt") {
-				return isExROptionActive[item.info.uniqueOptionId] ?? false;
-			}
-
-			return true;
-		});
-
-		setResults(filtered.slice(0, 10)); // 最大10件表示
-	}, [query, isExROptionActive]);
+						return true;
+					})
+					.slice(0, 10); // 最大10件表示
 
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
@@ -64,7 +62,7 @@ export function SearchBar() {
 		return () => {
 			document.removeEventListener("mousedown", handleClickOutside);
 		};
-	}, []);
+	}, [setIsOpen]);
 
 	const handleSelect = (item: SearchItem) => {
 		if (item.info.mode === "exr-opt") {

--- a/src/feature/SearchBar.tsx
+++ b/src/feature/SearchBar.tsx
@@ -1,26 +1,117 @@
 import { Search } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import {
 	InputGroup,
 	InputGroupAddon,
 	InputGroupInput,
 } from "@/components/ui/input-group";
+import {
+	useAuOptionNavigationInline,
+	useExROptionNavigationInline,
+} from "@/hooks/useOptionNavigation";
+import { globalSearchItems } from "@/logics/api";
 import { OPTION_SEARCH_PLACEHOLDER } from "@/noTrans";
+import type { SearchItem } from "@/type";
+import { useStore } from "@/useStore";
 
 /**
  * オプションやカテゴリをを検索するための検索バーコンポーネント。
- * UIのみを提供し、メインのロジックはまだ実装されていません。
  */
 export function SearchBar() {
+	const [query, setQuery] = useState("");
+	const [isOpen, setIsOpen] = useState(false);
+	const [results, setResults] = useState<SearchItem[]>([]);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	const isExROptionActive = useStore((state) => state.isExROptionActive);
+	const navigateToExR = useExROptionNavigationInline();
+	const navigateToAu = useAuOptionNavigationInline();
+
+	useEffect(() => {
+		if (query.trim() === "") {
+			setResults([]);
+			return;
+		}
+
+		const lowerQuery = query.toLowerCase();
+		const filtered = globalSearchItems.filter((item) => {
+			if (!item.term.toLowerCase().includes(lowerQuery)) {
+				return false;
+			}
+
+			// ExRオプションの場合はアクティブチェックを行う
+			if (item.info.mode === "exr-opt") {
+				return isExROptionActive[item.info.uniqueOptionId] ?? false;
+			}
+
+			return true;
+		});
+
+		setResults(filtered.slice(0, 10)); // 最大10件表示
+	}, [query, isExROptionActive]);
+
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (
+				containerRef.current &&
+				!containerRef.current.contains(event.target as Node)
+			) {
+				setIsOpen(false);
+			}
+		};
+
+		document.addEventListener("mousedown", handleClickOutside);
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+		};
+	}, []);
+
+	const handleSelect = (item: SearchItem) => {
+		if (item.info.mode === "exr-opt") {
+			navigateToExR(item.info.uniqueOptionId);
+		} else if (item.info.mode === "au-opt") {
+			navigateToAu(item.info.tabId, item.info.categoryId, item.info.auOptionId);
+		}
+		setIsOpen(false);
+		setQuery("");
+	};
+
 	return (
-		<InputGroup className="w-64">
-			<InputGroupAddon align="inline-start">
-				<Search className="size-4 text-muted-foreground" />
-			</InputGroupAddon>
-			<InputGroupInput
-				placeholder={OPTION_SEARCH_PLACEHOLDER}
-				type="search"
-				className="flex-1"
-			/>
-		</InputGroup>
+		<div className="relative w-64" ref={containerRef}>
+			<InputGroup>
+				<InputGroupAddon align="inline-start">
+					<Search className="size-4 text-muted-foreground" />
+				</InputGroupAddon>
+				<InputGroupInput
+					placeholder={OPTION_SEARCH_PLACEHOLDER}
+					type="search"
+					className="flex-1"
+					value={query}
+					onChange={(e) => {
+						setQuery(e.target.value);
+						setIsOpen(true);
+					}}
+					onFocus={() => setIsOpen(true)}
+				/>
+			</InputGroup>
+
+			{isOpen && results.length > 0 && (
+				<div className="absolute top-full left-0 w-full mt-1 bg-popover border rounded-md shadow-lg z-50 overflow-hidden">
+					<ul className="max-h-60 overflow-y-auto py-1">
+						{results.map((item) => (
+							<li key={item.id}>
+								<button
+									type="button"
+									className="w-full text-left px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors"
+									onClick={() => handleSelect(item)}
+								>
+									{item.term}
+								</button>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+		</div>
 	);
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -79,7 +79,12 @@ export function resetExrOptionMetaData() {
 	exrOptionMetaData.categories = {};
 	exrOptionMetaData.options = {};
 	exrOptionMetaData.globalCategoryIdTopLevelMap = {};
+
+	const nextItems = globalSearchItems.filter((item) => {
+		return !item.info.mode.startsWith("exr-");
+	});
 	globalSearchItems.length = 0;
+	globalSearchItems.push(...nextItems);
 }
 
 /**
@@ -91,7 +96,12 @@ export function resetAuOptionMetaData() {
 	auOptionMetaData.tabCategoryMap = {};
 	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};
+
+	const nextItems = globalSearchItems.filter((item) => {
+		return !item.info.mode.startsWith("au-");
+	});
 	globalSearchItems.length = 0;
+	globalSearchItems.push(...nextItems);
 }
 
 /**

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -79,6 +79,7 @@ export function resetExrOptionMetaData() {
 	exrOptionMetaData.categories = {};
 	exrOptionMetaData.options = {};
 	exrOptionMetaData.globalCategoryIdTopLevelMap = {};
+	globalSearchItems.length = 0;
 }
 
 /**
@@ -90,6 +91,7 @@ export function resetAuOptionMetaData() {
 	auOptionMetaData.tabCategoryMap = {};
 	auOptionMetaData.categoryMetaData = {};
 	auOptionMetaData.options = {};
+	globalSearchItems.length = 0;
 }
 
 /**
@@ -226,6 +228,15 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 					exrOptionMetaData.options[uniqueId]?.childOptionIds ?? [],
 				parentOptionIds: ancestorIds,
 			};
+
+			globalSearchItems.push({
+				id: `exr-opt-${uniqueId}`,
+				term: opt.TranslatedName,
+				info: {
+					mode: "exr-opt",
+					uniqueOptionId: uniqueId,
+				},
+			});
 
 			valueData[uniqueId] = {
 				selection: opt.Selection,
@@ -391,6 +402,17 @@ export async function createAuOptionMetaData(): Promise<
 					categoryId: categoryId,
 				};
 				initialValueData[maxCountId] = roleValue.MaxCount;
+
+				globalSearchItems.push({
+					id: `au-opt-${chanceId}`,
+					term: opt.TranslatedTitle,
+					info: {
+						mode: "au-opt",
+						tabId: currentTab,
+						categoryId: categoryId,
+						auOptionId: chanceId,
+					},
+				});
 			} else {
 				const auOptionId = getAuOptionId(optionName, valueType);
 				auOptionMetaData.categoryMetaData[categoryId].options.push(auOptionId);
@@ -418,6 +440,17 @@ export async function createAuOptionMetaData(): Promise<
 					categoryId: categoryId,
 				};
 				initialValueData[auOptionId] = index;
+
+				globalSearchItems.push({
+					id: `au-opt-${auOptionId}`,
+					term: opt.TranslatedTitle,
+					info: {
+						mode: "au-opt",
+						tabId: currentTab,
+						categoryId: categoryId,
+						auOptionId: auOptionId,
+					},
+				});
 			}
 		}
 	}

--- a/src/slices/globalUiSlice.ts
+++ b/src/slices/globalUiSlice.ts
@@ -18,6 +18,10 @@ export interface GlobalUiSlice {
 	setRoleSearchQuery: (query: string) => void;
 	setSelectedRoleIds: (roleIds: number[]) => void;
 	setLastClickedId: (roleId: number | null) => void;
+	optionSearchQuery: string;
+	setOptionSearchQuery: (query: string) => void;
+	isOptionSearchOpen: boolean;
+	setIsOptionSearchOpen: (isOpen: boolean) => void;
 	windowWidth: number;
 	setWindowWidth: (width: number) => void;
 }
@@ -26,6 +30,10 @@ export const createGlobalUiSlice: StateCreator<GlobalUiSlice> = (set, get) => {
 	return {
 		windowWidth: typeof window !== "undefined" ? window.innerWidth : 1920,
 		setWindowWidth: (width) => set({ windowWidth: width }),
+		optionSearchQuery: "",
+		setOptionSearchQuery: (query) => set({ optionSearchQuery: query }),
+		isOptionSearchOpen: false,
+		setIsOptionSearchOpen: (isOpen) => set({ isOptionSearchOpen: isOpen }),
 		isPendingBlock: false,
 		blockCount: 0,
 		blockDialog: undefined,

--- a/src/type.ts
+++ b/src/type.ts
@@ -525,7 +525,7 @@ export interface AuCategorySearchTargetInfo {
 
 export interface SearchItem {
 	id: string;
-	tearm: string;
+	term: string;
 	info:
 		| AuCategorySearchTargetInfo
 		| AuOptionSearchTargetInfo

--- a/tests/SearchBar.test.tsx
+++ b/tests/SearchBar.test.tsx
@@ -1,7 +1,15 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { SearchBar } from "@/feature/SearchBar";
+import { globalSearchItems } from "@/logics/api";
 import { OPTION_SEARCH_PLACEHOLDER } from "@/noTrans";
+import { useStore } from "@/useStore";
+
+// Mock the navigation hooks
+vi.mock("@/hooks/useOptionNavigation", () => ({
+	useExROptionNavigationInline: () => vi.fn(),
+	useAuOptionNavigationInline: () => vi.fn(),
+}));
 
 describe("SearchBar", () => {
 	it("renders correctly with search icon and placeholder", () => {
@@ -14,5 +22,48 @@ describe("SearchBar", () => {
 		const icon = document.querySelector("svg");
 		expect(icon).toBeInTheDocument();
 		expect(icon).toHaveClass("lucide-search");
+	});
+
+	it("shows results when typing and filters by active state for ExR", () => {
+		// Setup mock data
+		globalSearchItems.push(
+			{
+				id: "exr-opt-1",
+				term: "Active Option",
+				info: { mode: "exr-opt", uniqueOptionId: 1 as any },
+			},
+			{
+				id: "exr-opt-2",
+				term: "Inactive Option",
+				info: { mode: "exr-opt", uniqueOptionId: 2 as any },
+			},
+			{
+				id: "au-opt-3",
+				term: "Au Option",
+				info: {
+					mode: "au-opt",
+					tabId: 0,
+					categoryId: 0,
+					auOptionId: 3 as any,
+				},
+			},
+		);
+
+		// Mock store state
+		useStore.setState({
+			isExROptionActive: { 1: true, 2: false } as any,
+		});
+
+		render(<SearchBar />);
+
+		const input = screen.getByPlaceholderText(OPTION_SEARCH_PLACEHOLDER);
+
+		// Search for "Option"
+		fireEvent.change(input, { target: { value: "Option" } });
+
+		// Should show "Active Option" and "Au Option", but not "Inactive Option"
+		expect(screen.getByText("Active Option")).toBeInTheDocument();
+		expect(screen.getByText("Au Option")).toBeInTheDocument();
+		expect(screen.queryByText("Inactive Option")).not.toBeInTheDocument();
 	});
 });

--- a/tests/SearchBar.test.tsx
+++ b/tests/SearchBar.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { SearchBar } from "@/feature/SearchBar";
 import { globalSearchItems } from "@/logics/api";
 import { OPTION_SEARCH_PLACEHOLDER } from "@/noTrans";
+import type { AuOptionId, UniqueOptionId } from "@/type";
 import { useStore } from "@/useStore";
 
 // Mock the navigation hooks
@@ -30,12 +31,18 @@ describe("SearchBar", () => {
 			{
 				id: "exr-opt-1",
 				term: "Active Option",
-				info: { mode: "exr-opt", uniqueOptionId: 1 as any },
+				info: {
+					mode: "exr-opt",
+					uniqueOptionId: 1 as unknown as UniqueOptionId,
+				},
 			},
 			{
 				id: "exr-opt-2",
 				term: "Inactive Option",
-				info: { mode: "exr-opt", uniqueOptionId: 2 as any },
+				info: {
+					mode: "exr-opt",
+					uniqueOptionId: 2 as unknown as UniqueOptionId,
+				},
 			},
 			{
 				id: "au-opt-3",
@@ -44,14 +51,17 @@ describe("SearchBar", () => {
 					mode: "au-opt",
 					tabId: 0,
 					categoryId: 0,
-					auOptionId: 3 as any,
+					auOptionId: 3 as unknown as AuOptionId,
 				},
 			},
 		);
 
 		// Mock store state
 		useStore.setState({
-			isExROptionActive: { 1: true, 2: false } as any,
+			isExROptionActive: {
+				[1 as unknown as UniqueOptionId]: true,
+				[2 as unknown as UniqueOptionId]: false,
+			},
 		});
 
 		render(<SearchBar />);


### PR DESCRIPTION
SearchBarにオプションの検索機能を追加しました。
- 初期フェッチ時にメタデータから検索インデックスを作成するようにしました。
- ExRのオプションについては、`isExROptionActive`を確認し、アクティブなもののみが検索結果に表示されるようにしました。
- 検索結果を選択した際に、該当のオプション位置までナビゲートする機能を実装しました。
- `SearchItem`インターフェースのタイポ（`tearm` -> `term`）を修正しました。
- Vitestによる単体テストとPlaywrightによる動作確認を行いました。

---
*PR created automatically by Jules for task [3273426551403448685](https://jules.google.com/task/3273426551403448685) started by @yukieiji*