### PR TITLE
Keyboard Navigation for Search Suggestions

### DIFF
--- a/e2e/option_search_keyboard.spec.ts
+++ b/e2e/option_search_keyboard.spec.ts
@@ -49,7 +49,7 @@ test.describe("Option Search Keyboard Navigation", () => {
 		const suggestions = popover.getByRole("button");
 
 		// Navigate to the second suggestion if exists
-		if (await suggestions.count() > 1) {
+		if ((await suggestions.count()) > 1) {
 			await searchInput.press("ArrowDown");
 		}
 

--- a/e2e/option_search_keyboard.spec.ts
+++ b/e2e/option_search_keyboard.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Option Search Keyboard Navigation", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/");
+		// Wait for the main content to be visible (meaning the app has loaded)
+		await page.waitForSelector("input[type='search']");
+	});
+
+	test("should navigate suggestions with arrow keys", async ({ page }) => {
+		const searchInput = page.getByPlaceholder("オプションを検索...");
+		await searchInput.focus();
+		await searchInput.fill("a"); // Type something to get suggestions in mock
+
+		// Wait for the popover to appear
+		const popover = page.getByRole("dialog");
+		await expect(popover).toBeVisible();
+
+		// Get all suggestion buttons
+		const suggestions = popover.getByRole("button");
+		const count = await suggestions.count();
+		expect(count).toBeGreaterThan(0);
+
+		// First item should be highlighted by default (bg-secondary class)
+		await expect(suggestions.nth(0)).toHaveClass(/bg-secondary/);
+
+		// Press ArrowDown
+		await searchInput.press("ArrowDown");
+		await expect(suggestions.nth(1 % count)).toHaveClass(/bg-secondary/);
+		await expect(suggestions.nth(0)).not.toHaveClass(/bg-secondary/);
+
+		// Press ArrowUp (should wrap back to the first item if count is 2 or more)
+		await searchInput.press("ArrowUp");
+		await expect(suggestions.nth(0)).toHaveClass(/bg-secondary/);
+
+		// Press ArrowUp again (should wrap to the last item)
+		await searchInput.press("ArrowUp");
+		await expect(suggestions.nth(count - 1)).toHaveClass(/bg-secondary/);
+	});
+
+	test("should select suggestion with Enter", async ({ page }) => {
+		const searchInput = page.getByPlaceholder("オプションを検索...");
+		await searchInput.focus();
+		await searchInput.fill("map");
+
+		const popover = page.getByRole("dialog");
+		await expect(popover).toBeVisible();
+
+		const suggestions = popover.getByRole("button");
+
+		// Navigate to the second suggestion if exists
+		if (await suggestions.count() > 1) {
+			await searchInput.press("ArrowDown");
+		}
+
+		// Press Enter
+		await searchInput.press("Enter");
+
+		// Popover should close
+		await expect(popover).not.toBeVisible();
+	});
+});

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.13'
+const PACKAGE_VERSION = '2.14.6'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/feature/SearchBar.tsx
+++ b/src/feature/SearchBar.tsx
@@ -9,6 +9,7 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import { useSearchNavigation } from "@/hooks/useSearchNavigation";
 import { OPTION_SEARCH_PLACEHOLDER } from "@/noTrans";
 import { useStore } from "@/useStore";
 import { SearchSuggestion } from "./SearchSuggestion";
