### PR TITLE
Extreme Rolesの詳細設定にカテゴリ名を出力するように修正

### DIFF
--- a/src/logics/clipboardLogic.ts
+++ b/src/logics/clipboardLogic.ts
@@ -16,6 +16,7 @@ import {
 	EXR_RANDOM_MAP_OPTION_ID,
 	getBaseOptionName,
 	getUniqueOptionId,
+	MOVED_EXR_OPTION_UNIQUE_IDS,
 	PRESET_OPTION_UNIQUE_ID,
 	VANILLA_ROLE_CATEGORY_IDS,
 } from "@/logics/optionUtils";
@@ -314,56 +315,56 @@ export function generateClipboardText(
 	const exrGeneralTab = exrMeta.tabs[ExRTabId.GeneralTab];
 	if (exrGeneralTab) {
 		const processedOptions = new Set<UniqueOptionId>();
-		const addOptionAndChildren = (optId: UniqueOptionId, indent = 0) => {
-			if (processedOptions.has(optId)) {
-				return;
-			}
-			processedOptions.add(optId);
-
-			const optionDetail = exrMeta.options[optId];
-			const meta = optionDetail?.metaData;
-			if (!meta) {
-				return;
-			}
-
-			// サマリーにあるものは除く
-			const summaryOptionIds = [
-				PRESET_OPTION_UNIQUE_ID,
-				EXR_CREW_MIN_ID,
-				EXR_CREW_MAX_ID,
-				EXR_IMPOSTOR_MIN_ID,
-				EXR_IMPOSTOR_MAX_ID,
-				EXR_NEUTRAL_MIN_ID,
-				EXR_NEUTRAL_MAX_ID,
-				EXR_LIBERAL_MIN_ID,
-				EXR_LIBERAL_MAX_ID,
-				EXR_MILITANT_MIN_ID,
-				EXR_MILITANT_MAX_ID,
-				EXR_RANDOM_MAP_OPTION_ID,
-			];
-
-			if (!state.isExROptionActive[optId]) {
-				return;
-			}
-
-			if (!summaryOptionIds.includes(optId)) {
-				const indentStr = "  ".repeat(indent);
-				detailedSettings += `${indentStr} - ${cleanText(
-					meta.translatedName,
-				)} : ${getExRFormattedValue(optId)}\n`;
-			}
-
-			// 子オプションを再帰的に追加
-			for (const childId of optionDetail.childOptionIds) {
-				addOptionAndChildren(childId, indent + 1);
-			}
-		};
 
 		for (const catId of exrGeneralTab.categoryIds) {
+			const category = exrMeta.categories[catId];
+			if (!category) {
+				continue;
+			}
+
+			let categoryContent = "";
+			const addOptionAndChildren = (optId: UniqueOptionId, indent = 0) => {
+				if (processedOptions.has(optId)) {
+					return;
+				}
+
+				const optionDetail = exrMeta.options[optId];
+				const meta = optionDetail?.metaData;
+				if (!meta) {
+					return;
+				}
+
+				if (!state.isExROptionActive[optId]) {
+					return;
+				}
+
+				// サマリーにあるものは除く
+				if (
+					(MOVED_EXR_OPTION_UNIQUE_IDS as readonly number[]).includes(optId)
+				) {
+					return;
+				}
+
+				processedOptions.add(optId);
+				const indentStr = "  ".repeat(indent);
+				categoryContent += `${indentStr} - ${cleanText(
+					meta.translatedName,
+				)} : ${getExRFormattedValue(optId)}\n`;
+
+				// 子オプションを再帰的に追加
+				for (const childId of optionDetail.childOptionIds) {
+					addOptionAndChildren(childId, indent + 1);
+				}
+			};
+
 			const topLevelOptionIds =
 				exrMeta.globalCategoryIdTopLevelMap[catId] || [];
 			for (const optId of topLevelOptionIds) {
 				addOptionAndChildren(optId);
+			}
+
+			if (categoryContent) {
+				detailedSettings += `### ${cleanText(category.name)}\n${categoryContent}`;
 			}
 		}
 	}

--- a/src/logics/clipboardLogic.ts
+++ b/src/logics/clipboardLogic.ts
@@ -315,6 +315,7 @@ export function generateClipboardText(
 	const exrGeneralTab = exrMeta.tabs[ExRTabId.GeneralTab];
 	if (exrGeneralTab) {
 		const processedOptions = new Set<UniqueOptionId>();
+		const movedOptionIds = new Set<number>(MOVED_EXR_OPTION_UNIQUE_IDS);
 
 		for (const catId of exrGeneralTab.categoryIds) {
 			const category = exrMeta.categories[catId];
@@ -327,6 +328,7 @@ export function generateClipboardText(
 				if (processedOptions.has(optId)) {
 					return;
 				}
+				processedOptions.add(optId);
 
 				const optionDetail = exrMeta.options[optId];
 				const meta = optionDetail?.metaData;
@@ -339,13 +341,10 @@ export function generateClipboardText(
 				}
 
 				// サマリーにあるものは除く
-				if (
-					(MOVED_EXR_OPTION_UNIQUE_IDS as readonly number[]).includes(optId)
-				) {
+				if (movedOptionIds.has(optId)) {
 					return;
 				}
 
-				processedOptions.add(optId);
 				const indentStr = "  ".repeat(indent);
 				categoryContent += `${indentStr} - ${cleanText(
 					meta.translatedName,

--- a/tests/clipboardLogic.test.ts
+++ b/tests/clipboardLogic.test.ts
@@ -218,28 +218,28 @@ describe("generateClipboardText", () => {
 			["1000" as AuOptionId]: {
 				title: "Chance",
 				range: [0, 100],
-				tabId: 0, // Crew
+				tabId: 1, // Crew
 				categoryId: 5,
 				format: "",
 			},
 			["1001" as AuOptionId]: {
 				title: "Max",
 				range: [0, 1],
-				tabId: 0, // Crew
+				tabId: 1, // Crew
 				categoryId: 5,
 				format: "",
 			},
 			["1002" as AuOptionId]: {
 				title: "Chance",
 				range: [0, 100],
-				tabId: 1, // Impostor
+				tabId: 2, // Impostor
 				categoryId: 6,
 				format: "",
 			},
 			["1003" as AuOptionId]: {
 				title: "Max",
 				range: [0, 1],
-				tabId: 1, // Impostor
+				tabId: 2, // Impostor
 				categoryId: 6,
 				format: "",
 			},
@@ -250,11 +250,18 @@ describe("generateClipboardText", () => {
 				categoryId: 2,
 				format: "",
 			},
+			["3000" as AuOptionId]: {
+				title: "Extra Game Setting",
+				range: ["Value"],
+				tabId: 0,
+				categoryId: 3,
+				format: "",
+			},
 		} as unknown as AuOptionMetaDataRecords["options"],
 		tabCategoryMap: {
-			0: [0, 1, 2],
-			1: [],
-			2: [],
+			0: [0, 1, 2, 3],
+			1: [5],
+			2: [6],
 		},
 		categoryMetaData: {
 			0: { name: "Map Category", options: [AU_MAP_OPTION_ID], tabId: 0 },
@@ -264,15 +271,16 @@ describe("generateClipboardText", () => {
 				tabId: 0,
 			},
 			2: { name: "Other Settings", options: ["2000" as AuOptionId], tabId: 0 },
+			3: { name: "Game Extra", options: ["3000" as AuOptionId], tabId: 0 },
 			5: {
 				name: "Scientist",
 				options: ["1000" as AuOptionId, "1001" as AuOptionId],
-				tabId: 0, // Crew
+				tabId: 1, // Crew
 			},
 			6: {
 				name: "Shapeshifter",
 				options: ["1002" as AuOptionId, "1003" as AuOptionId],
-				tabId: 1, // Impostor
+				tabId: 2, // Impostor
 			},
 		},
 	};
@@ -301,6 +309,7 @@ describe("generateClipboardText", () => {
 			[AU_KILL_COOLDOWN_OPTION_ID]: 0,
 			[AU_IMPOSTOR_COUNT_OPTION_ID]: 0,
 			["2000" as AuOptionId]: 0,
+			["3000" as AuOptionId]: 0,
 		},
 		isExROptionActive: {
 			[PRESET_OPTION_UNIQUE_ID]: true,
@@ -321,6 +330,9 @@ describe("generateClipboardText", () => {
 		expect(text).toContain(`## ${CLIPBOARD_ROLES}`);
 		expect(text).toContain(`### ${CLIPBOARD_CREW}`);
 		expect(text).toContain(" - ExR Role --- **1 / 100%**");
+		expect(text).toContain("### Game Extra");
+		// Preset Category is empty because both PRESET_OPTION_UNIQUE_ID and EXR_RANDOM_MAP_OPTION_ID are excluded
+		expect(text).not.toContain("### Preset Category");
 	});
 
 	it("should handle random map", () => {
@@ -393,7 +405,7 @@ describe("generateClipboardText", () => {
 		expect(vanillaPos).toBeLessThan(exrPos);
 	});
 
-	it("should include detailed settings including child options", () => {
+	it("should include detailed settings including child options and category names", () => {
 		const childOptionId = 500 as unknown as UniqueOptionId;
 		const metaWithChild = {
 			...mockExrMeta,
@@ -440,7 +452,9 @@ describe("generateClipboardText", () => {
 			mockAuMeta,
 		);
 		expect(text).toContain("## 詳細設定");
+		expect(text).toContain("### Other Settings");
 		expect(text).toContain("- Setting A : On");
+		expect(text).toContain("### Preset Category");
 		expect(text).toContain("- Parent Option : Val");
 		expect(text).toContain("  - Child Option : ChildVal");
 	});


### PR DESCRIPTION
Extreme Rolesの全般設定（General Tab）において、Among Usの設定と同様にカテゴリ名を `###` で出力するように変更しました。また、右サイドパネルで非表示（非アクティブ）になっているカテゴリやオプションはクリップボードに出力されないように修正しています。 Among Us側の設定については既存の動作を維持するように調整しました。

---
*PR created automatically by Jules for task [13598963303376399492](https://jules.google.com/task/13598963303376399492) started by @yukieiji*