### PR TITLE
初期フェッチ時のSearchItem保存実装

### DIFF
--- a/src/logics/api.store.ts
+++ b/src/logics/api.store.ts
@@ -12,6 +12,7 @@ import {
 	createExROptionMetaData,
 	fetchRoleFilterData,
 	fetchTranslationMetaData,
+	globalSearchItems,
 	updateAuOption,
 	updateExrOption,
 } from "./api";
@@ -186,6 +187,7 @@ export function useUpdateAuRoleOptionSelection(): (
 }
 
 export async function refetchAll(): Promise<void> {
+	globalSearchItems.length = 0;
 	await fetchTranslationMetaData();
 	await Promise.all([
 		createExROptionMetaDataWithStore(),

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -427,16 +427,6 @@ export async function createAuOptionMetaData(): Promise<
 					categoryId: categoryId,
 				};
 				initialValueData[maxCountId] = roleValue.MaxCount;
-
-				globalSearchItems.push({
-					term: opt.TranslatedTitle,
-					info: {
-						mode: "au-opt",
-						tabId: currentTab,
-						categoryId: categoryId,
-						auOptionId: maxCountId,
-					},
-				});
 			} else {
 				const auOptionId = getAuOptionId(optionName, valueType);
 				auOptionMetaData.categoryMetaData[categoryId].options.push(auOptionId);

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -227,6 +227,15 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 				parentOptionIds: ancestorIds,
 			};
 
+			globalSearchItems.push({
+				term: opt.TranslatedName,
+				info: {
+					mode: "exr-opt",
+					uniqueOptionId: uniqueId,
+					parentUniqueOptionIds: ancestorIds,
+				},
+			});
+
 			valueData[uniqueId] = {
 				selection: opt.Selection,
 				values: opt.RangeMeta.Values,
@@ -290,6 +299,14 @@ export async function createExROptionMetaData(): Promise<ExRinitializeData> {
 				name: category.Name,
 				tabId: tab.Id,
 			};
+			globalSearchItems.push({
+				term: category.Name,
+				info: {
+					mode: "exr-cat",
+					tabId: tab.Id,
+					categoryId: category.Id,
+				},
+			});
 			if (tab.Id === ExRTabId.GeneralTab) {
 				// 一般タブのカテゴリは、トップレベルオプションIDを直接カテゴリIDに紐づける
 				exrOptionMetaData.globalCategoryIdTopLevelMap[category.Id] =
@@ -357,6 +374,15 @@ export async function createAuOptionMetaData(): Promise<
 			tabId: currentTab,
 		};
 
+		globalSearchItems.push({
+			term: category.TranslatedTitle,
+			info: {
+				mode: "au-cat",
+				tabId: currentTab,
+				categoryId: categoryId,
+			},
+		});
+
 		for (const opt of category.Options) {
 			const valueType = opt.Info.ValueType;
 			const optionName = opt.Info.OptionName;
@@ -376,6 +402,16 @@ export async function createAuOptionMetaData(): Promise<
 				};
 				initialValueData[chanceId] = Math.floor(roleValue.Chance / 10);
 
+				globalSearchItems.push({
+					term: opt.TranslatedTitle,
+					info: {
+						mode: "au-opt",
+						tabId: currentTab,
+						categoryId: categoryId,
+						auOptionId: chanceId,
+					},
+				});
+
 				// MaxCount
 				const maxCountId = getAuOptionId(
 					optionName,
@@ -391,6 +427,16 @@ export async function createAuOptionMetaData(): Promise<
 					categoryId: categoryId,
 				};
 				initialValueData[maxCountId] = roleValue.MaxCount;
+
+				globalSearchItems.push({
+					term: opt.TranslatedTitle,
+					info: {
+						mode: "au-opt",
+						tabId: currentTab,
+						categoryId: categoryId,
+						auOptionId: maxCountId,
+					},
+				});
 			} else {
 				const auOptionId = getAuOptionId(optionName, valueType);
 				auOptionMetaData.categoryMetaData[categoryId].options.push(auOptionId);
@@ -418,6 +464,16 @@ export async function createAuOptionMetaData(): Promise<
 					categoryId: categoryId,
 				};
 				initialValueData[auOptionId] = index;
+
+				globalSearchItems.push({
+					term: opt.TranslatedTitle,
+					info: {
+						mode: "au-opt",
+						tabId: currentTab,
+						categoryId: categoryId,
+						auOptionId: auOptionId,
+					},
+				});
 			}
 		}
 	}

