### PR TITLE
Fix pnpm build error by making ColorCode optional

### DIFF
--- a/src/type.ts
+++ b/src/type.ts
@@ -120,7 +120,7 @@ export const ExROptionDtoSchema: z.ZodType<ExROptionDto> = z.lazy(() =>
 export interface ExRCategoryDto {
 	Id: number;
 	Name: string;
-	ColorCode: string | null | undefined;
+	ColorCode?: string | null;
 	Options: ExROptionDto[];
 }
 


### PR DESCRIPTION
Modified `src/type.ts` to make `ExRCategoryDto.ColorCode` optional (`?`). This resolves a TypeScript error during `pnpm build` where the compiler complained about a missing property that was expected to be required, but was actually optional in the data and Zod schema. Verified with `pnpm build`, `pnpm run check`, `pnpm run test`, and `pnpm run e2e`.

---
*PR created automatically by Jules for task [16758030719452288083](https://jules.google.com/task/16758030719452288083) started by @yukieiji*