### PR TITLE
Enhance SearchSuggestion with parent and category info

### DIFF
--- a/src/feature/SearchSuggestion.tsx
+++ b/src/feature/SearchSuggestion.tsx
@@ -1,14 +1,22 @@
 import { useShallow } from "zustand/react/shallow";
+import { Button } from "@/components/ui/button";
 import {
 	PopoverDescription,
 	PopoverHeader,
 	PopoverTitle,
 } from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
 import {
 	useAuOptionNavigationInline,
 	useExROptionNavigationInline,
 } from "@/hooks/useOptionNavigation";
-import { globalSearchItems } from "@/logics/api";
+import {
+	auOptionMetaData,
+	exrOptionMetaData,
+	globalSearchItems,
+} from "@/logics/api";
+import { stripColorTags } from "@/logics/colorUtils";
+import { parseUniqueOptionId } from "@/logics/optionUtils";
 import type { SearchItem } from "@/type";
 import { useStore } from "@/useStore";
 
@@ -46,13 +54,75 @@ export function SearchSuggestion() {
 		setIsOpen(false);
 	};
 
+	const getMetadataText = (item: SearchItem) => {
+		if (item.info.mode === "exr-opt") {
+			const { categoryId } = parseUniqueOptionId(item.info.uniqueOptionId);
+			const categoryName = exrOptionMetaData.categories[categoryId]?.name ?? "";
+			const parentNames = item.info.parentUniqueOptionIds
+				.map((id) => exrOptionMetaData.options[id]?.metaData.translatedName)
+				.filter(Boolean)
+				.reverse();
+			return stripColorTags([categoryName, ...parentNames].join(" > "));
+		}
+		if (item.info.mode === "au-opt") {
+			return stripColorTags(
+				auOptionMetaData.categoryMetaData[item.info.categoryId]?.name ?? "",
+			);
+		}
+		if (item.info.mode === "exr-cat") {
+			return stripColorTags(
+				exrOptionMetaData.tabs[item.info.tabId]?.name ?? "",
+			);
+		}
+		if (item.info.mode === "au-cat") {
+			return stripColorTags(auOptionMetaData.tabNames[item.info.tabId] ?? "");
+		}
+		return "";
+	};
+
 	return (
-		<PopoverHeader>
-			<PopoverTitle>Search Results</PopoverTitle>
-			<PopoverDescription>
-				Query:{" "}
-				<span data-testid="search-query-display">{optionSearchQuery}</span>
-			</PopoverDescription>
-		</PopoverHeader>
+		<>
+			<PopoverHeader>
+				<PopoverTitle>Search Results</PopoverTitle>
+				<PopoverDescription>
+					Query:{" "}
+					<span data-testid="search-query-display">{optionSearchQuery}</span>
+				</PopoverDescription>
+			</PopoverHeader>
+			{_results.length > 0 && (
+				<>
+					<Separator className="my-2" />
+					<div className="flex flex-col gap-1">
+						{_results.map((item) => {
+							const key =
+								item.info.mode === "exr-opt"
+									? `exr-opt-${item.info.uniqueOptionId}`
+									: item.info.mode === "au-opt"
+										? `au-opt-${item.info.auOptionId}`
+										: item.info.mode === "exr-cat"
+											? `exr-cat-${item.info.categoryId}`
+											: `au-cat-${item.info.categoryId}`;
+
+							return (
+								<Button
+									key={key}
+									variant="ghost"
+									size="sm"
+									className="h-auto flex-col items-start px-2 py-1.5"
+									onClick={() => _handleSelect(item)}
+								>
+									<span className="w-full text-left font-medium">
+										{stripColorTags(item.term)}
+									</span>
+									<span className="w-full text-left text-muted-foreground text-xs">
+										{getMetadataText(item)}
+									</span>
+								</Button>
+							);
+						})}
+					</div>
+				</>
+			)}
+		</>
 	);
 }

--- a/tests/SearchSuggestion.test.tsx
+++ b/tests/SearchSuggestion.test.tsx
@@ -2,6 +2,12 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Popover } from "@/components/ui/popover";
 import { SearchSuggestion } from "@/feature/SearchSuggestion";
+import {
+	auOptionMetaData,
+	exrOptionMetaData,
+	globalSearchItems,
+} from "@/logics/api";
+import { getUniqueOptionId } from "@/logics/optionUtils";
 import { useStore } from "@/useStore";
 
 // Mock the hooks used in SearchSuggestion
@@ -36,5 +42,80 @@ describe("SearchSuggestion", () => {
 
 		const queryDisplay = screen.getByTestId("search-query-display");
 		expect(queryDisplay).toHaveTextContent("");
+	});
+
+	it("renders filtered search results with metadata", () => {
+		const uniqueId = getUniqueOptionId(1, 1, 1);
+		const parentId = getUniqueOptionId(1, 1, 2);
+
+		// Setup mock data
+		exrOptionMetaData.categories[1] = { name: "Test Category", tabId: 1 };
+		exrOptionMetaData.options[uniqueId] = {
+			metaData: { translatedName: "Child Option", format: "", type: "" },
+			childOptionIds: [],
+			parentOptionIds: [parentId],
+		};
+		exrOptionMetaData.options[parentId] = {
+			metaData: { translatedName: "Parent Option", format: "", type: "" },
+			childOptionIds: [uniqueId],
+			parentOptionIds: [],
+		};
+
+		globalSearchItems.length = 0;
+		globalSearchItems.push({
+			term: "Child Option",
+			info: {
+				mode: "exr-opt",
+				uniqueOptionId: uniqueId,
+				parentUniqueOptionIds: [parentId],
+			},
+		});
+
+		useStore.setState({
+			optionSearchQuery: "Child",
+			isExROptionActive: { [uniqueId]: true },
+		});
+
+		render(
+			<Popover open={true}>
+				<SearchSuggestion />
+			</Popover>,
+		);
+
+		expect(screen.getByText("Child Option")).toBeInTheDocument();
+		expect(
+			screen.getByText("Test Category > Parent Option"),
+		).toBeInTheDocument();
+	});
+
+	it("renders au-opt search results with category name", () => {
+		const auOptionId = 10001 as any;
+		auOptionMetaData.categoryMetaData[10] = {
+			name: "Au Category",
+			options: [auOptionId],
+			tabId: 1,
+		};
+
+		globalSearchItems.length = 0;
+		globalSearchItems.push({
+			term: "Au Option",
+			info: {
+				mode: "au-opt",
+				tabId: 1,
+				categoryId: 10,
+				auOptionId: auOptionId,
+			},
+		});
+
+		useStore.setState({ optionSearchQuery: "Au" });
+
+		render(
+			<Popover open={true}>
+				<SearchSuggestion />
+			</Popover>,
+		);
+
+		expect(screen.getByText("Au Option")).toBeInTheDocument();
+		expect(screen.getByText("Au Category")).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Enhanced the `SearchSuggestion` component to provide more context in search results. Results are now displayed as a list of buttons, where each button shows the option name and a breadcrumb-style metadata text (e.g., "Category > Parent Option") for better clarity. Among Us options also show their category name. All labels are cleaned using `stripColorTags` to ensure a clean UI. Unit tests were added to verify the correct rendering of these new elements.

---
*PR created automatically by Jules for task [3063485998511330124](https://jules.google.com/task/3063485998511330124) started by @yukieiji*