### PR TITLE
Display hierarchy in search suggestions

### DIFF
--- a/src/components/blocks/SearchParentData.tsx
+++ b/src/components/blocks/SearchParentData.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight, CornerDownRight } from "lucide-react";
 import { Fragment } from "react";
 import type { ParentData } from "@/type";
+import { ParentItem } from "../parts/ParentItem";
 
 interface SearchParentDataProps {
 	parentData: ParentData;
@@ -14,19 +15,14 @@ export function SearchParentData({ parentData }: SearchParentDataProps) {
 	const orderedParents = [...parentOptionNames].reverse().filter(Boolean);
 
 	return (
-		<div className="flex w-full min-w-0 items-center gap-1 text-muted-foreground text-[10px] leading-tight">
-			<CornerDownRight className="size-3 shrink-0" />
-			<span className="min-w-0 truncate">{tabName}</span>
-			{categoryName && (
-				<>
-					<ChevronRight className="size-3 shrink-0" />
-					<span className="min-w-0 truncate">{categoryName}</span>
-				</>
+		<div className="flex w-full min-w-0 items-center gap-0.5 leading-tight">
+			<ParentItem icon={CornerDownRight} text={tabName} />
+			{categoryName !== "" && (
+				<ParentItem icon={ChevronRight} text={categoryName} />
 			)}
 			{orderedParents.map((name) => (
 				<Fragment key={name}>
-					<ChevronRight className="size-3 shrink-0" />
-					<span className="min-w-0 truncate">{name}</span>
+					<ParentItem icon={ChevronRight} text={name} />
 				</Fragment>
 			))}
 		</div>

--- a/src/components/parts/ParentItem.tsx
+++ b/src/components/parts/ParentItem.tsx
@@ -1,0 +1,15 @@
+import type { FC, SVGProps } from "react";
+
+interface ParentItemProps {
+	icon: FC<SVGProps<SVGSVGElement>>;
+	text: string;
+}
+
+export function ParentItem({ icon: Icon, text }: ParentItemProps) {
+	return (
+		<>
+			<Icon className="size-3 shrink-0" />
+			<span className="min-w-0 truncate">{text}</span>
+		</>
+	);
+}

--- a/src/components/parts/SearchParentData.tsx
+++ b/src/components/parts/SearchParentData.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight, CornerDownRight } from "lucide-react";
+import { Fragment } from "react";
 import type { ParentData } from "@/type";
 
 interface SearchParentDataProps {
@@ -13,20 +14,20 @@ export function SearchParentData({ parentData }: SearchParentDataProps) {
 	const orderedParents = [...parentOptionNames].reverse().filter(Boolean);
 
 	return (
-		<div className="flex items-center gap-1 text-muted-foreground text-[10px] leading-tight">
+		<div className="flex w-full min-w-0 items-center gap-1 text-muted-foreground text-[10px] leading-tight">
 			<CornerDownRight className="size-3 shrink-0" />
-			<span className="truncate">{tabName}</span>
+			<span className="min-w-0 truncate">{tabName}</span>
 			{categoryName && (
 				<>
 					<ChevronRight className="size-3 shrink-0" />
-					<span className="truncate">{categoryName}</span>
+					<span className="min-w-0 truncate">{categoryName}</span>
 				</>
 			)}
 			{orderedParents.map((name) => (
-				<div key={name} className="flex items-center gap-1 truncate">
+				<Fragment key={name}>
 					<ChevronRight className="size-3 shrink-0" />
-					<span className="truncate">{name}</span>
-				</div>
+					<span className="min-w-0 truncate">{name}</span>
+				</Fragment>
 			))}
 		</div>
 	);

--- a/src/components/parts/SearchParentData.tsx
+++ b/src/components/parts/SearchParentData.tsx
@@ -22,8 +22,8 @@ export function SearchParentData({ parentData }: SearchParentDataProps) {
 					<span className="truncate">{categoryName}</span>
 				</>
 			)}
-			{orderedParents.map((name, index) => (
-				<div key={`${name}-${index}`} className="flex items-center gap-1 truncate">
+			{orderedParents.map((name) => (
+				<div key={name} className="flex items-center gap-1 truncate">
 					<ChevronRight className="size-3 shrink-0" />
 					<span className="truncate">{name}</span>
 				</div>

--- a/src/components/parts/SearchParentData.tsx
+++ b/src/components/parts/SearchParentData.tsx
@@ -1,7 +1,33 @@
+import { ChevronRight, CornerDownRight } from "lucide-react";
 import type { ParentData } from "@/type";
 
 interface SearchParentDataProps {
 	parentData: ParentData;
 }
 
-export function SearchParentData({ parentData }: SearchParentDataProps) {}
+export function SearchParentData({ parentData }: SearchParentDataProps) {
+	const { tabName, categoryName, parentOptionNames } = parentData;
+
+	// 親オプション名は、API側で[直近の親, その親, ...]の順で入っているため、
+	// 表示用に[ルートに近い親, ..., 直近の親]の順に反転させる
+	const orderedParents = [...parentOptionNames].reverse().filter(Boolean);
+
+	return (
+		<div className="flex items-center gap-1 text-muted-foreground text-[10px] leading-tight">
+			<CornerDownRight className="size-3 shrink-0" />
+			<span className="truncate">{tabName}</span>
+			{categoryName && (
+				<>
+					<ChevronRight className="size-3 shrink-0" />
+					<span className="truncate">{categoryName}</span>
+				</>
+			)}
+			{orderedParents.map((name, index) => (
+				<div key={`${name}-${index}`} className="flex items-center gap-1 truncate">
+					<ChevronRight className="size-3 shrink-0" />
+					<span className="truncate">{name}</span>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/src/feature/SearchSuggestionResult.tsx
+++ b/src/feature/SearchSuggestionResult.tsx
@@ -1,4 +1,6 @@
+import { Fragment } from "react";
 import { ColoredText } from "@/components/parts/ColoredText";
+import { SearchParentData } from "@/components/parts/SearchParentData";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { Separator } from "@/components/ui/separator";
@@ -44,17 +46,17 @@ export function SearchSuggestionResult({
 	return (
 		<ButtonGroup orientation="vertical" className="w-full">
 			{results.map((item, index) => (
-				<>
+				<Fragment key={getKeyByMode(item)}>
 					<Button
-						className="justify-start"
-						key={getKeyByMode(item)}
+						className="h-auto w-full flex-col items-start justify-start py-2"
 						variant="ghost"
 						onClick={() => handleSelect(item)}
 					>
 						<ColoredText text={item.term} />
+						<SearchParentData parentData={item.parentData} />
 					</Button>
 					{index < results.length - 1 && <Separator />}
-				</>
+				</Fragment>
 			))}
 		</ButtonGroup>
 	);

--- a/src/feature/SearchSuggestionResult.tsx
+++ b/src/feature/SearchSuggestionResult.tsx
@@ -49,7 +49,7 @@ export function SearchSuggestionResult({
 			{results.map((item, index) => (
 				<Fragment key={getKeyByMode(item)}>
 					<Button
-						className="h-auto w-full min-w-0 flex-col items-start justify-start py-2 text-left"
+						className="h-auto w-full min-w-0 flex-col items-start justify-start py-1 text-left"
 						variant="ghost"
 						onClick={() => handleSelect(item)}
 					>

--- a/src/feature/SearchSuggestionResult.tsx
+++ b/src/feature/SearchSuggestionResult.tsx
@@ -49,11 +49,11 @@ export function SearchSuggestionResult({
 			{results.map((item, index) => (
 				<Fragment key={getKeyByMode(item)}>
 					<Button
-						className="h-auto w-full min-w-0 flex-col items-start justify-start py-2"
+						className="h-auto w-full min-w-0 flex-col items-start justify-start py-2 text-left"
 						variant="ghost"
 						onClick={() => handleSelect(item)}
 					>
-						<div className="w-full min-w-0 truncate text-left">
+						<div className="w-full min-w-0 truncate">
 							<ColoredText text={item.term} />
 						</div>
 						<SearchParentData parentData={item.parentData} />

--- a/src/feature/SearchSuggestionResult.tsx
+++ b/src/feature/SearchSuggestionResult.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
+import { SearchParentData } from "@/components/blocks/SearchParentData";
 import { ColoredText } from "@/components/parts/ColoredText";
-import { SearchParentData } from "@/components/parts/SearchParentData";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { Separator } from "@/components/ui/separator";

--- a/src/feature/SearchSuggestionResult.tsx
+++ b/src/feature/SearchSuggestionResult.tsx
@@ -37,10 +37,11 @@ export function SearchSuggestionResult({
 	const handleSelect = (item: SearchItem) => {
 		if (item.info.mode === "exr-opt") {
 			navigateToExR(item.info.uniqueOptionId);
+			setIsOpen(false);
 		} else if (item.info.mode === "au-opt") {
 			navigateToAu(item.info.tabId, item.info.categoryId, item.info.auOptionId);
+			setIsOpen(false);
 		}
-		setIsOpen(false);
 	};
 
 	return (
@@ -48,11 +49,13 @@ export function SearchSuggestionResult({
 			{results.map((item, index) => (
 				<Fragment key={getKeyByMode(item)}>
 					<Button
-						className="h-auto w-full flex-col items-start justify-start py-2"
+						className="h-auto w-full min-w-0 flex-col items-start justify-start py-2"
 						variant="ghost"
 						onClick={() => handleSelect(item)}
 					>
-						<ColoredText text={item.term} />
+						<div className="w-full min-w-0 truncate text-left">
+							<ColoredText text={item.term} />
+						</div>
 						<SearchParentData parentData={item.parentData} />
 					</Button>
 					{index < results.length - 1 && <Separator />}

--- a/tests/SearchSuggestion.test.tsx
+++ b/tests/SearchSuggestion.test.tsx
@@ -1,7 +1,8 @@
-import { SearchSuggestion } from "@/feature/SearchSuggestion";
-import { useStore } from "@/useStore";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { SearchSuggestion } from "@/feature/SearchSuggestion";
+import type { SearchItem } from "@/type";
+import { useStore } from "@/useStore";
 
 vi.mock("@/useStore", () => ({
 	useStore: vi.fn(),
@@ -11,17 +12,29 @@ vi.mock("@/logics/api", () => ({
 	globalSearchItems: Array.from({ length: 15 }, (_, i) => ({
 		term: `Item ${i}`,
 		info: { mode: "au-cat", tabId: 0, categoryId: i },
-		parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] },
+		parentData: {
+			tabName: "Tab",
+			categoryName: "Cat",
+			parentOptionNames: [],
+		},
 	})).concat([
 		{
 			term: "Active ExR",
 			info: { mode: "exr-opt", uniqueOptionId: 100 },
-			parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] },
+			parentData: {
+				tabName: "Tab",
+				categoryName: "Cat",
+				parentOptionNames: [],
+			},
 		},
 		{
 			term: "Inactive ExR",
 			info: { mode: "exr-opt", uniqueOptionId: 101 },
-			parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] },
+			parentData: {
+				tabName: "Tab",
+				categoryName: "Cat",
+				parentOptionNames: [],
+			},
 		},
 	]),
 }));
@@ -43,33 +56,36 @@ type StoreState = {
 
 describe("SearchSuggestion", () => {
 	it("renders no results when query is empty", () => {
-		vi.mocked(useStore).mockImplementation((selector: any) =>
-			selector({
-				optionSearchQuery: "",
-				isExROptionActive: {},
-			} as StoreState),
+		vi.mocked(useStore).mockImplementation(
+			(selector: (state: StoreState) => string | SearchItem[]) =>
+				selector({
+					optionSearchQuery: "",
+					isExROptionActive: {},
+				} as StoreState),
 		);
 		render(<SearchSuggestion />);
 		expect(screen.getByText("Search No Results")).toBeInTheDocument();
 	});
 
 	it("limits results to 10", () => {
-		vi.mocked(useStore).mockImplementation((selector: any) =>
-			selector({
-				optionSearchQuery: "Item",
-				isExROptionActive: {},
-			} as StoreState),
+		vi.mocked(useStore).mockImplementation(
+			(selector: (state: StoreState) => string | SearchItem[]) =>
+				selector({
+					optionSearchQuery: "Item",
+					isExROptionActive: {},
+				} as StoreState),
 		);
 		render(<SearchSuggestion />);
 		expect(screen.getAllByRole("button")).toHaveLength(10);
 	});
 
 	it("filters ExR options by active status", () => {
-		vi.mocked(useStore).mockImplementation((selector: any) =>
-			selector({
-				optionSearchQuery: "ExR",
-				isExROptionActive: { 100: true, 101: false },
-			} as StoreState),
+		vi.mocked(useStore).mockImplementation(
+			(selector: (state: StoreState) => string | SearchItem[]) =>
+				selector({
+					optionSearchQuery: "ExR",
+					isExROptionActive: { 100: true, 101: false },
+				} as StoreState),
 		);
 		render(<SearchSuggestion />);
 		expect(screen.getByText("Active ExR")).toBeInTheDocument();
@@ -77,11 +93,12 @@ describe("SearchSuggestion", () => {
 	});
 
 	it("handles missing isExROptionActive entry as inactive", () => {
-		vi.mocked(useStore).mockImplementation((selector: any) =>
-			selector({
-				optionSearchQuery: "ExR",
-				isExROptionActive: {}, // 100 and 101 missing
-			} as StoreState),
+		vi.mocked(useStore).mockImplementation(
+			(selector: (state: StoreState) => string | SearchItem[]) =>
+				selector({
+					optionSearchQuery: "ExR",
+					isExROptionActive: {}, // 100 and 101 missing
+				} as StoreState),
 		);
 		render(<SearchSuggestion />);
 		expect(screen.queryByText("Active ExR")).not.toBeInTheDocument();

--- a/tests/SearchSuggestion.test.tsx
+++ b/tests/SearchSuggestion.test.tsx
@@ -1,0 +1,90 @@
+import { SearchSuggestion } from "@/feature/SearchSuggestion";
+import { useStore } from "@/useStore";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/useStore", () => ({
+	useStore: vi.fn(),
+}));
+
+vi.mock("@/logics/api", () => ({
+	globalSearchItems: Array.from({ length: 15 }, (_, i) => ({
+		term: `Item ${i}`,
+		info: { mode: "au-cat", tabId: 0, categoryId: i },
+		parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] },
+	})).concat([
+		{
+			term: "Active ExR",
+			info: { mode: "exr-opt", uniqueOptionId: 100 },
+			parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] },
+		},
+		{
+			term: "Inactive ExR",
+			info: { mode: "exr-opt", uniqueOptionId: 101 },
+			parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] },
+		},
+	]),
+}));
+
+// Mock Popover components to avoid Context errors
+vi.mock("@/components/ui/popover", () => ({
+	PopoverHeader: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	PopoverTitle: ({ children }: { children: React.ReactNode }) => (
+		<h1>{children}</h1>
+	),
+}));
+
+type StoreState = {
+	optionSearchQuery: string;
+	isExROptionActive: Record<number, boolean>;
+};
+
+describe("SearchSuggestion", () => {
+	it("renders no results when query is empty", () => {
+		vi.mocked(useStore).mockImplementation((selector: any) =>
+			selector({
+				optionSearchQuery: "",
+				isExROptionActive: {},
+			} as StoreState),
+		);
+		render(<SearchSuggestion />);
+		expect(screen.getByText("Search No Results")).toBeInTheDocument();
+	});
+
+	it("limits results to 10", () => {
+		vi.mocked(useStore).mockImplementation((selector: any) =>
+			selector({
+				optionSearchQuery: "Item",
+				isExROptionActive: {},
+			} as StoreState),
+		);
+		render(<SearchSuggestion />);
+		expect(screen.getAllByRole("button")).toHaveLength(10);
+	});
+
+	it("filters ExR options by active status", () => {
+		vi.mocked(useStore).mockImplementation((selector: any) =>
+			selector({
+				optionSearchQuery: "ExR",
+				isExROptionActive: { 100: true, 101: false },
+			} as StoreState),
+		);
+		render(<SearchSuggestion />);
+		expect(screen.getByText("Active ExR")).toBeInTheDocument();
+		expect(screen.queryByText("Inactive ExR")).not.toBeInTheDocument();
+	});
+
+	it("handles missing isExROptionActive entry as inactive", () => {
+		vi.mocked(useStore).mockImplementation((selector: any) =>
+			selector({
+				optionSearchQuery: "ExR",
+				isExROptionActive: {}, // 100 and 101 missing
+			} as StoreState),
+		);
+		render(<SearchSuggestion />);
+		expect(screen.queryByText("Active ExR")).not.toBeInTheDocument();
+		expect(screen.queryByText("Inactive ExR")).not.toBeInTheDocument();
+	});
+});

--- a/tests/SearchSuggestionResult.test.tsx
+++ b/tests/SearchSuggestionResult.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SearchSuggestionResult } from "@/feature/SearchSuggestionResult";
+import type { SearchItem } from "@/type";
+
+// Mock dependencies
+vi.mock("@/hooks/useOptionNavigation", () => ({
+	useAuOptionNavigationInline: () => vi.fn(),
+	useExROptionNavigationInline: () => vi.fn(),
+}));
+
+vi.mock("@/useStore", () => ({
+	useStore: (fn: any) => fn({ setSuggestOpen: vi.fn() }),
+}));
+
+describe("SearchSuggestionResult", () => {
+	const mockResults: SearchItem[] = [
+		{
+			term: "Test Option",
+			parentData: {
+				tabName: "General",
+				categoryName: "Category 1",
+				parentOptionNames: ["Parent 1"],
+			},
+			info: {
+				mode: "exr-opt",
+				uniqueOptionId: 1 as any,
+				parentUniqueOptionIds: [],
+			},
+		},
+	];
+
+	it("renders term and parent data", () => {
+		render(<SearchSuggestionResult results={mockResults} />);
+
+		expect(screen.getByText("Test Option")).toBeInTheDocument();
+		expect(screen.getByText("General")).toBeInTheDocument();
+		expect(screen.getByText("Category 1")).toBeInTheDocument();
+		expect(screen.getByText("Parent 1")).toBeInTheDocument();
+	});
+
+    it("renders icons in SearchParentData", () => {
+        const { container } = render(<SearchSuggestionResult results={mockResults} />);
+
+        // CornerDownRight and ChevronRight icons should be present
+        const icons = container.querySelectorAll("svg");
+        expect(icons.length).toBeGreaterThanOrEqual(3); // 1 for CornerDownRight, 2 for ChevronRight
+    });
+});

--- a/tests/SearchSuggestionResult.test.tsx
+++ b/tests/SearchSuggestionResult.test.tsx
@@ -1,27 +1,36 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SearchSuggestionResult } from "@/feature/SearchSuggestionResult";
-import type { SearchItem, UniqueOptionId } from "@/type";
+import type { AuOptionId, ExRTabId, SearchItem, UniqueOptionId } from "@/type";
+
+const mockNavigateToExR = vi.fn();
+const mockNavigateToAu = vi.fn();
+const mockSetIsOpen = vi.fn();
 
 // Mock dependencies
 vi.mock("@/hooks/useOptionNavigation", () => ({
-	useAuOptionNavigationInline: () => vi.fn(),
-	useExROptionNavigationInline: () => vi.fn(),
+	useAuOptionNavigationInline: () => mockNavigateToAu,
+	useExROptionNavigationInline: () => mockNavigateToExR,
 }));
 
 vi.mock("@/useStore", () => ({
-	useStore: (fn: (state: { setSuggestOpen: () => void }) => void) =>
-		fn({ setSuggestOpen: vi.fn() }),
+	useStore: (
+		fn: (state: { setSuggestOpen: (open: boolean) => void }) => void,
+	) => fn({ setSuggestOpen: mockSetIsOpen }),
 }));
 
 describe("SearchSuggestionResult", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
 	const mockResults: SearchItem[] = [
 		{
-			term: "Test Option",
+			term: "ExR Opt",
 			parentData: {
-				tabName: "General",
-				categoryName: "Category 1",
-				parentOptionNames: ["Parent 1"],
+				tabName: "Tab",
+				categoryName: "Cat",
+				parentOptionNames: ["P1"],
 			},
 			info: {
 				mode: "exr-opt",
@@ -29,24 +38,88 @@ describe("SearchSuggestionResult", () => {
 				parentUniqueOptionIds: [],
 			},
 		},
+		{
+			term: "Au Opt",
+			parentData: {
+				tabName: "Tab",
+				categoryName: "Cat",
+				parentOptionNames: [],
+			},
+			info: {
+				mode: "au-opt",
+				tabId: 0,
+				categoryId: 1,
+				auOptionId: 100 as unknown as AuOptionId,
+			},
+		},
+		{
+			term: "Au Cat",
+			parentData: {
+				tabName: "Tab",
+				categoryName: "",
+				parentOptionNames: [],
+			},
+			info: {
+				mode: "au-cat",
+				tabId: 0,
+				categoryId: 2,
+			},
+		},
+		{
+			term: "ExR Cat",
+			parentData: {
+				tabName: "Tab",
+				categoryName: "",
+				parentOptionNames: [],
+			},
+			info: {
+				mode: "exr-cat",
+				tabId: 0 as ExRTabId,
+				categoryId: 3,
+			},
+		},
 	];
 
-	it("renders term and parent data", () => {
+	it("renders all result terms", () => {
 		render(<SearchSuggestionResult results={mockResults} />);
+		expect(screen.getByText("ExR Opt")).toBeInTheDocument();
+		expect(screen.getByText("Au Opt")).toBeInTheDocument();
+		expect(screen.getByText("Au Cat")).toBeInTheDocument();
+		expect(screen.getByText("ExR Cat")).toBeInTheDocument();
+	});
 
-		expect(screen.getByText("Test Option")).toBeInTheDocument();
-		expect(screen.getByText("General")).toBeInTheDocument();
-		expect(screen.getByText("Category 1")).toBeInTheDocument();
-		expect(screen.getByText("Parent 1")).toBeInTheDocument();
+	it("calls navigation and closes suggest on click (exr-opt)", () => {
+		render(<SearchSuggestionResult results={mockResults} />);
+		fireEvent.click(screen.getByText("ExR Opt"));
+		expect(mockNavigateToExR).toHaveBeenCalledWith(1);
+		expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+	});
+
+	it("calls navigation and closes suggest on click (au-opt)", () => {
+		render(<SearchSuggestionResult results={mockResults} />);
+		fireEvent.click(screen.getByText("Au Opt"));
+		expect(mockNavigateToAu).toHaveBeenCalledWith(0, 1, 100);
+		expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+	});
+
+	it("does nothing on click for categories", () => {
+		render(<SearchSuggestionResult results={mockResults} />);
+		fireEvent.click(screen.getByText("Au Cat"));
+		expect(mockNavigateToExR).not.toHaveBeenCalled();
+		expect(mockNavigateToAu).not.toHaveBeenCalled();
+		expect(mockSetIsOpen).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByText("ExR Cat"));
+		expect(mockNavigateToExR).not.toHaveBeenCalled();
+		expect(mockNavigateToAu).not.toHaveBeenCalled();
+		expect(mockSetIsOpen).not.toHaveBeenCalled();
 	});
 
 	it("renders icons in SearchParentData", () => {
 		const { container } = render(
-			<SearchSuggestionResult results={mockResults} />,
+			<SearchSuggestionResult results={[mockResults[0]]} />,
 		);
-
-		// CornerDownRight and ChevronRight icons should be present
 		const icons = container.querySelectorAll("svg");
-		expect(icons.length).toBeGreaterThanOrEqual(3); // 1 for CornerDownRight, 2 for ChevronRight
+		expect(icons.length).toBeGreaterThanOrEqual(3);
 	});
 });

--- a/tests/SearchSuggestionResult.test.tsx
+++ b/tests/SearchSuggestionResult.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { SearchSuggestionResult } from "@/feature/SearchSuggestionResult";
-import type { SearchItem } from "@/type";
+import type { SearchItem, UniqueOptionId } from "@/type";
 
 // Mock dependencies
 vi.mock("@/hooks/useOptionNavigation", () => ({
@@ -10,7 +10,8 @@ vi.mock("@/hooks/useOptionNavigation", () => ({
 }));
 
 vi.mock("@/useStore", () => ({
-	useStore: (fn: any) => fn({ setSuggestOpen: vi.fn() }),
+	useStore: (fn: (state: { setSuggestOpen: () => void }) => void) =>
+		fn({ setSuggestOpen: vi.fn() }),
 }));
 
 describe("SearchSuggestionResult", () => {
@@ -24,7 +25,7 @@ describe("SearchSuggestionResult", () => {
 			},
 			info: {
 				mode: "exr-opt",
-				uniqueOptionId: 1 as any,
+				uniqueOptionId: 1 as unknown as UniqueOptionId,
 				parentUniqueOptionIds: [],
 			},
 		},
@@ -39,11 +40,13 @@ describe("SearchSuggestionResult", () => {
 		expect(screen.getByText("Parent 1")).toBeInTheDocument();
 	});
 
-    it("renders icons in SearchParentData", () => {
-        const { container } = render(<SearchSuggestionResult results={mockResults} />);
+	it("renders icons in SearchParentData", () => {
+		const { container } = render(
+			<SearchSuggestionResult results={mockResults} />,
+		);
 
-        // CornerDownRight and ChevronRight icons should be present
-        const icons = container.querySelectorAll("svg");
-        expect(icons.length).toBeGreaterThanOrEqual(3); // 1 for CornerDownRight, 2 for ChevronRight
-    });
+		// CornerDownRight and ChevronRight icons should be present
+		const icons = container.querySelectorAll("svg");
+		expect(icons.length).toBeGreaterThanOrEqual(3); // 1 for CornerDownRight, 2 for ChevronRight
+	});
 });


### PR DESCRIPTION
This change enhances the search suggestion results by displaying the hierarchical path (Tab Name, Category Name, and Parent Option Names) for each item. 

Key changes:
1. Created `SearchParentData.tsx` to render the hierarchy with `CornerDownRight` and `ChevronRight` icons from `lucide-react`.
2. Modified `SearchSuggestionResult.tsx` to:
   - Include the `SearchParentData` component inside each suggestion button.
   - Adjust button styling (`h-auto`, `w-full`, `flex-col`, `items-start`) for a multi-line, left-aligned layout.
   - Use `Fragment` instead of a `div` wrapper to maintain the intended `ButtonGroup` flex layout and styling.
3. Added `tests/SearchSuggestionResult.test.tsx` to verify that the term and parent data are correctly rendered.
4. Visually verified the changes using a Playwright screenshot.

---
*PR created automatically by Jules for task [3094878667738615850](https://jules.google.com/task/3094878667738615850) started by @yukieiji*