### PR TITLE
E2Eテストの不具合修正

### DIFF
--- a/e2e/au-options.spec.ts
+++ b/e2e/au-options.spec.ts
@@ -26,12 +26,12 @@ test.describe("Au Option Interactions", () => {
 		await page.getByRole("tab", { name: "0", exact: true }).click();
 
 		// Map is now a direct dropdown (select element)
-		// モックデータでは "map" (小文字)
-		// "map" というテキストと combobox の両方を含む行要素を特定する
+		// モックデータでは「マップ」
+		// 「マップ」というテキストと combobox の両方を含む行要素を特定する
 		const mapCategoryRow = page
 			.locator("main")
 			.locator("div")
-			.filter({ hasText: "map" })
+			.filter({ hasText: "マップ" })
 			.filter({ has: page.getByRole("combobox") })
 			.first();
 		await expect(mapCategoryRow).toBeVisible();

--- a/e2e/random_map.spec.ts
+++ b/e2e/random_map.spec.ts
@@ -17,11 +17,11 @@ test.describe("Random Map Display and Hiding", () => {
 		page,
 	}) => {
 		// 1. 右サイドパネルを開く
-		const toggleButton = page.getByRole("button", { name: "パネルを開く" });
-		if (await toggleButton.isVisible()) {
-			await toggleButton.click();
+		const summary = page.getByTestId("right-panel-summary");
+		if (!(await summary.isVisible())) {
+			await page.getByTestId("right-panel-toggle").click();
 		}
-		await expect(page.getByTestId("right-panel-summary")).toBeVisible();
+		await expect(summary).toBeVisible();
 
 		// 2. 初期状態の確認（マップのサマリーが表示されていること）
 		// モックの初期値は map: 4
@@ -54,7 +54,6 @@ test.describe("Random Map Display and Hiding", () => {
 		await expect(optionRow.getByText("オン", { exact: true })).toBeVisible();
 
 		// 4. 右パネルのサマリー表示が「ランダム」に変わったことを確認
-		const summary = page.getByTestId("right-panel-summary");
 		await expect(summary.getByText("ランダム")).toBeVisible();
 
 		// 5. 右パネルの ExR 設定リストから「ランダムマップに関する設定」が消えていることを確認


### PR DESCRIPTION
E2Eテストで発生していた以下の不具合を修正しました。

1. **au-options.spec.ts**: 
   - UI上の「マップ」ラベルがE2Eテストコード内で "map" となっていたため、要素が見つからず失敗していました。これを「マップ」に修正しました。

2. **random_map.spec.ts**:
   - 右パネルを開く際のロジックが不安定で、パネルが閉じている場合に正しく開けないことがありました。`data-testid` を使用し、パネルの状態を確認してから開くように改善しました。

全てのE2Eテストが正常にパスすることを確認済みです。

---
*PR created automatically by Jules for task [3361604316086507385](https://jules.google.com/task/3361604316086507385) started by @yukieiji*