### PR TITLE
検索機能のカテゴリ対応実装

### DIFF
--- a/e2e/category_search.spec.ts
+++ b/e2e/category_search.spec.ts
@@ -39,6 +39,40 @@ test.describe("Category Search", () => {
 		await expect(highlighted).toContainText("会議");
 	});
 
+	test("should navigate to and highlight map option when selected from search (Au Map)", async ({
+		page,
+	}) => {
+		const searchInput = page.getByPlaceholder("オプションを検索...");
+		await searchInput.click();
+		await searchInput.fill("マップ");
+
+		// Wait for suggestions in popover
+		const popover = page.locator('[role="dialog"]');
+
+		// Map should now be an option (term "マップ")
+		const suggestion = popover
+			.getByRole("button")
+			.filter({ hasText: "マップ" })
+			.filter({ hasText: "0" })
+			.first();
+		await expect(suggestion).toBeVisible({ timeout: 10000 });
+		await suggestion.click();
+
+		// Wait for potential navigation and state update
+		await page.waitForTimeout(2000);
+
+		// The title should change to Au Options
+		await expect(
+			page.getByRole("heading", { name: "Au Options" }),
+		).toBeVisible();
+
+		// Check if it's highlighted.
+		const highlighted = page.locator('[data-highlighted="true"]').first();
+		await expect(highlighted).toBeVisible({ timeout: 15000 });
+		// In MapDropDown.tsx, the title comes from optionMeta.title which might be "map" in mock data
+		// but the highlight wrapper should be there.
+	});
+
 	test("should navigate to and highlight category when selected from search (ExR)", async ({
 		page,
 	}) => {

--- a/e2e/category_search.spec.ts
+++ b/e2e/category_search.spec.ts
@@ -17,7 +17,11 @@ test.describe("Category Search", () => {
 		const popover = page.locator('[role="dialog"]'); // Popover standard role
 
 		// Find a button that has both "会議" and "0" (Au tab number)
-		const suggestion = popover.getByRole("button").filter({ hasText: "会議" }).filter({ hasText: "0" }).first();
+		const suggestion = popover
+			.getByRole("button")
+			.filter({ hasText: "会議" })
+			.filter({ hasText: "0" })
+			.first();
 		await expect(suggestion).toBeVisible({ timeout: 10000 });
 		await suggestion.click();
 
@@ -25,7 +29,9 @@ test.describe("Category Search", () => {
 		await page.waitForTimeout(2000);
 
 		// The title should change to Au Options
-		await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Au Options" }),
+		).toBeVisible();
 
 		// Check if it's highlighted.
 		const highlighted = page.locator('[data-highlighted="true"]').first();
@@ -43,7 +49,10 @@ test.describe("Category Search", () => {
 		const popover = page.locator('[role="dialog"]');
 
 		// "シェリフ" is a category in ExR tab (implied by missing tab number or "クルーメイト役職設定")
-		const suggestion = popover.getByRole("button").filter({ hasText: "シェリフ" }).first();
+		const suggestion = popover
+			.getByRole("button")
+			.filter({ hasText: "シェリフ" })
+			.first();
 		await expect(suggestion).toBeVisible({ timeout: 10000 });
 		await suggestion.click();
 

--- a/e2e/category_search.spec.ts
+++ b/e2e/category_search.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Category Search", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/");
+		await page.waitForSelector('[data-testid="main-content-section"]');
+	});
+
+	test("should navigate to and highlight category when selected from search (Au)", async ({
+		page,
+	}) => {
+		const searchInput = page.getByPlaceholder("オプションを検索...");
+		await searchInput.click();
+		await searchInput.fill("会議");
+
+		// Wait for suggestions in popover
+		const popover = page.locator('[role="dialog"]'); // Popover standard role
+
+		// Find a button that has both "会議" and "0" (Au tab number)
+		const suggestion = popover.getByRole("button").filter({ hasText: "会議" }).filter({ hasText: "0" }).first();
+		await expect(suggestion).toBeVisible({ timeout: 10000 });
+		await suggestion.click();
+
+		// Wait for potential navigation and state update
+		await page.waitForTimeout(2000);
+
+		// The title should change to Au Options
+		await expect(page.getByRole("heading", { name: "Au Options" })).toBeVisible();
+
+		// Check if it's highlighted.
+		const highlighted = page.locator('[data-highlighted="true"]').first();
+		await expect(highlighted).toBeVisible({ timeout: 15000 });
+		await expect(highlighted).toContainText("会議");
+	});
+
+	test("should navigate to and highlight category when selected from search (ExR)", async ({
+		page,
+	}) => {
+		const searchInput = page.getByPlaceholder("オプションを検索...");
+		await searchInput.click();
+		await searchInput.fill("シェリフ");
+
+		const popover = page.locator('[role="dialog"]');
+
+		// "シェリフ" is a category in ExR tab (implied by missing tab number or "クルーメイト役職設定")
+		const suggestion = popover.getByRole("button").filter({ hasText: "シェリフ" }).first();
+		await expect(suggestion).toBeVisible({ timeout: 10000 });
+		await suggestion.click();
+
+		await page.waitForTimeout(2000);
+
+		// Check if it's highlighted
+		const highlighted = page.locator('[data-highlighted="true"]').first();
+		await expect(highlighted).toBeVisible({ timeout: 15000 });
+		await expect(highlighted).toContainText("シェリフ");
+	});
+});

--- a/src/components/parts/HighlightWrapper.tsx
+++ b/src/components/parts/HighlightWrapper.tsx
@@ -23,6 +23,7 @@ export function HighlightWrapper({
 	return (
 		<div
 			id={id}
+			data-highlighted={isHighlighted}
 			className={`transition-all duration-500 rounded ${highlightClass}`}
 		>
 			{children}

--- a/src/feature/amongus/AuRoleCategoryItem.tsx
+++ b/src/feature/amongus/AuRoleCategoryItem.tsx
@@ -61,7 +61,7 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 		<HighlightWrapper
 			id={navigateId}
 			isHighlighted={isHighlighted}
-			isInset={false}
+			isInset={true}
 		>
 			<RoleCategoryAccordion
 				isOpen={isOpen}

--- a/src/feature/amongus/AuRoleCategoryItem.tsx
+++ b/src/feature/amongus/AuRoleCategoryItem.tsx
@@ -1,6 +1,9 @@
 import { RoleCategoryAccordion } from "@/components/blocks/RoleCategoryAccordion";
 import { HighlightWrapper } from "@/components/parts/HighlightWrapper";
-import { createAuNavigateId } from "@/hooks/useOptionNavigation";
+import {
+	createAuCategoryNavigateId,
+	createAuNavigateId,
+} from "@/hooks/useOptionNavigation";
 import { auOptionMetaData } from "@/logics/api";
 import { useStore } from "@/useStore";
 import { AuCategoryOptionList } from "./AuCategoryOptionList";
@@ -29,6 +32,9 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 	const highlightedAuOptionId = useStore(
 		(state) => state.highlightedAuOptionId,
 	);
+	const highlightedAuCategoryId = useStore(
+		(state) => state.highlightedAuCategoryId,
+	);
 
 	const chanceOptionMeta = auOptionMetaData.options[chanceOptionId];
 
@@ -42,10 +48,14 @@ export function AuRoleCategoryItem({ categoryId }: AuRoleCategoryItemProps) {
 	const otherOptionIds = categoryMeta.options.slice(2);
 
 	const isHighlighted =
-		highlightedAuOptionId !== null &&
-		categoryMeta.options.includes(highlightedAuOptionId);
+		(highlightedAuOptionId !== null &&
+			categoryMeta.options.includes(highlightedAuOptionId)) ||
+		highlightedAuCategoryId === categoryId;
 
-	const navigateId = createAuNavigateId(chanceOptionId);
+	const navigateId =
+		highlightedAuCategoryId === categoryId
+			? createAuCategoryNavigateId(categoryId)
+			: createAuNavigateId(chanceOptionId);
 
 	return (
 		<HighlightWrapper

--- a/src/feature/amongus/AuStandardCategoryItem.tsx
+++ b/src/feature/amongus/AuStandardCategoryItem.tsx
@@ -1,4 +1,6 @@
 import { OptionEditorAccordion } from "@/components/blocks/OptionEditorAccordion";
+import { HighlightWrapper } from "@/components/parts/HighlightWrapper";
+import { createAuCategoryNavigateId } from "@/hooks/useOptionNavigation";
 import { auOptionMetaData } from "@/logics/api";
 import { useStore } from "@/useStore";
 import { AuCategoryOptionList } from "./AuCategoryOptionList";
@@ -17,18 +19,30 @@ export function AuStandardCategoryItem({
 		(state) => state.openedAuCategoryIds[categoryId] ?? false,
 	);
 	const toggleAuCategory = useStore((state) => state.toggleAuCategory);
+	const highlightedAuCategoryId = useStore(
+		(state) => state.highlightedAuCategoryId,
+	);
 	const categoryMeta = auOptionMetaData.categoryMetaData[categoryId];
 	if (!categoryMeta) {
 		return null;
 	}
 
+	const isHighlighted = highlightedAuCategoryId === categoryId;
+	const navigateId = createAuCategoryNavigateId(categoryId);
+
 	return (
-		<OptionEditorAccordion
-			title={categoryMeta.name}
-			isOpen={isOpen}
-			onToggle={() => toggleAuCategory(categoryId)}
+		<HighlightWrapper
+			id={navigateId}
+			isHighlighted={isHighlighted}
+			isInset={false}
 		>
-			<AuCategoryOptionList optionIds={categoryMeta.options} />
-		</OptionEditorAccordion>
+			<OptionEditorAccordion
+				title={categoryMeta.name}
+				isOpen={isOpen}
+				onToggle={() => toggleAuCategory(categoryId)}
+			>
+				<AuCategoryOptionList optionIds={categoryMeta.options} />
+			</OptionEditorAccordion>
+		</HighlightWrapper>
 	);
 }

--- a/src/feature/amongus/MapDropDown.tsx
+++ b/src/feature/amongus/MapDropDown.tsx
@@ -57,25 +57,25 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 					isHighlighted={isHighlighted}
 					isInset={true}
 				>
-				<div className="flex items-center justify-between py-2 px-4">
-					<div className="flex items-center gap-3">
-						{/* アコーディオンの矢印アイコンのスペースを確保して配置を揃える */}
-						<div className="w-5" />
-						<span className="font-semibold text-gray-200">
-							{optionMeta.title}
-						</span>
+					<div className="flex items-center justify-between py-2 px-4">
+						<div className="flex items-center gap-3">
+							{/* アコーディオンの矢印アイコンのスペースを確保して配置を揃える */}
+							<div className="w-5" />
+							<span className="font-semibold text-gray-200">
+								{optionMeta.title}
+							</span>
+						</div>
+						<OptionDropdownControl
+							values={displayValues}
+							selection={selection}
+							onChange={(newSelectionValue) => {
+								updateAuOption({
+									auOptionId: mapOptionId,
+									selection: newSelectionValue,
+								});
+							}}
+						/>
 					</div>
-					<OptionDropdownControl
-						values={displayValues}
-						selection={selection}
-						onChange={(newSelectionValue) => {
-							updateAuOption({
-								auOptionId: mapOptionId,
-								selection: newSelectionValue,
-							});
-						}}
-					/>
-				</div>
 				</HighlightWrapper>
 			</div>
 		</HighlightWrapper>

--- a/src/feature/amongus/MapDropDown.tsx
+++ b/src/feature/amongus/MapDropDown.tsx
@@ -1,9 +1,6 @@
 import { HighlightWrapper } from "@/components/parts/HighlightWrapper";
 import { OptionDropdownControl } from "@/components/parts/OptionDropdownControl";
-import {
-	createAuCategoryNavigateId,
-	createAuNavigateId,
-} from "@/hooks/useOptionNavigation";
+import { createAuNavigateId } from "@/hooks/useOptionNavigation";
 import { auOptionMetaData } from "@/logics/api";
 import { useUpdateAuOptionSelection } from "@/logics/api.store";
 import { useStore } from "@/useStore";

--- a/src/feature/amongus/MapDropDown.tsx
+++ b/src/feature/amongus/MapDropDown.tsx
@@ -1,6 +1,9 @@
 import { HighlightWrapper } from "@/components/parts/HighlightWrapper";
 import { OptionDropdownControl } from "@/components/parts/OptionDropdownControl";
-import { createAuNavigateId } from "@/hooks/useOptionNavigation";
+import {
+	createAuCategoryNavigateId,
+	createAuNavigateId,
+} from "@/hooks/useOptionNavigation";
 import { auOptionMetaData } from "@/logics/api";
 import { useUpdateAuOptionSelection } from "@/logics/api.store";
 import { useStore } from "@/useStore";
@@ -23,6 +26,9 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 	const highlightedAuOptionId = useStore(
 		(state) => state.highlightedAuOptionId,
 	);
+	const highlightedAuCategoryId = useStore(
+		(state) => state.highlightedAuCategoryId,
+	);
 
 	const optionMeta = auOptionMetaData.options[mapOptionId];
 
@@ -34,16 +40,23 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 	const displayValues = optionMeta.range.map((v) => v.toString());
 
 	const isHighlighted = mapOptionId && highlightedAuOptionId === mapOptionId;
+	const isCategoryHighlighted = highlightedAuCategoryId === categoryId;
 
 	const navigateId = createAuNavigateId(mapOptionId);
+	const categoryNavigateId = createAuCategoryNavigateId(categoryId);
 
 	return (
-		<div className="border border-gray-700 rounded-lg overflow-hidden">
-			<HighlightWrapper
-				id={navigateId}
-				isHighlighted={isHighlighted}
-				isInset={true}
-			>
+		<HighlightWrapper
+			id={categoryNavigateId}
+			isHighlighted={isCategoryHighlighted}
+			isInset={false}
+		>
+			<div className="border border-gray-700 rounded-lg overflow-hidden">
+				<HighlightWrapper
+					id={navigateId}
+					isHighlighted={isHighlighted}
+					isInset={true}
+				>
 				<div className="flex items-center justify-between py-2 px-4">
 					<div className="flex items-center gap-3">
 						{/* アコーディオンの矢印アイコンのスペースを確保して配置を揃える */}
@@ -63,7 +76,8 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 						}}
 					/>
 				</div>
-			</HighlightWrapper>
-		</div>
+				</HighlightWrapper>
+			</div>
+		</HighlightWrapper>
 	);
 }

--- a/src/feature/amongus/MapDropDown.tsx
+++ b/src/feature/amongus/MapDropDown.tsx
@@ -26,9 +26,6 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 	const highlightedAuOptionId = useStore(
 		(state) => state.highlightedAuOptionId,
 	);
-	const highlightedAuCategoryId = useStore(
-		(state) => state.highlightedAuCategoryId,
-	);
 
 	const optionMeta = auOptionMetaData.options[mapOptionId];
 
@@ -40,44 +37,36 @@ export function MapDropDown({ categoryId }: MapDropDownProps) {
 	const displayValues = optionMeta.range.map((v) => v.toString());
 
 	const isHighlighted = mapOptionId && highlightedAuOptionId === mapOptionId;
-	const isCategoryHighlighted = highlightedAuCategoryId === categoryId;
 
 	const navigateId = createAuNavigateId(mapOptionId);
-	const categoryNavigateId = createAuCategoryNavigateId(categoryId);
 
 	return (
-		<HighlightWrapper
-			id={categoryNavigateId}
-			isHighlighted={isCategoryHighlighted}
-			isInset={false}
-		>
-			<div className="border border-gray-700 rounded-lg overflow-hidden">
-				<HighlightWrapper
-					id={navigateId}
-					isHighlighted={isHighlighted}
-					isInset={true}
-				>
-					<div className="flex items-center justify-between py-2 px-4">
-						<div className="flex items-center gap-3">
-							{/* アコーディオンの矢印アイコンのスペースを確保して配置を揃える */}
-							<div className="w-5" />
-							<span className="font-semibold text-gray-200">
-								{optionMeta.title}
-							</span>
-						</div>
-						<OptionDropdownControl
-							values={displayValues}
-							selection={selection}
-							onChange={(newSelectionValue) => {
-								updateAuOption({
-									auOptionId: mapOptionId,
-									selection: newSelectionValue,
-								});
-							}}
-						/>
+		<div className="border border-gray-700 rounded-lg overflow-hidden">
+			<HighlightWrapper
+				id={navigateId}
+				isHighlighted={isHighlighted}
+				isInset={true}
+			>
+				<div className="flex items-center justify-between py-2 px-4">
+					<div className="flex items-center gap-3">
+						{/* アコーディオンの矢印アイコンのスペースを確保して配置を揃える */}
+						<div className="w-5" />
+						<span className="font-semibold text-gray-200">
+							{optionMeta.title}
+						</span>
 					</div>
-				</HighlightWrapper>
-			</div>
-		</HighlightWrapper>
+					<OptionDropdownControl
+						values={displayValues}
+						selection={selection}
+						onChange={(newSelectionValue) => {
+							updateAuOption({
+								auOptionId: mapOptionId,
+								selection: newSelectionValue,
+							});
+						}}
+					/>
+				</div>
+			</HighlightWrapper>
+		</div>
 	);
 }

--- a/src/feature/exr/ExRRoleCategoryItem.tsx
+++ b/src/feature/exr/ExRRoleCategoryItem.tsx
@@ -1,5 +1,7 @@
 import { RoleCategoryAccordion } from "@/components/blocks/RoleCategoryAccordion";
 import { ColoredText } from "@/components/parts/ColoredText";
+import { HighlightWrapper } from "@/components/parts/HighlightWrapper";
+import { createExRCategoryNavigateId } from "@/hooks/useOptionNavigation";
 import { useOptionData } from "@/hooks/useExROptionData";
 import { exrOptionMetaData } from "@/logics/api";
 import { getUniqueOptionId } from "@/logics/optionUtils";
@@ -22,6 +24,9 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
 	});
+	const highlightedExRCategoryId = useStore(
+		(state) => state.highlightedExRCategoryId,
+	);
 
 	const selectedExRTabId = useStore((state) => {
 		return state.selectedExRTabId;
@@ -62,23 +67,32 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 		return null;
 	}
 
+	const isHighlighted = highlightedExRCategoryId === categoryId;
+	const navigateId = createExRCategoryNavigateId(categoryId);
+
 	return (
-		<RoleCategoryAccordion
-			isOpen={isOpen}
-			onClick={() => toggleExRCategory(categoryId)}
-			text={<ColoredText text={category} />}
-			spawnControl={
-				<ExRRoleSpawnControls
-					tabId={selectedExRTabId}
-					categoryId={categoryId}
-				/>
-			}
-			disable={isSpawnRateZero}
+		<HighlightWrapper
+			id={navigateId}
+			isHighlighted={isHighlighted}
+			isInset={false}
 		>
-			<ExRCategoryOptionList
-				categoryId={categoryId}
-				uniqueOptionIds={filteredChildOptionIds}
-			/>
-		</RoleCategoryAccordion>
+			<RoleCategoryAccordion
+				isOpen={isOpen}
+				onClick={() => toggleExRCategory(categoryId)}
+				text={<ColoredText text={category} />}
+				spawnControl={
+					<ExRRoleSpawnControls
+						tabId={selectedExRTabId}
+						categoryId={categoryId}
+					/>
+				}
+				disable={isSpawnRateZero}
+			>
+				<ExRCategoryOptionList
+					categoryId={categoryId}
+					uniqueOptionIds={filteredChildOptionIds}
+				/>
+			</RoleCategoryAccordion>
+		</HighlightWrapper>
 	);
 }

--- a/src/feature/exr/ExRRoleCategoryItem.tsx
+++ b/src/feature/exr/ExRRoleCategoryItem.tsx
@@ -1,8 +1,8 @@
 import { RoleCategoryAccordion } from "@/components/blocks/RoleCategoryAccordion";
 import { ColoredText } from "@/components/parts/ColoredText";
 import { HighlightWrapper } from "@/components/parts/HighlightWrapper";
-import { createExRCategoryNavigateId } from "@/hooks/useOptionNavigation";
 import { useOptionData } from "@/hooks/useExROptionData";
+import { createExRCategoryNavigateId } from "@/hooks/useOptionNavigation";
 import { exrOptionMetaData } from "@/logics/api";
 import { getUniqueOptionId } from "@/logics/optionUtils";
 import { SPAWN_COUNT_OPTION_ID, SPAWN_RATE_OPTION_ID } from "@/type";

--- a/src/feature/exr/ExRRoleCategoryItem.tsx
+++ b/src/feature/exr/ExRRoleCategoryItem.tsx
@@ -74,7 +74,7 @@ export function ExRRoleCategoryItem({ categoryId }: ExRRoleCategoryItemProps) {
 		<HighlightWrapper
 			id={navigateId}
 			isHighlighted={isHighlighted}
-			isInset={false}
+			isInset={true}
 		>
 			<RoleCategoryAccordion
 				isOpen={isOpen}

--- a/src/feature/exr/ExRStandardCategoryItem.tsx
+++ b/src/feature/exr/ExRStandardCategoryItem.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import { OptionEditorAccordion } from "@/components/blocks/OptionEditorAccordion";
 import { ColoredText } from "@/components/parts/ColoredText";
+import { HighlightWrapper } from "@/components/parts/HighlightWrapper";
+import { createExRCategoryNavigateId } from "@/hooks/useOptionNavigation";
 import { exrOptionMetaData } from "@/logics/api";
 import { PRESET_OPTION_UNIQUE_ID } from "@/logics/optionUtils";
 import { useStore } from "@/useStore";
@@ -22,6 +24,9 @@ export function ExRStandardCategoryItem({
 	const toggleExRCategory = useStore((state) => {
 		return state.toggleExRCategory;
 	});
+	const highlightedExRCategoryId = useStore(
+		(state) => state.highlightedExRCategoryId,
+	);
 
 	const uniqueOptions =
 		exrOptionMetaData.globalCategoryIdTopLevelMap[categoryId];
@@ -38,24 +43,33 @@ export function ExRStandardCategoryItem({
 		return null;
 	}
 
+	const isHighlighted = highlightedExRCategoryId === categoryId;
+	const navigateId = createExRCategoryNavigateId(categoryId);
+
 	return (
-		<div data-testid={`exr-category-${categoryId}`}>
-			<OptionEditorAccordion
-				title={
-					<ColoredText
-						text={exrOptionMetaData.categories[categoryId]?.name ?? ""}
+		<HighlightWrapper
+			id={navigateId}
+			isHighlighted={isHighlighted}
+			isInset={false}
+		>
+			<div data-testid={`exr-category-${categoryId}`}>
+				<OptionEditorAccordion
+					title={
+						<ColoredText
+							text={exrOptionMetaData.categories[categoryId]?.name ?? ""}
+						/>
+					}
+					isOpen={isOpen}
+					onToggle={() => {
+						toggleExRCategory(categoryId);
+					}}
+				>
+					<ExRCategoryOptionList
+						categoryId={categoryId}
+						uniqueOptionIds={filteredOptions}
 					/>
-				}
-				isOpen={isOpen}
-				onToggle={() => {
-					toggleExRCategory(categoryId);
-				}}
-			>
-				<ExRCategoryOptionList
-					categoryId={categoryId}
-					uniqueOptionIds={filteredOptions}
-				/>
-			</OptionEditorAccordion>
-		</div>
+				</OptionEditorAccordion>
+			</div>
+		</HighlightWrapper>
 	);
 }

--- a/src/hooks/useOptionNavigation.ts
+++ b/src/hooks/useOptionNavigation.ts
@@ -28,7 +28,7 @@ function useNavigate() {
 					element.scrollIntoView({ behavior: "smooth", block: "center" });
 				}
 			}
-			setTimeout(timeoutFunc, 2000);
+			setTimeout(timeoutFunc, 5000);
 		}, 100);
 	};
 }

