### PR TITLE
ユニットテストの biome-ignore 解消とコード改善

### DIFF
--- a/tests/AuOptionSummaryRow.test.tsx
+++ b/tests/AuOptionSummaryRow.test.tsx
@@ -30,8 +30,7 @@ describe("AuOptionSummaryRow", () => {
 		};
 
 		// useStore の振る舞いをモック
-		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-		(useStore as any).mockImplementation((selector: any) => {
+		vi.mocked(useStore).mockImplementation((selector) => {
 			return selector({
 				auValue: {
 					[AU_MAP_OPTION_ID]: 0,
@@ -42,7 +41,7 @@ describe("AuOptionSummaryRow", () => {
 						values: ["オフ", "オン"],
 					},
 				},
-			});
+			} as unknown as Parameters<typeof selector>[0]);
 		});
 
 		render(
@@ -54,8 +53,7 @@ describe("AuOptionSummaryRow", () => {
 	});
 
 	it("renders the normal map name when randomization is OFF", () => {
-		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-		(useStore as any).mockImplementation((selector: any) => {
+		vi.mocked(useStore).mockImplementation((selector) => {
 			return selector({
 				auValue: {
 					[AU_MAP_OPTION_ID]: 1, // MiraHQ
@@ -66,7 +64,7 @@ describe("AuOptionSummaryRow", () => {
 						values: ["オフ", "オン"],
 					},
 				},
-			});
+			} as unknown as Parameters<typeof selector>[0]);
 		});
 
 		render(

--- a/tests/ExROptionControl.test.tsx
+++ b/tests/ExROptionControl.test.tsx
@@ -245,7 +245,7 @@ describe("ExROptionControl", () => {
 			values: [0, 1],
 		});
 
-		let renderResult: RenderResult;
+		let renderResult: RenderResult | undefined;
 		await act(async () => {
 			renderResult = render(
 				<ExROptionControl
@@ -256,7 +256,6 @@ describe("ExROptionControl", () => {
 			);
 		});
 
-		// biome-ignore lint/style/noNonNullAssertion: test
-		expect(renderResult!.container.firstChild).toBeNull();
+		expect(renderResult?.container.firstChild).toBeNull();
 	});
 });

--- a/tests/RoleFilterAssignNum.test.tsx
+++ b/tests/RoleFilterAssignNum.test.tsx
@@ -78,10 +78,8 @@ describe("RoleFilter AssignNum Adjustment", () => {
 
 	it("disables buttons while updating", async () => {
 		const guid = "test-guid";
-		// biome-ignore lint/suspicious/noExplicitAny: Mocking API function
-		let resolveUpdate: any;
-		// biome-ignore lint/suspicious/noExplicitAny: Mocking API function
-		(postRoleFilterUpdate as any).mockReturnValue(
+		let resolveUpdate: (value: unknown) => void = () => {};
+		vi.mocked(postRoleFilterUpdate).mockReturnValue(
 			new Promise((resolve) => {
 				resolveUpdate = resolve;
 			}),

--- a/tests/useExRNavigation.test.tsx
+++ b/tests/useExRNavigation.test.tsx
@@ -31,7 +31,7 @@ describe("useExRNavigation", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.mocked(useStore).mockImplementation((selector: unknown) => {
+		vi.mocked(useStore).mockImplementation((selector) => {
 			const state = {
 				setSelectedTab,
 				setSelectedExRTabId,
@@ -40,10 +40,9 @@ describe("useExRNavigation", () => {
 				setHighlightedExROptionId,
 				setRightPanelOpen,
 			};
-			return (selector as (s: typeof state) => unknown)(state);
+			return selector(state as unknown as Parameters<typeof selector>[0]);
 		});
-		// biome-ignore lint/suspicious/noExplicitAny: mock useStore.getState
-		(useStore as any).getState = vi.fn().mockReturnValue({
+		vi.mocked(useStore).getState = vi.fn().mockReturnValue({
 			openedExRCategoryIds: {},
 		});
 	});

--- a/tests/useExportCsv.test.tsx
+++ b/tests/useExportCsv.test.tsx
@@ -19,8 +19,7 @@ describe("useExportCsv", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(fetchCsvData as any).mockResolvedValue(mockCsvData);
+		vi.mocked(fetchCsvData).mockResolvedValue(mockCsvData);
 
 		// URL.createObjectURL のモック化
 		vi.stubGlobal("URL", {
@@ -29,8 +28,7 @@ describe("useExportCsv", () => {
 		});
 
 		// showSaveFilePicker をデフォルトで未定義にする
-		// biome-ignore lint/suspicious/noExplicitAny: mock
-		delete (window as any).showSaveFilePicker;
+		vi.stubGlobal("showSaveFilePicker", undefined);
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
ユニットテスト内で使われていた `biome-ignore` を修正し、ワーニングを解消しました。
単に説明文を追加するのではなく、`vi.mocked` や `vi.stubGlobal` を活用するようにコード自体を改善することで、`biome-ignore` を使わずに済むようにリファクタリングを行いました。
対象ファイル:
- tests/AuOptionSummaryRow.test.tsx
- tests/ExROptionControl.test.tsx
- tests/RoleFilterAssignNum.test.tsx
- tests/useExRNavigation.test.tsx
- tests/useExportCsv.test.tsx

---
*PR created automatically by Jules for task [9664035237486092922](https://jules.google.com/task/9664035237486092922) started by @yukieiji*