### PR TITLE
右サイドパネルのマップ表示の改善（ランダム表示とリスト非表示）

### DIFF
--- a/e2e/random_map.spec.ts
+++ b/e2e/random_map.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+	await page.request.post("/mock/reset", { maxRetries: 5 });
+	await page.addInitScript(() => {
+		// @ts-expect-error - window has no __API_DELAY__ property
+		window.__API_DELAY__ = 0;
+	});
+	await page.goto("/");
+	await expect(page.getByText("Loading data...")).not.toBeVisible({
+		timeout: 30000,
+	});
+});
+
+test.describe("Random Map Display and Hiding", () => {
+	test("should display 'ランダム' in summary and hide from ExR list in right panel", async ({
+		page,
+	}) => {
+		// 1. 右サイドパネルを開く
+		const toggleButton = page.getByRole("button", { name: "パネルを開く" });
+		if (await toggleButton.isVisible()) {
+			await toggleButton.click();
+		}
+		await expect(page.getByTestId("right-panel-summary")).toBeVisible();
+
+		// 2. 初期状態の確認（マップのサマリーが表示されていること）
+		// モックの初期値は map: 4
+		// 実際には AuOptionSummaryRow は fallbackTitle="マップ" を使っているので "マップ" または "map"
+		const mapSummary = page
+			.locator('[data-testid="right-panel-summary"]')
+			.getByText(/^(map|マップ)$/);
+		await expect(mapSummary).toBeVisible();
+
+		// 3. ExR Options で「毎回マップがランダムに変わるか」をオンにする
+		await page.getByRole("button", { name: "ExR Options" }).click();
+
+		// カテゴリ「ランダムマップに関する設定」を探して開く
+		const categoryHeader = page.getByText("ランダムマップに関する設定");
+		await categoryHeader.scrollIntoViewIfNeeded();
+		await categoryHeader.click();
+
+		// トグルをオンにする
+		const optionRow = page
+			.locator("div")
+			.filter({ hasText: "毎回マップがランダムに変わるか" })
+			.last();
+		const toggleSwitch = optionRow.getByTestId("option-toggle");
+		await expect(optionRow.getByText("オフ")).toBeVisible();
+		await toggleSwitch.click();
+		await expect(optionRow.getByText("オン")).toBeVisible();
+
+		// 4. 右パネルのサマリー表示が「ランダム」に変わったことを確認
+		const summary = page.getByTestId("right-panel-summary");
+		await expect(summary.getByText("ランダム")).toBeVisible();
+
+		// 5. 右パネルの ExR 設定リストから「ランダムマップに関する設定」が消えていることを確認
+		// 右パネル内の "ExRの設定" アコーディオンの中身を確認
+		const exrSettingsInRightPanel = page
+			.locator("div")
+			.filter({ hasText: "ExRの設定" })
+			.locator("..");
+		await expect(
+			exrSettingsInRightPanel.getByText("ランダムマップに関する設定"),
+		).not.toBeVisible();
+	});
+});

--- a/src/feature/rightsidepanel/summary/AuOptionSummaryRow.tsx
+++ b/src/feature/rightsidepanel/summary/AuOptionSummaryRow.tsx
@@ -2,6 +2,11 @@ import { ColoredText } from "@/components/parts/ColoredText";
 import { ViewerOptionRow } from "@/components/parts/ViewerOptionRow";
 import { useAuOptionNavigationInline } from "@/hooks/useOptionNavigation";
 import { auOptionMetaData } from "@/logics/api";
+import {
+	AU_MAP_OPTION_ID,
+	EXR_RANDOM_MAP_OPTION_ID,
+} from "@/logics/optionUtils";
+import { RANDOM_MAP_LABEL } from "@/noTrans";
 import type { AuOptionId } from "@/type";
 import { useStore } from "@/useStore";
 
