### PR TITLE
Update UpdatedOptions structure

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -47,6 +47,7 @@ const mockUpdatedOptions: UpdatedOptions = {
     ],
   },
   ChainUpdatedOption: [],
+  ChainUpdateCategory: null,
 };
 
 const validatedUpdatedOptions = UpdatedOptionsSchema.parse(mockUpdatedOptions);
@@ -112,6 +113,7 @@ export const handlers = [
     const mockUpdatedOptions: UpdatedOptions = {
       UpdatedCategory: updatedCategory,
       ChainUpdatedOption: chainUpdatedOptions,
+      ChainUpdateCategory: null,
     };
 
     // レスポンスデータのバリデーション

--- a/src/logics/exrStateLogic.ts
+++ b/src/logics/exrStateLogic.ts
@@ -77,6 +77,10 @@ export function getUpdatedExRState(
 			processCategory(x.UpdatedCategory);
 		}
 
+		if (x.ChainUpdateCategory) {
+			processCategory(x.ChainUpdateCategory);
+		}
+
 		for (const chain of x.ChainUpdatedOption) {
 			const tId = exrOptionMetaData.categories[chain.Id]?.tabId;
 			if (tId === undefined) {

--- a/src/type.ts
+++ b/src/type.ts
@@ -311,11 +311,13 @@ export const CategoryOptionDtoSchema = z.object({
 export interface UpdatedOptions {
 	UpdatedCategory?: ExRCategoryDto | null;
 	ChainUpdatedOption: CategoryOptionDto[];
+	ChainUpdateCategory?: ExRCategoryDto | null;
 }
 
 export const UpdatedOptionsSchema = z.object({
 	UpdatedCategory: ExRCategoryDtoSchema.nullish(),
 	ChainUpdatedOption: z.array(CategoryOptionDtoSchema),
+	ChainUpdateCategory: ExRCategoryDtoSchema.nullish(),
 });
 
 // 内部データ向け

--- a/tests/api-validation.test.ts
+++ b/tests/api-validation.test.ts
@@ -69,6 +69,11 @@ describe("ExROptionPutRequest and UpdatedOptions Validation", () => {
 					],
 				},
 			],
+			ChainUpdateCategory: {
+				Id: 3,
+				Name: "Chain Update Category",
+				Options: [],
+			},
 		};
 
 		const result = UpdatedOptionsSchema.safeParse(data);

--- a/tests/exrStateLogic.test.ts
+++ b/tests/exrStateLogic.test.ts
@@ -139,6 +139,51 @@ describe("exrStateLogic", () => {
 		expect(result.isOptionActiveChanged).toBe(true);
 	});
 
+	it("should update state from ChainUpdateCategory", () => {
+		const catId = 250;
+		const tabId = ExRTabId.GeneralTab;
+		const optId = 3;
+		const uId = getUniqueOptionId(tabId, catId, optId);
+
+		exrOptionMetaData.categories[catId] = { name: "Chain Update Category", tabId };
+
+		const updateResults: (UpdatedOptions | null)[] = [
+			{
+				UpdatedCategory: null,
+				ChainUpdatedOption: [],
+				ChainUpdateCategory: {
+					Id: catId,
+					Name: "Chain Update Category",
+					Options: [
+						{
+							Id: optId,
+							IsActive: true,
+							TranslatedName: "Chain Update Option",
+							Selection: 7,
+							Format: "Format",
+							RangeMeta: { Type: "Int32", Values: [0, 7, 14] },
+							Childs: [],
+						},
+					],
+				},
+			},
+		];
+
+		const currentExrValue: Record<UniqueOptionId, ExROptionValueData> = {};
+		const currentIsExROptionActive: Record<UniqueOptionId, boolean> = {};
+
+		const result = getUpdatedExRState(
+			updateResults,
+			currentExrValue,
+			currentIsExROptionActive,
+		);
+
+		expect(result.nextValueData[uId].selection).toBe(7);
+		expect(result.nextIsOptionActive[uId]).toBe(true);
+		expect(result.valueDataChanged).toBe(true);
+		expect(result.isOptionActiveChanged).toBe(true);
+	});
+
 	it("should process child options recursively", () => {
 		const catId = 300;
 		const tabId = ExRTabId.NeutralTab;

--- a/tests/exrStateLogic.test.ts
+++ b/tests/exrStateLogic.test.ts
@@ -145,7 +145,10 @@ describe("exrStateLogic", () => {
 		const optId = 3;
 		const uId = getUniqueOptionId(tabId, catId, optId);
 
-		exrOptionMetaData.categories[catId] = { name: "Chain Update Category", tabId };
+		exrOptionMetaData.categories[catId] = {
+			name: "Chain Update Category",
+			tabId,
+		};
 
 		const updateResults: (UpdatedOptions | null)[] = [
 			{


### PR DESCRIPTION
Updated the `UpdatedOptions` structure to include the new `ChainUpdateCategory` field as requested. The field is optional and is processed similarly to `UpdatedCategory` in the state logic. Mock handlers and tests have also been updated to reflect and verify these changes.

---
*PR created automatically by Jules for task [13611110310660889154](https://jules.google.com/task/13611110310660889154) started by @yukieiji*