--- a/tests/globalSearchItems.test.ts
+++ b/tests/globalSearchItems.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createAuOptionMetaData,
+	createExROptionMetaData,
+	globalSearchItems,
+} from "@/logics/api";
+import { refetchAll } from "@/logics/api.store";
+import type { UniqueOptionId } from "@/type";
+
+// Mock fetch for API calls
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("globalSearchItems population", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		globalSearchItems.length = 0;
+	});
+
+	it("should clear globalSearchItems in refetchAll", async () => {
+		globalSearchItems.push({
+			term: "old",
+			info: {
+				mode: "exr-opt",
+				uniqueOptionId: 1 as UniqueOptionId,
+				parentUniqueOptionIds: [],
+			},
+		});
+		expect(globalSearchItems.length).toBe(1);
+
+		// Mocking all internal calls of refetchAll
+		mockFetch.mockImplementation((url: string) => {
+			let data: unknown = [];
+			if (url.includes("/exr/role/filter/")) {
+				data = {
+					FilterSet: {},
+					FilterRoleId: [],
+					NormalRoleId: {},
+					CombinationId: {},
+					GhostRoleId: {},
+				};
+			}
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve(data),
+			});
+		});
+
+		await refetchAll();
+		// Since we mocked with empty arrays, it should be empty but importantly, the "old" item should be gone.
+		expect(globalSearchItems.find((i) => i.term === "old")).toBeUndefined();
+	});
+
+	it("should populate globalSearchItems with ExR data", async () => {
+		const mockExRData = [
+			{
+				Id: 0,
+				Name: "Tab 1",
+				Categories: [
+					{
+						Id: 10,
+						Name: "Category 10",
+						Options: [
+							{
+								Id: 100,
+								TranslatedName: "Option 100",
+								IsActive: true,
+								Selection: 0,
+								Format: "Format1",
+								RangeMeta: { Type: "Int32", Values: [0, 1] },
+								Childs: [],
+							},
+						],
+					},
+				],
+			},
+		];
+
+		mockFetch.mockImplementation((url: string) => {
+			if (url.includes("/exr/option/")) {
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					json: () => Promise.resolve(mockExRData),
+				});
+			}
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve([]),
+			});
+		});
+
+		await createExROptionMetaData();
+
+		expect(globalSearchItems).toContainEqual(
+			expect.objectContaining({
+				term: "Category 10",
+				info: expect.objectContaining({ mode: "exr-cat", categoryId: 10 }),
+			}),
+		);
+		expect(globalSearchItems).toContainEqual(
+			expect.objectContaining({
+				term: "Option 100",
+				info: expect.objectContaining({ mode: "exr-opt" }),
+			}),
+		);
+	});
+
+	it("should populate globalSearchItems with Au data", async () => {
+		const mockAuData = [
+			{
+				TranslatedTitle: "Au Category",
+				Options: [
+					{
+						TranslatedTitle: "Au Option",
+						TranslatedFormat: "Format",
+						Value: 0,
+						Info: { ValueType: 2, OptionName: 1000 },
+						Range: [0, 1],
+					},
+				],
+			},
+		];
+
+		mockFetch.mockImplementation((url: string) => {
+			if (url.includes("/au/option/")) {
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					json: () => Promise.resolve(mockAuData),
+				});
+			}
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve([]),
+			});
+		});
+
+		await createAuOptionMetaData();
+
+		expect(globalSearchItems).toContainEqual(
+			expect.objectContaining({
+				term: "Au Category",
+				info: expect.objectContaining({ mode: "au-cat" }),
+			}),
+		);
+		expect(globalSearchItems).toContainEqual(
+			expect.objectContaining({
+				term: "Au Option",
+				info: expect.objectContaining({ mode: "au-opt" }),
+			}),
+		);
+	});
+});


### PR DESCRIPTION
初期フェッチ時に、検索用のデータである `globalSearchItems` に ExR と Among Us のオプション・カテゴリ情報を保存するように変更しました。これにより、アプリケーション起動直後から検索機能が正しく動作するようになります。また、再取得時（refetchAll）には古い情報をクリアし、常に最新の情報が検索対象となるようにしています。

---
*PR created automatically by Jules for task [599627775532185844](https://jules.google.com/task/599627775532185844) started by @yukieiji*