@@ -16,6 +21,13 @@ export function AuOptionSummaryRow({
 }: AuOptionSummaryRowProps) {
 	const navigateAu = useAuOptionNavigationInline();
 	const value = useStore((state) => {
+		if (optionId === AU_MAP_OPTION_ID) {
+			const randomMapSelection =
+				state.exrValue[EXR_RANDOM_MAP_OPTION_ID]?.selection ?? 0;
+			if (randomMapSelection === 1) {
+				return RANDOM_MAP_LABEL;
+			}
+		}
 		const selection = state.auValue[optionId] ?? 0;
 		return String(auOptionMetaData.options[optionId]?.range[selection] ?? "");
 	});

--- a/src/logics/optionUtils.ts
+++ b/src/logics/optionUtils.ts
@@ -92,6 +92,8 @@ export const EXR_LIBERAL_MAX_ID = getUniqueOptionId(0, 5, 7);
 export const EXR_MILITANT_MIN_ID = getUniqueOptionId(0, 7, 22);
 export const EXR_MILITANT_MAX_ID = getUniqueOptionId(0, 7, 23);
 
+export const EXR_RANDOM_MAP_OPTION_ID = getUniqueOptionId(0, 20, 0);
+
 export const VANILLA_ROLE_CATEGORY_IDS = [
 	5, 6, 7, 8, 9, 10, 11, 12, 13,
 ] as const;
@@ -109,6 +111,7 @@ export const MOVED_EXR_OPTION_UNIQUE_IDS = [
 	EXR_LIBERAL_MAX_ID,
 	EXR_MILITANT_MIN_ID,
 	EXR_MILITANT_MAX_ID,
+	EXR_RANDOM_MAP_OPTION_ID,
 ] as const;
 
 const MIN_SUFFIXES = [

--- a/src/noTrans.ts
+++ b/src/noTrans.ts
@@ -73,6 +73,7 @@ export const EXR_SHORT_LABEL = "E";
 export const ROLE_FILTER_SHORT_LABEL = "R";
 export const ON = "ON";
 export const OFF = "OFF";
+export const RANDOM_MAP_LABEL = "ランダム";
 
 export const ERROR_TITLE = "エラーが発生しました";
 export const ERROR_RETRY_BUTTON = "再試行";

--- a/tests/AuOptionSummaryRow.test.tsx
+++ b/tests/AuOptionSummaryRow.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AuOptionSummaryRow } from "@/feature/rightsidepanel/summary/AuOptionSummaryRow";
+import { auOptionMetaData } from "@/logics/api";
+import {
+	AU_MAP_OPTION_ID,
+	EXR_RANDOM_MAP_OPTION_ID,
+} from "@/logics/optionUtils";
+import { RANDOM_MAP_LABEL } from "@/noTrans";
+import { useStore } from "@/useStore";
+
+// モック化
+vi.mock("@/useStore", () => ({
+	useStore: vi.fn(),
+}));
+
+vi.mock("@/hooks/useOptionNavigation", () => ({
+	useAuOptionNavigationInline: () => vi.fn(),
+}));
+
+describe("AuOptionSummaryRow", () => {
+	it("renders 'ランダム' when the map is randomized (EXR_RANDOM_MAP_OPTION_ID is ON)", () => {
+		// auOptionMetaData の設定
+		auOptionMetaData.options[AU_MAP_OPTION_ID] = {
+			title: "マップ",
+			format: "",
+			range: ["Skeld", "MiraHQ"],
+			tabId: 0,
+			categoryId: 0,
+		};
+
+		// useStore の振る舞いをモック
+		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+		(useStore as any).mockImplementation((selector: any) => {
+			return selector({
+				auValue: {
+					[AU_MAP_OPTION_ID]: 0,
+				},
+				exrValue: {
+					[EXR_RANDOM_MAP_OPTION_ID]: {
+						selection: 1, // ON
+						values: ["オフ", "オン"],
+					},
+				},
+			});
+		});
+
+		render(
+			<AuOptionSummaryRow optionId={AU_MAP_OPTION_ID} fallbackTitle="マップ" />,
+		);
+
+		expect(screen.getByText(RANDOM_MAP_LABEL)).toBeInTheDocument();
+		expect(screen.queryByText("Skeld")).not.toBeInTheDocument();
+	});
+
+	it("renders the normal map name when randomization is OFF", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+		(useStore as any).mockImplementation((selector: any) => {
+			return selector({
+				auValue: {
+					[AU_MAP_OPTION_ID]: 1, // MiraHQ
+				},
+				exrValue: {
+					[EXR_RANDOM_MAP_OPTION_ID]: {
+						selection: 0, // OFF
+						values: ["オフ", "オン"],
+					},
+				},
+			});
+		});
+
+		render(
+			<AuOptionSummaryRow optionId={AU_MAP_OPTION_ID} fallbackTitle="マップ" />,
+		);
+
+		expect(screen.getByText("MiraHQ")).toBeInTheDocument();
+		expect(screen.queryByText(RANDOM_MAP_LABEL)).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
右サイドパネルの表示を改善しました。
1. 「毎回マップがランダムに変わるか」がオンの時、サマリーのマップ欄に「ランダム」と表示されるようにしました。
2. 同設定項目を、右サイドパネルのExRカテゴリ一覧から非表示にしました（サマリーに表示されるため）。
これらの変更により、ユーザーが現在のマップ設定（固定かランダムか）をひと目で確認できるようになります。

---
*PR created automatically by Jules for task [14955595732551443133](https://jules.google.com/task/14955595732551443133) started by @yukieiji*