@@ -21,6 +22,7 @@ export function SearchBar() {
 	const setQuery = useStore((state) => state.setOptionSearchQuery);
 	const isOpen = useStore((state) => state.isSuggestOpen);
 	const setIsOpen = useStore((state) => state.setSuggestOpen);
+	const { onKeyDown } = useSearchNavigation();
 
 	return (
 		<Popover
@@ -61,6 +63,7 @@ export function SearchBar() {
 							onChange={(e) => {
 								setQuery(e.target.value);
 							}}
+							onKeyDown={onKeyDown}
 							value={optionSearchQuery}
 						/>
 					</InputGroup>

--- a/src/feature/SearchSuggestion.tsx
+++ b/src/feature/SearchSuggestion.tsx
@@ -1,29 +1,9 @@
-import { useShallow } from "zustand/react/shallow";
 import { PopoverHeader, PopoverTitle } from "@/components/ui/popover";
-import { globalSearchItems } from "@/logics/api";
 import { useStore } from "@/useStore";
 import { SearchSuggestionResult } from "./SearchSuggestionResult";
 
 export function SearchSuggestion() {
-	const results = useStore(
-		useShallow((state) => {
-			if (state.optionSearchQuery.trim() === "") {
-				return [];
-			}
-			const lowerQuery = state.optionSearchQuery.toLowerCase();
-			return globalSearchItems
-				.filter((item) => {
-					if (!item.term.toLowerCase().includes(lowerQuery)) {
-						return false;
-					}
-					return item.info.mode === "exr-opt"
-						? (state.isExROptionActive[item.info.uniqueOptionId] ?? false)
-						: true;
-				})
-				.slice(0, 10);
-		}),
-	);
-
+	const results = useStore((state) => state.filteredResults);
 	const optionSearchQuery = useStore((state) => state.optionSearchQuery.trim());
 
 	return optionSearchQuery === "" || results.length === 0 ? (

--- a/src/feature/SearchSuggestionResult.tsx
+++ b/src/feature/SearchSuggestionResult.tsx
@@ -3,9 +3,9 @@ import { SearchParentData } from "@/components/blocks/SearchParentData";
 import { ColoredText } from "@/components/parts/ColoredText";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
+import { Separator } from "@/components/ui/separator";
 import { useSearchNavigation } from "@/hooks/useSearchNavigation";
 import { cn } from "@/lib/utils";
-import { Separator } from "@/components/ui/separator";
 import type { SearchItem } from "@/type";
 
 interface SearchSuggestionResultProps {
@@ -36,7 +36,8 @@ export function SearchSuggestionResult({
 					<Button
 						className={cn(
 							"h-auto w-full min-w-0 flex-col items-start justify-start py-1 text-left",
-							index === selectedSuggestIndex && "bg-secondary text-secondary-foreground",
+							index === selectedSuggestIndex &&
+								"bg-secondary text-secondary-foreground",
 						)}
 						variant="ghost"
 						onClick={() => handleSelect(item)}

--- a/src/feature/SearchSuggestionResult.tsx
+++ b/src/feature/SearchSuggestionResult.tsx
@@ -3,13 +3,10 @@ import { SearchParentData } from "@/components/blocks/SearchParentData";
 import { ColoredText } from "@/components/parts/ColoredText";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
+import { useSearchNavigation } from "@/hooks/useSearchNavigation";
+import { cn } from "@/lib/utils";
 import { Separator } from "@/components/ui/separator";
-import {
-	useAuOptionNavigationInline,
-	useExROptionNavigationInline,
-} from "@/hooks/useOptionNavigation";
 import type { SearchItem } from "@/type";
-import { useStore } from "@/useStore";
 
 interface SearchSuggestionResultProps {
 	results: SearchItem[];
@@ -30,26 +27,17 @@ function getKeyByMode(item: SearchItem) {
 export function SearchSuggestionResult({
 	results,
 }: SearchSuggestionResultProps) {
-	const navigateToExR = useExROptionNavigationInline();
-	const navigateToAu = useAuOptionNavigationInline();
-	const setIsOpen = useStore((state) => state.setSuggestOpen);
-
-	const handleSelect = (item: SearchItem) => {
-		if (item.info.mode === "exr-opt") {
-			navigateToExR(item.info.uniqueOptionId);
-			setIsOpen(false);
-		} else if (item.info.mode === "au-opt") {
-			navigateToAu(item.info.tabId, item.info.categoryId, item.info.auOptionId);
-			setIsOpen(false);
-		}
-	};
+	const { selectedSuggestIndex, handleSelect } = useSearchNavigation();
 
 	return (
 		<ButtonGroup orientation="vertical" className="w-full">
 			{results.map((item, index) => (
 				<Fragment key={getKeyByMode(item)}>
 					<Button
-						className="h-auto w-full min-w-0 flex-col items-start justify-start py-1 text-left"
+						className={cn(
+							"h-auto w-full min-w-0 flex-col items-start justify-start py-1 text-left",
+							index === selectedSuggestIndex && "bg-secondary text-secondary-foreground",
+						)}
 						variant="ghost"
 						onClick={() => handleSelect(item)}
 					>

--- a/src/hooks/useSearchNavigation.ts
+++ b/src/hooks/useSearchNavigation.ts
@@ -1,0 +1,54 @@
+import type { KeyboardEvent } from "react";
+import {
+	useAuOptionNavigationInline,
+	useExROptionNavigationInline,
+} from "@/hooks/useOptionNavigation";
+import type { SearchItem } from "@/type";
+import { useStore } from "@/useStore";
+
+export function useSearchNavigation() {
+	const results = useStore((state) => state.filteredResults);
+	const selectedSuggestIndex = useStore((state) => state.selectedSuggestIndex);
+	const setIsOpen = useStore((state) => state.setSuggestOpen);
+	const selectNext = useStore((state) => state.selectNextSuggestion);
+	const selectPrev = useStore((state) => state.selectPrevSuggestion);
+
+	const navigateToExR = useExROptionNavigationInline();
+	const navigateToAu = useAuOptionNavigationInline();
+
+	const handleSelect = (item: SearchItem) => {
+		if (item.info.mode === "exr-opt") {
+			navigateToExR(item.info.uniqueOptionId);
+			setIsOpen(false);
+		} else if (item.info.mode === "au-opt") {
+			navigateToAu(item.info.tabId, item.info.categoryId, item.info.auOptionId);
+			setIsOpen(false);
+		}
+	};
+
+	const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (results.length === 0) {
+			return;
+		}
+
+		if (e.key === "ArrowDown") {
+			e.preventDefault();
+			selectNext();
+		} else if (e.key === "ArrowUp") {
+			e.preventDefault();
+			selectPrev();
+		} else if (e.key === "Enter") {
+			if (selectedSuggestIndex >= 0 && selectedSuggestIndex < results.length) {
+				e.preventDefault();
+				handleSelect(results[selectedSuggestIndex]);
+			}
+		}
+	};
+
+	return {
+		results,
+		selectedSuggestIndex,
+		handleSelect,
+		onKeyDown,
+	};
+}

--- a/src/slices/searchBarSlice.ts
+++ b/src/slices/searchBarSlice.ts
@@ -1,4 +1,6 @@
 import type { StateCreator } from "zustand";
+import { globalSearchItems } from "@/logics/api";
+import type { SearchItem } from "@/type";
 
 export type SelectedTab = "Au" | "ExR" | "RoleFilter";
 
@@ -10,20 +12,68 @@ export interface SearchBarSlice {
 	setOptionSearchQuery: (query: string) => void;
 	isSuggestOpen: boolean;
 	setSuggestOpen: (isOpen: boolean) => void;
+	selectedSuggestIndex: number;
+	setSelectedSuggestIndex: (index: number) => void;
+	filteredResults: SearchItem[];
+	selectNextSuggestion: () => void;
+	selectPrevSuggestion: () => void;
 }
 
 /**
  * サイドバーの状態管理を行うスライスの生成
  */
-export const createSearchBarSlice: StateCreator<SearchBarSlice> = (set) => {
+export const createSearchBarSlice: StateCreator<SearchBarSlice> = (
+	set,
+	get,
+) => {
 	return {
 		optionSearchQuery: "",
 		setOptionSearchQuery: (query: string) => {
-			set({ optionSearchQuery: query });
+			const lowerQuery = query.toLowerCase().trim();
+			let filteredResults: SearchItem[] = [];
+			if (lowerQuery !== "") {
+				const state = get() as any; // FIXME: state type
+				filteredResults = globalSearchItems
+					.filter((item) => {
+						if (!item.term.toLowerCase().includes(lowerQuery)) {
+							return false;
+						}
+						return item.info.mode === "exr-opt"
+							? (state.isExROptionActive[item.info.uniqueOptionId] ?? false)
+							: true;
+					})
+					.slice(0, 10);
+			}
+			set({
+				optionSearchQuery: query,
+				selectedSuggestIndex: 0,
+				filteredResults,
+			});
 		},
 		isSuggestOpen: false,
 		setSuggestOpen: (isOpen: boolean) => {
 			set({ isSuggestOpen: isOpen });
+		},
+		selectedSuggestIndex: 0,
+		setSelectedSuggestIndex: (index: number) => {
+			set({ selectedSuggestIndex: index });
+		},
+		filteredResults: [],
+		selectNextSuggestion: () => {
+			const { filteredResults, selectedSuggestIndex } = get();
+			if (filteredResults.length === 0) return;
+			set({
+				selectedSuggestIndex: (selectedSuggestIndex + 1) % filteredResults.length,
+			});
+		},
+		selectPrevSuggestion: () => {
+			const { filteredResults, selectedSuggestIndex } = get();
+			if (filteredResults.length === 0) return;
+			set({
+				selectedSuggestIndex:
+					(selectedSuggestIndex - 1 + filteredResults.length) %
+					filteredResults.length,
+			});
 		},
 	};
 };

--- a/src/slices/searchBarSlice.ts
+++ b/src/slices/searchBarSlice.ts
@@ -22,17 +22,21 @@ export interface SearchBarSlice {
 /**
  * サイドバーの状態管理を行うスライスの生成
  */
-export const createSearchBarSlice: StateCreator<SearchBarSlice> = (
-	set,
-	get,
-) => {
+import type { ExROptionViewerSlice } from "./exrOptionViewerSlice";
+
+export const createSearchBarSlice: StateCreator<
+	SearchBarSlice & ExROptionViewerSlice,
+	[],
+	[],
+	SearchBarSlice
+> = (set, get) => {
 	return {
 		optionSearchQuery: "",
 		setOptionSearchQuery: (query: string) => {
 			const lowerQuery = query.toLowerCase().trim();
 			let filteredResults: SearchItem[] = [];
 			if (lowerQuery !== "") {
-				const state = get() as any; // FIXME: state type
+				const state = get();
 				filteredResults = globalSearchItems
 					.filter((item) => {
 						if (!item.term.toLowerCase().includes(lowerQuery)) {
@@ -61,14 +65,19 @@ export const createSearchBarSlice: StateCreator<SearchBarSlice> = (
 		filteredResults: [],
 		selectNextSuggestion: () => {
 			const { filteredResults, selectedSuggestIndex } = get();
-			if (filteredResults.length === 0) return;
+			if (filteredResults.length === 0) {
+				return;
+			}
 			set({
-				selectedSuggestIndex: (selectedSuggestIndex + 1) % filteredResults.length,
+				selectedSuggestIndex:
+					(selectedSuggestIndex + 1) % filteredResults.length,
 			});
 		},
 		selectPrevSuggestion: () => {
 			const { filteredResults, selectedSuggestIndex } = get();
-			if (filteredResults.length === 0) return;
+			if (filteredResults.length === 0) {
+				return;
+			}
 			set({
 				selectedSuggestIndex:
 					(selectedSuggestIndex - 1 + filteredResults.length) %

--- a/tests/useSearchNavigation.test.ts
+++ b/tests/useSearchNavigation.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useSearchNavigation } from "@/hooks/useSearchNavigation";
+import { useStore } from "@/useStore";
+import { globalSearchItems } from "@/logics/api";
+
+// Reset globalSearchItems for testing
+(globalSearchItems as any).push(
+	{ term: "Item 1", info: { mode: "au-opt", tabId: 0, categoryId: 0, auOptionId: 1 }, parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] } },
+	{ term: "Item 2", info: { mode: "au-opt", tabId: 0, categoryId: 0, auOptionId: 2 }, parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] } },
+);
+
+vi.mock("@/hooks/useOptionNavigation", () => ({
+	useAuOptionNavigationInline: vi.fn(() => vi.fn()),
+	useExROptionNavigationInline: vi.fn(() => vi.fn()),
+}));
+
+describe("useSearchNavigation", () => {
+	it("initializes with default values", () => {
+		const { result } = renderHook(() => useSearchNavigation());
+		expect(result.current.selectedSuggestIndex).toBe(0);
+	});
+
+	it("handles ArrowDown navigation via store", () => {
+		const { result } = renderHook(() => useSearchNavigation());
+
+		act(() => {
+			useStore.getState().setOptionSearchQuery("Item");
+		});
+
+		act(() => {
+			result.current.onKeyDown({
+				key: "ArrowDown",
+				preventDefault: vi.fn(),
+			} as any);
+		});
+
+		expect(useStore.getState().selectedSuggestIndex).toBe(1);
+	});
+
+	it("handles ArrowUp navigation (wrap around) via store", () => {
+		const { result } = renderHook(() => useSearchNavigation());
+
+		act(() => {
+			useStore.getState().setOptionSearchQuery("Item");
+			useStore.getState().setSelectedSuggestIndex(0);
+		});
+
+		act(() => {
+			result.current.onKeyDown({
+				key: "ArrowUp",
+				preventDefault: vi.fn(),
+			} as any);
+		});
+
+		expect(useStore.getState().selectedSuggestIndex).toBe(1);
+	});
+
+    it("resets selection index when search query changes", () => {
+        act(() => {
+            useStore.getState().setOptionSearchQuery("Item");
+            useStore.getState().setSelectedSuggestIndex(1);
+        });
+
+        act(() => {
+            useStore.getState().setOptionSearchQuery("new");
+        });
+
+        expect(useStore.getState().selectedSuggestIndex).toBe(0);
+    });
+});

--- a/tests/useSearchNavigation.test.ts
+++ b/tests/useSearchNavigation.test.ts
@@ -1,13 +1,22 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useSearchNavigation } from "@/hooks/useSearchNavigation";
-import { useStore } from "@/useStore";
 import { globalSearchItems } from "@/logics/api";
+import type { SearchItem } from "@/type";
+import { useStore } from "@/useStore";
 
 // Reset globalSearchItems for testing
-(globalSearchItems as any).push(
-	{ term: "Item 1", info: { mode: "au-opt", tabId: 0, categoryId: 0, auOptionId: 1 }, parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] } },
-	{ term: "Item 2", info: { mode: "au-opt", tabId: 0, categoryId: 0, auOptionId: 2 }, parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] } },
+(globalSearchItems as SearchItem[]).push(
+	{
+		term: "Item 1",
+		info: { mode: "au-opt", tabId: 0, categoryId: 0, auOptionId: 1 },
+		parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] },
+	},
+	{
+		term: "Item 2",
+		info: { mode: "au-opt", tabId: 0, categoryId: 0, auOptionId: 2 },
+		parentData: { tabName: "Tab", categoryName: "Cat", parentOptionNames: [] },
+	},
 );
 
 vi.mock("@/hooks/useOptionNavigation", () => ({
@@ -32,7 +41,7 @@ describe("useSearchNavigation", () => {
 			result.current.onKeyDown({
 				key: "ArrowDown",
 				preventDefault: vi.fn(),
-			} as any);
+			} as unknown as React.KeyboardEvent<HTMLInputElement>);
 		});
 
 		expect(useStore.getState().selectedSuggestIndex).toBe(1);
@@ -50,22 +59,22 @@ describe("useSearchNavigation", () => {
 			result.current.onKeyDown({
 				key: "ArrowUp",
 				preventDefault: vi.fn(),
-			} as any);
+			} as unknown as React.KeyboardEvent<HTMLInputElement>);
 		});
 
 		expect(useStore.getState().selectedSuggestIndex).toBe(1);
 	});
 
-    it("resets selection index when search query changes", () => {
-        act(() => {
-            useStore.getState().setOptionSearchQuery("Item");
-            useStore.getState().setSelectedSuggestIndex(1);
-        });
+	it("resets selection index when search query changes", () => {
+		act(() => {
+			useStore.getState().setOptionSearchQuery("Item");
+			useStore.getState().setSelectedSuggestIndex(1);
+		});
 
-        act(() => {
-            useStore.getState().setOptionSearchQuery("new");
-        });
+		act(() => {
+			useStore.getState().setOptionSearchQuery("new");
+		});
 
-        expect(useStore.getState().selectedSuggestIndex).toBe(0);
-    });
+		expect(useStore.getState().selectedSuggestIndex).toBe(0);
+	});
 });


### PR DESCRIPTION
Enabled ArrowDown, ArrowUp, and Enter keys to navigate and select search suggestions while keeping focus on the search bar. The first suggestion is now selected by default. Refactored logic into the store for better maintainability and testability.

---
*PR created automatically by Jules for task [17241164725510366796](https://jules.google.com/task/17241164725510366796) started by @yukieiji*