--- a/src/hooks/useOptionNavigation.ts
+++ b/src/hooks/useOptionNavigation.ts
@@ -11,6 +11,14 @@ export function createAuNavigateId(auOptionId: AuOptionId) {
 	return `au-option-${auOptionId}`;
 }
 
+export function createExRCategoryNavigateId(categoryId: number) {
+	return `exr-category-${categoryId}`;
+}
+
+export function createAuCategoryNavigateId(categoryId: number) {
+	return `au-category-${categoryId}`;
+}
+
 function useNavigate() {
 	return (navId: string, timeoutFunc: () => void) => {
 		setTimeout(() => {
@@ -80,6 +88,37 @@ export function useAuOptionNavigation(
 	return navigateToOption;
 }
 
+function useAuCategoryNavigationInner() {
+	const setSelectedTab = useStore((state) => state.setSelectedTab);
+	const setSelectedAuTabId = useStore((state) => state.setSelectedAuTabId);
+	const setAuCategoryOpen = useStore((state) => state.setAuCategoryOpen);
+	const setHighlightedAuCategoryId = useStore(
+		(state) => state.setHighlightedAuCategoryId,
+	);
+
+	const nav = useNavigate();
+
+	return (tabId: number, categoryId: number, navId: string) => {
+		setSelectedTab("Au");
+		setSelectedAuTabId(tabId);
+		setAuCategoryOpen(categoryId, true);
+		setHighlightedAuCategoryId(categoryId);
+
+		nav(navId, () => {
+			setHighlightedAuCategoryId(null);
+		});
+	};
+}
+
+export function useAuCategoryNavigationInline() {
+	const navigateToAuCategory = useAuCategoryNavigationInner();
+
+	return (tabId: number, categoryId: number) => {
+		const navigateId = createAuCategoryNavigateId(categoryId);
+		navigateToAuCategory(tabId, categoryId, navigateId);
+	};
+}
+
 export function useAuOptionNavigationInline() {
 	const navigateToAuOption = useAuNavigationInner();
 
@@ -93,6 +132,37 @@ export function useAuOptionNavigationInline() {
 	};
 
 	return navigateToOption;
+}
+
+function useExRCategoryNavigationInner() {
+	const setSelectedTab = useStore((state) => state.setSelectedTab);
+	const setSelectedExRTabId = useStore((state) => state.setSelectedExRTabId);
+	const setExRCategoryOpen = useStore((state) => state.setExRCategoryOpen);
+	const setHighlightedExRCategoryId = useStore(
+		(state) => state.setHighlightedExRCategoryId,
+	);
+
+	const nav = useNavigate();
+
+	return (tabId: ExRTabId, categoryId: number, navId: string) => {
+		setSelectedTab("ExR");
+		setSelectedExRTabId(tabId);
+		setExRCategoryOpen(categoryId, true);
+		setHighlightedExRCategoryId(categoryId);
+
+		nav(navId, () => {
+			setHighlightedExRCategoryId(null);
+		});
+	};
+}
+
+export function useExRCategoryNavigationInline() {
+	const navigateToExRCategory = useExRCategoryNavigationInner();
+
+	return (tabId: ExRTabId, categoryId: number) => {
+		const navigateId = createExRCategoryNavigateId(categoryId);
+		navigateToExRCategory(tabId, categoryId, navigateId);
+	};
 }
 
 /**

--- a/src/hooks/useSearchSelection.ts
+++ b/src/hooks/useSearchSelection.ts
@@ -1,5 +1,7 @@
 import {
+	useAuCategoryNavigationInline,
 	useAuOptionNavigationInline,
+	useExRCategoryNavigationInline,
 	useExROptionNavigationInline,
 } from "@/hooks/useOptionNavigation";
 import type { SearchItem } from "@/type";
@@ -11,6 +13,8 @@ import { useStore } from "@/useStore";
 export function useSearchSelection() {
 	const navigateToExR = useExROptionNavigationInline();
 	const navigateToAu = useAuOptionNavigationInline();
+	const navigateToExRCat = useExRCategoryNavigationInline();
+	const navigateToAuCat = useAuCategoryNavigationInline();
 	const setIsOpen = useStore((state) => state.setSuggestOpen);
 
 	return (selectedItem: SearchItem) => {
@@ -23,6 +27,12 @@ export function useSearchSelection() {
 				selectedItem.info.categoryId,
 				selectedItem.info.auOptionId,
 			);
+			setIsOpen(false);
+		} else if (selectedItem.info.mode === "exr-cat") {
+			navigateToExRCat(selectedItem.info.tabId, selectedItem.info.categoryId);
+			setIsOpen(false);
+		} else if (selectedItem.info.mode === "au-cat") {
+			navigateToAuCat(selectedItem.info.tabId, selectedItem.info.categoryId);
 			setIsOpen(false);
 		}
 	};

--- a/src/hooks/useSearchSelection.ts
+++ b/src/hooks/useSearchSelection.ts
@@ -20,20 +20,20 @@ export function useSearchSelection() {
 	return (selectedItem: SearchItem) => {
 		if (selectedItem.info.mode === "exr-opt") {
 			navigateToExR(selectedItem.info.uniqueOptionId);
-			setIsOpen(false);
 		} else if (selectedItem.info.mode === "au-opt") {
 			navigateToAu(
 				selectedItem.info.tabId,
 				selectedItem.info.categoryId,
 				selectedItem.info.auOptionId,
 			);
-			setIsOpen(false);
 		} else if (selectedItem.info.mode === "exr-cat") {
 			navigateToExRCat(selectedItem.info.tabId, selectedItem.info.categoryId);
-			setIsOpen(false);
 		} else if (selectedItem.info.mode === "au-cat") {
 			navigateToAuCat(selectedItem.info.tabId, selectedItem.info.categoryId);
-			setIsOpen(false);
+		} else {
+			console.warn("Unknown search item ", selectedItem);
+			return;
 		}
+		setIsOpen(false);
 	};
 }

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -387,19 +387,24 @@ export async function createAuOptionMetaData(): Promise<
 			tabId: currentTab,
 		};
 
-		globalSearchItems.push({
-			term: category.TranslatedTitle,
-			parentData: {
-				tabName: auOptionMetaData.tabNames[currentTab],
-				categoryName: "", // カテゴリはタブの直下にあるため、親カテゴリは存在しない
-				parentOptionNames: [],
-			},
-			info: {
-				mode: "au-cat",
-				tabId: currentTab,
-				categoryId: categoryId,
-			},
-		});
+		const isMapCategory =
+			currentTab === 0 && auOptionMetaData.tabCategoryMap[0].length === 1;
+
+		if (!isMapCategory) {
+			globalSearchItems.push({
+				term: category.TranslatedTitle,
+				parentData: {
+					tabName: auOptionMetaData.tabNames[currentTab],
+					categoryName: "", // カテゴリはタブの直下にあるため、親カテゴリは存在しない
+					parentOptionNames: [],
+				},
+				info: {
+					mode: "au-cat",
+					tabId: currentTab,
+					categoryId: categoryId,
+				},
+			});
+		}
 
 		for (const opt of category.Options) {
 			const valueType = opt.Info.ValueType;
@@ -465,10 +470,10 @@ export async function createAuOptionMetaData(): Promise<
 				initialValueData[auOptionId] = index;
 
 				globalSearchItems.push({
-					term: tlanslatedTitle,
+					term: isMapCategory ? "マップ" : tlanslatedTitle,
 					parentData: {
 						tabName: auOptionMetaData.tabNames[currentTab],
-						categoryName: category.TranslatedTitle,
+						categoryName: isMapCategory ? "" : category.TranslatedTitle,
 						parentOptionNames: [],
 					},
 					info: {

--- a/src/logics/api.ts
+++ b/src/logics/api.ts
@@ -470,7 +470,7 @@ export async function createAuOptionMetaData(): Promise<
 				initialValueData[auOptionId] = index;
 
 				globalSearchItems.push({
-					term: isMapCategory ? "マップ" : tlanslatedTitle,
+					term: tlanslatedTitle,
 					parentData: {
 						tabName: auOptionMetaData.tabNames[currentTab],
 						categoryName: isMapCategory ? "" : category.TranslatedTitle,

--- a/src/slices/auOptionViewerSlice.ts
+++ b/src/slices/auOptionViewerSlice.ts
@@ -9,13 +9,16 @@ export interface AuOptionViewerSlice {
 	isAuTabPending: boolean;
 	openedAuCategoryIds: Record<number, boolean>;
 	highlightedAuOptionId: AuOptionId | null;
+	highlightedAuCategoryId: number | null;
 	auValue: Record<AuOptionId, number>; // セレクション
 	setSelectedAuTabId: (id: number) => void;
 	setIsAuTabPending: (isPending: boolean) => void;
 	setAuValue: (value: Record<AuOptionId, number>) => void;
 	setOpenedAuCategoryIds: (ids: Record<number, boolean>) => void;
 	setHighlightedAuOptionId: (id: AuOptionId | null) => void;
+	setHighlightedAuCategoryId: (id: number | null) => void;
 	toggleAuCategory: (categoryId: number) => void;
+	setAuCategoryOpen: (categoryId: number, isOpen: boolean) => void;
 	updateAuOptionSelection: (...args: UpdateAuArg[]) => void;
 }
 
@@ -30,6 +33,7 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 		isAuTabPending: false,
 		openedAuCategoryIds: {},
 		highlightedAuOptionId: null,
+		highlightedAuCategoryId: null,
 		auValue: {},
 		setSelectedAuTabId: (id: number) => {
 			console.log(
@@ -53,6 +57,9 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 		setHighlightedAuOptionId: (id) => {
 			set({ highlightedAuOptionId: id });
 		},
+		setHighlightedAuCategoryId: (id) => {
+			set({ highlightedAuCategoryId: id });
+		},
 		toggleAuCategory: (categoryId) => {
 			console.log(
 				JSON.stringify({
@@ -64,6 +71,13 @@ export const createAuOptionViewerSlice: StateCreator<AuOptionViewerSlice> = (
 			set((state) => {
 				const next = { ...state.openedAuCategoryIds };
 				next[categoryId] = !next[categoryId];
+				return { openedAuCategoryIds: next };
+			});
+		},
+		setAuCategoryOpen: (categoryId, isOpen) => {
+			set((state) => {
+				const next = { ...state.openedAuCategoryIds };
+				next[categoryId] = isOpen;
 				return { openedAuCategoryIds: next };
 			});
 		},

--- a/src/slices/exrOptionViewerSlice.ts
+++ b/src/slices/exrOptionViewerSlice.ts
@@ -24,14 +24,17 @@ export interface ExROptionViewerSlice {
 	exrValue: Record<UniqueOptionId, ExROptionValueData>;
 	isExROptionActive: Record<UniqueOptionId, boolean>;
 	highlightedExROptionId: UniqueOptionId | null;
+	highlightedExRCategoryId: number | null;
 	setSelectedExRTabId: (id: ExRTabId) => void;
 	setIsExRTabPending: (isPending: boolean) => void;
 	toggleExRCategory: (categoryId: number) => void;
+	setExRCategoryOpen: (categoryId: number, isOpen: boolean) => void;
 	toggleExROption: (uniqueOptionId: UniqueOptionId) => void;
 	openExROptions: (uniqueOptionIds: UniqueOptionId[]) => void;
 	updateExROption: (updateOptions: (UpdatedOptions | null)[]) => void;
 	updatePresetName: (presetIndex: number, name: string) => void;
 	setHighlightedExROptionId: (id: UniqueOptionId | null) => void;
+	setHighlightedExRCategoryId: (id: number | null) => void;
 	resetViewer: () => void;
 	setExROptions: (
 		valueData: Record<UniqueOptionId, ExROptionValueData>,
@@ -54,6 +57,7 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		exrValue: {},
 		isExROptionActive: {},
 		highlightedExROptionId: null,
+		highlightedExRCategoryId: null,
 		presetNames: loadPresetNamesFromLocalStorage(),
 		setSelectedExRTabId: (id: ExRTabId) => {
 			console.log(
@@ -89,6 +93,16 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 					openedExRCategoryIds: {
 						...state.openedExRCategoryIds,
 						[categoryId]: !state.openedExRCategoryIds[categoryId],
+					},
+				};
+			});
+		},
+		setExRCategoryOpen: (categoryId: number, isOpen: boolean) => {
+			set((state) => {
+				return {
+					openedExRCategoryIds: {
+						...state.openedExRCategoryIds,
+						[categoryId]: isOpen,
 					},
 				};
 			});
@@ -166,6 +180,9 @@ export const createExROptionViewerSlice: StateCreator<ExROptionViewerSlice> = (
 		},
 		setHighlightedExROptionId: (id) => {
 			set({ highlightedExROptionId: id });
+		},
+		setHighlightedExRCategoryId: (id) => {
+			set({ highlightedExRCategoryId: id });
 		},
 		setExROptions: (
 			valueData: Record<number, ExROptionValueData>,

--- a/tests/SearchBar.test.tsx
+++ b/tests/SearchBar.test.tsx
@@ -49,6 +49,8 @@ vi.mock("@/components/ui/popover", () => ({
 
 const mockNavigateToExR = vi.fn();
 const mockNavigateToAu = vi.fn();
+const mockNavigateToExRCat = vi.fn();
+const mockNavigateToAuCat = vi.fn();
 
 vi.mock("@/useStore", () => ({
 	useStore: vi.fn(),
@@ -57,6 +59,8 @@ vi.mock("@/useStore", () => ({
 vi.mock("@/hooks/useOptionNavigation", () => ({
 	useAuOptionNavigationInline: () => mockNavigateToAu,
 	useExROptionNavigationInline: () => mockNavigateToExR,
+	useExRCategoryNavigationInline: () => mockNavigateToExRCat,
+	useAuCategoryNavigationInline: () => mockNavigateToAuCat,
 }));
 
 vi.mock("@/hooks/useSearchResults", () => ({

--- a/tests/SearchSuggestionResult.test.tsx
+++ b/tests/SearchSuggestionResult.test.tsx
@@ -5,12 +5,16 @@ import type { AuOptionId, ExRTabId, SearchItem, UniqueOptionId } from "@/type";
 
 const mockNavigateToExR = vi.fn();
 const mockNavigateToAu = vi.fn();
+const mockNavigateToExRCat = vi.fn();
+const mockNavigateToAuCat = vi.fn();
 const mockSetIsOpen = vi.fn();
 
 // Mock dependencies
 vi.mock("@/hooks/useOptionNavigation", () => ({
 	useAuOptionNavigationInline: () => mockNavigateToAu,
 	useExROptionNavigationInline: () => mockNavigateToExR,
+	useExRCategoryNavigationInline: () => mockNavigateToExRCat,
+	useAuCategoryNavigationInline: () => mockNavigateToAuCat,
 }));
 
 vi.mock("@/useStore", () => ({
@@ -102,17 +106,18 @@ describe("SearchSuggestionResult", () => {
 		expect(mockSetIsOpen).toHaveBeenCalledWith(false);
 	});
 
-	it("does nothing on click for categories", () => {
+	it("calls navigation and closes suggest on click (au-cat)", () => {
 		render(<SearchSuggestionResult results={mockResults} />);
 		fireEvent.click(screen.getByText("Au Cat"));
-		expect(mockNavigateToExR).not.toHaveBeenCalled();
-		expect(mockNavigateToAu).not.toHaveBeenCalled();
-		expect(mockSetIsOpen).not.toHaveBeenCalled();
+		expect(mockNavigateToAuCat).toHaveBeenCalledWith(0, 2);
+		expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+	});
 
+	it("calls navigation and closes suggest on click (exr-cat)", () => {
+		render(<SearchSuggestionResult results={mockResults} />);
 		fireEvent.click(screen.getByText("ExR Cat"));
-		expect(mockNavigateToExR).not.toHaveBeenCalled();
-		expect(mockNavigateToAu).not.toHaveBeenCalled();
-		expect(mockSetIsOpen).not.toHaveBeenCalled();
+		expect(mockNavigateToExRCat).toHaveBeenCalledWith(0, 3);
+		expect(mockSetIsOpen).toHaveBeenCalledWith(false);
 	});
 
 	it("renders icons in SearchParentData", () => {

--- a/tests/globalSearchItems.test.ts
+++ b/tests/globalSearchItems.test.ts
@@ -162,14 +162,6 @@ describe("globalSearchItems population", () => {
 			}),
 		);
 
-		// Map option should be in globalSearchItems as au-opt with term "マップ"
-		expect(globalSearchItems).toContainEqual(
-			expect.objectContaining({
-				term: "マップ",
-				info: expect.objectContaining({ mode: "au-opt", categoryId: 0 }),
-			}),
-		);
-
 		// Normal category should be in globalSearchItems as au-cat
 		expect(globalSearchItems).toContainEqual(
 			expect.objectContaining({

--- a/tests/globalSearchItems.test.ts
+++ b/tests/globalSearchItems.test.ts
@@ -111,13 +111,27 @@ describe("globalSearchItems population", () => {
 	it("should populate globalSearchItems with Au data", async () => {
 		const mockAuData = [
 			{
-				TranslatedTitle: "Au Category",
+				// First category in Tab 0 is treated as Map
+				TranslatedTitle: "Map Category",
 				Options: [
 					{
-						TranslatedTitle: "Au Option",
+						TranslatedTitle: "map",
 						TranslatedFormat: "Format",
 						Value: 0,
 						Info: { ValueType: 2, OptionName: 1000 },
+						Range: [0, 1],
+					},
+				],
+			},
+			{
+				// Second category in Tab 0 is treated normally
+				TranslatedTitle: "Normal Category",
+				Options: [
+					{
+						TranslatedTitle: "Normal Option",
+						TranslatedFormat: "Format",
+						Value: 0,
+						Info: { ValueType: 2, OptionName: 1001 },
 						Range: [0, 1],
 					},
 				],
@@ -141,16 +155,34 @@ describe("globalSearchItems population", () => {
 
 		await createAuOptionMetaData();
 
-		expect(globalSearchItems).toContainEqual(
+		// Map category itself should NOT be in globalSearchItems as au-cat
+		expect(globalSearchItems).not.toContainEqual(
 			expect.objectContaining({
-				term: "Au Category",
-				info: expect.objectContaining({ mode: "au-cat" }),
+				info: expect.objectContaining({ mode: "au-cat", categoryId: 0 }),
 			}),
 		);
+
+		// Map option should be in globalSearchItems as au-opt with term "マップ"
 		expect(globalSearchItems).toContainEqual(
 			expect.objectContaining({
-				term: "Au Option",
-				info: expect.objectContaining({ mode: "au-opt" }),
+				term: "マップ",
+				info: expect.objectContaining({ mode: "au-opt", categoryId: 0 }),
+			}),
+		);
+
+		// Normal category should be in globalSearchItems as au-cat
+		expect(globalSearchItems).toContainEqual(
+			expect.objectContaining({
+				term: "Normal Category",
+				info: expect.objectContaining({ mode: "au-cat", categoryId: 1 }),
+			}),
+		);
+
+		// Normal option should be in globalSearchItems as au-opt
+		expect(globalSearchItems).toContainEqual(
+			expect.objectContaining({
+				term: "Normal Option",
+				info: expect.objectContaining({ mode: "au-opt", categoryId: 1 }),
 			}),
 		);
 	});


### PR DESCRIPTION
検索結果からカテゴリを選択した際に、該当するカテゴリまでスクロールし、自動的にアコーディオンを開いてハイライト表示する機能を実装しました。
ExRとAmong Usの両方のカテゴリ（標準カテゴリおよび役職カテゴリ）に対応しています。

---
*PR created automatically by Jules for task [3998068974852978090](https://jules.google.com/task/3998068974852978090) started by @yukieiji*